### PR TITLE
Fix repository URLs from csmt to haskell-csmt

### DIFF
--- a/CI/release.sh
+++ b/CI/release.sh
@@ -50,4 +50,4 @@ cp -L "$tarball" "$releaseTarball"
 
 gh release upload "$release" "$releaseTarball"
 
-echo "Release URL: https://github.com/paolino/csmt/releases/tag/$release"
+echo "Release URL: https://github.com/paolino/haskell-csmt/releases/tag/$release"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSMT - Compact Sparse Merkle Tree
 
-[![CI](https://github.com/paolino/csmt/actions/workflows/CI.yaml/badge.svg)](https://github.com/paolino/csmt/actions/workflows/CI.yaml)
-[![Documentation](https://github.com/paolino/csmt/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/paolino/csmt/actions/workflows/deploy-docs.yaml)
+[![CI](https://github.com/paolino/haskell-csmt/actions/workflows/CI.yaml/badge.svg)](https://github.com/paolino/haskell-csmt/actions/workflows/CI.yaml)
+[![Documentation](https://github.com/paolino/haskell-csmt/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/paolino/haskell-csmt/actions/workflows/deploy-docs.yaml)
 
 A Haskell library implementing a Compact Sparse Merkle Tree (CSMT) data structure with persistent storage backends.
 
@@ -71,7 +71,7 @@ NrJMih3czFriydMUwvFKFK6VYKZYVjKpKGe1WC4e+VU=
 
 ## Documentation
 
-Full documentation is available at [paolino.github.io/csmt](https://paolino.github.io/csmt/)
+Full documentation is available at [paolino.github.io/haskell-csmt](https://paolino.github.io/haskell-csmt/)
 
 ## Performance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 
 # CSMT - Compact Sparse Merkle Tree
 
-[![CI](https://github.com/paolino/csmt/actions/workflows/CI.yaml/badge.svg)](https://github.com/paolino/csmt/actions/workflows/CI.yaml) [![Build and deploy documentation](https://github.com/paolino/csmt/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/paolino/csmt/actions/workflows/deploy-docs.yaml)
+[![CI](https://github.com/paolino/haskell-csmt/actions/workflows/CI.yaml/badge.svg)](https://github.com/paolino/haskell-csmt/actions/workflows/CI.yaml) [![Build and deploy documentation](https://github.com/paolino/haskell-csmt/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/paolino/haskell-csmt/actions/workflows/deploy-docs.yaml)
 
 ## What is CSMT?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: CSMT Documentation
-site_url: https://paolino.github.io/csmt/
-repo_url: https://github.com/paolino/csmt
+site_url: https://paolino.github.io/haskell-csmt/
+repo_url: https://github.com/paolino/haskell-csmt
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

Fix GitHub Pages, badge links, and release URLs to use the correct repository name (`haskell-csmt` instead of `csmt`).

## Changes

- `mkdocs.yml`: Fix site_url and repo_url
- `README.md`: Fix CI and Documentation badge links
- `docs/index.md`: Fix badge links
- `CI/release.sh`: Fix release URL

## Test plan
- [x] Documentation builds successfully
- [x] GitHub Pages is accessible at correct URL