### PR TITLE
fix: relax QuickCheck bounds for Cardano compatibility

### DIFF
--- a/csmt.cabal
+++ b/csmt.cabal
@@ -111,7 +111,7 @@ library test-lib
     , csmt
     , free        >=5.2  && <5.3
     , lens        >=5.3  && <5.4
-    , QuickCheck  >=2.16 && <2.17
+    , QuickCheck  >=2.14 && <2.18
     , rocksdb-kv-transactions:kv-transactions
 
   hs-source-dirs:   test-lib
@@ -132,7 +132,7 @@ test-suite unit-tests
     , filepath                 >=1.4  && <1.5
     , hspec                    >=2.11 && <2.12
     , lens                     >=5.3  && <5.4
-    , QuickCheck               >=2.16 && <2.17
+    , QuickCheck               >=2.14 && <2.18
     , rocksdb-haskell-jprupp   >=2.1  && <2.2
     , rocksdb-kv-transactions  >=0.1  && <0.2
     , rocksdb-kv-transactions:kv-transactions


### PR DESCRIPTION
## Summary

- Widen QuickCheck bounds from `>=2.16 && <2.17` to `>=2.14 && <2.18`

## Reason

The Cardano ecosystem (via `ral` → `plutus-core`) requires `QuickCheck ^>=2.14.2 || ^>=2.15`, which conflicts with the stricter bounds merged in #29.

Tested successfully with `cardano-utxo-csmt` build.