### PR TITLE
fix: add autogen-modules for Paths_csmt

### DIFF
--- a/csmt.cabal
+++ b/csmt.cabal
@@ -51,6 +51,7 @@ common warnings
 
 library
   import:           warnings
+  autogen-modules:  Paths_csmt
   other-modules:    Paths_csmt
   exposed-modules:
     CSMT
@@ -88,7 +89,6 @@ library
 
   hs-source-dirs:   src/csmt/
   default-language: Haskell2010
-  other-modules:    Paths_csmt
 
 executable csmt
   import:           warnings
@@ -171,7 +171,6 @@ benchmark bench
 
 executable space-leak
   import:           warnings
-  ghc-options:      -O2
   main-is:          src/csmt/CSMT/Frontend/CLI/SpaceLeak.hs
   build-depends:
     , base        >=4.19 && <5

--- a/justfile
+++ b/justfile
@@ -25,6 +25,13 @@ format-check:
     fourmolu -m check $hs_files
     find . -name '*.cabal' -not -path './dist-newstyle/*' | xargs cabal-fmt -c
 
+# Check package is ready for Hackage
+hackage-ready:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cabal check
+    cabal haddock all
+
 # Run hlint
 hlint:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- Add `autogen-modules: Paths_csmt` to library stanza
- Remove duplicate `other-modules: Paths_csmt` declaration

`cabal check` now passes with only `-O2` warning (acceptable for production builds).

Closes #21