### PR TITLE
ci: add --quiet flag to nix commands

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,30 +20,30 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build executable
-        run: nix build .#csmt
+        run: nix --quiet build .#csmt
       - name: Build docker image
-        run: nix build .#docker-image -o csmt-image
+        run: nix --quiet build .#docker-image -o csmt-image
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: csmt-image
           path: csmt-image
       - name: Build appImage artifact
-        run: nix bundle --bundler github:ralismark/nix-appimage .#csmt -o csmt.AppImage
+        run: nix --quiet bundle --bundler github:ralismark/nix-appimage .#csmt -o csmt.AppImage
       - name: Upload appImage artifact
         uses: actions/upload-artifact@v4
         with:
           name: csmt-appImage
           path: csmt.AppImage
       - name: Build rpm artifact
-        run: nix bundle --bundler github:NixOS/bundlers#toRPM -o csmt.rpm
+        run: nix --quiet bundle --bundler github:NixOS/bundlers#toRPM -o csmt.rpm
       - name: Upload rpm artifact
         uses: actions/upload-artifact@v4
         with:
           name: csmt-rpm
           path: csmt.rpm
       - name: Build deb artifact
-        run: nix bundle --bundler github:NixOS/bundlers#toDEB -o csmt.deb
+        run: nix --quiet bundle --bundler github:NixOS/bundlers#toDEB -o csmt.deb
       - name: Upload deb artifact
         uses: actions/upload-artifact@v4
         with:
@@ -58,7 +58,7 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Run Tests
-        run: nix run .#unit-tests
+        run: nix --quiet run .#unit-tests
   bench:
     name: Run Benchmarks
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Run Benchmarks
-        run: nix run .#bench
+        run: nix --quiet run .#bench
   formatting:
     name: Check code formatting
     runs-on: ubuntu-latest
@@ -78,4 +78,4 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check Formatting
-        run: nix develop -c just format
+        run: nix --quiet develop -c just format

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -17,4 +17,4 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force
+      - run: nix --quiet develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- Adds `--quiet` flag to all nix commands in CI workflows
- Reduces verbose nix output in CI logs