### PR TITLE
docs: add Haddock documentation to all exports

### DIFF
--- a/src/csmt/CSMT/Frontend/CLI/App.hs
+++ b/src/csmt/CSMT/Frontend/CLI/App.hs
@@ -1,3 +1,12 @@
+-- |
+-- Module      : CSMT.Frontend.CLI.App
+-- Description : Interactive CLI for CSMT operations
+-- Copyright   : (c) Paolo Veronelli, 2026
+-- License     : Apache-2.0
+--
+-- Command-line interface for interacting with a CSMT database.
+-- Supports inserting, deleting, and querying key-value pairs,
+-- as well as generating and verifying inclusion proofs.
 module CSMT.Frontend.CLI.App
     ( main
     ) where
@@ -297,6 +306,7 @@ codecs =
         , nodeCodec = isoHash
         }
 
+-- | Entry point for the CSMT CLI application.
 main :: IO ()
 main = do
     Options{optDbPath, optCSMTMaxFiles, optKVMaxFiles} <-

--- a/src/csmt/CSMT/Interface.hs
+++ b/src/csmt/CSMT/Interface.hs
@@ -138,6 +138,7 @@ compareKeys (x : xs) (y : ys)
         in  (x : j, o, r)
     | otherwise = ([], x : xs, y : ys)
 
+-- | Query the root hash of the CSMT. Returns 'Nothing' if the tree is empty.
 root
     :: (Monad m, GCompare d)
     => Hashing a
@@ -152,10 +153,12 @@ root hsh sel = do
 bigendian :: [Int]
 bigendian = [7, 6 .. 0]
 
+-- | Serialize a 'Direction' to a single byte (0 for 'L', 1 for 'R').
 putDirection :: Direction -> PutM ()
 putDirection d = do
     putWord8 $ if toBool d then 1 else 0
 
+-- | Deserialize a 'Direction' from a single byte.
 getDirection :: Get Direction
 getDirection = do
     b <- getWord8
@@ -164,6 +167,7 @@ getDirection = do
         1 -> return R
         _ -> fail "Invalid direction byte"
 
+-- | Serialize a 'Key' to bytes: 2-byte length followed by bit-packed directions.
 putKey :: Key -> PutM ()
 putKey k = do
     let bytes = BA.pack $ unfoldr unconsDirection k
@@ -182,6 +186,7 @@ putKey k = do
         | toBool dir = setBit b i
         | otherwise = b
 
+-- | Deserialize a 'Key' from bytes.
 getKey :: Get Key
 getKey = do
     len <- getWord16be
@@ -195,12 +200,14 @@ getKey = do
     byteToDirections :: Bits b => b -> Key
     byteToDirections byte = [if testBit byte i then R else L | i <- bigendian]
 
+-- | Serialize a byte array with a 2-byte length prefix.
 putSizedByteString :: BA.ByteArrayAccess a => a -> PutM ()
 putSizedByteString bs = do
     let len = fromIntegral $ BA.length bs
     putWord16be len
     putByteString $ convert bs
 
+-- | Deserialize a length-prefixed byte array.
 getSizedByteString :: BA.ByteArray a => Get a
 getSizedByteString = do
     len <- getWord16be

--- a/src/csmt/Data/Serialize/Extra.hs
+++ b/src/csmt/Data/Serialize/Extra.hs
@@ -1,3 +1,10 @@
+-- |
+-- Module      : Data.Serialize.Extra
+-- Description : Convenience functions for cereal serialization
+-- Copyright   : (c) Paolo Veronelli, 2026
+-- License     : Apache-2.0
+--
+-- Helper functions for working with cereal's 'PutM' and 'Get' monads.
 module Data.Serialize.Extra
     ( evalPutM
     , unsafeEvalGet
@@ -13,14 +20,18 @@ import Data.Serialize
     , runPutM
     )
 
+-- | Run a 'PutM' action and return only the serialized bytes, discarding any result.
 evalPutM :: PutM a -> ByteString
 evalPutM putM = snd $ runPutM putM
 
+-- | Run a 'Get' parser, throwing an error on parse failure.
+-- Use only when parse failure indicates a programming error.
 unsafeEvalGet :: Get a -> ByteString -> a
 unsafeEvalGet get bs = case runGet get bs of
     Right a -> a
     Left err -> error $ "unsafeEvalGet: parse error: " ++ err
 
+-- | Run a 'Get' parser, returning 'Nothing' on parse failure.
 evalGetM :: Get a -> ByteString -> Maybe a
 evalGetM get bs = case runGet get bs of
     Right a -> Just a


### PR DESCRIPTION
## Summary

- Add module headers to `Data.Serialize.Extra` and `CSMT.Frontend.CLI.App`
- Add Haddock docs to all previously undocumented exports:
  - `Data.Serialize.Extra`: `evalPutM`, `unsafeEvalGet`, `evalGetM`
  - `CSMT.Frontend.CLI.App`: `main`
  - `CSMT.Interface`: `root`, `putDirection`, `getDirection`, `putKey`, `getKey`, `putSizedByteString`, `getSizedByteString`

Closes #22