### PR TITLE
ci: add workflow concurrency control per branch

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Summary

- Add concurrency settings to cancel in-progress CI runs when new commits are pushed to the same branch

Closes #27