### PR TITLE
fix: correct artifact copy commands for bundler outputs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,13 +53,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          # Find and copy actual files from bundler outputs
-          find csmt.deb -name "*.deb" -exec cp {} csmt-${TAG}.deb \;
-          find csmt.rpm -name "*.rpm" -exec cp {} csmt-${TAG}.rpm \;
-          cp -L csmt.AppImage csmt-${TAG}.AppImage 2>/dev/null || \
-            find csmt.AppImage -type f -exec cp {} csmt-${TAG}.AppImage \;
-          cp csmt-image csmt-${TAG}-docker.tar.gz 2>/dev/null || \
-            find csmt-image -type f -exec cp {} csmt-${TAG}-docker.tar.gz \;
+          # Copy actual files from bundler outputs (bundlers create directories)
+          cp csmt.deb/*.deb csmt-${TAG}.deb
+          cp csmt.rpm/*.rpm csmt-${TAG}.rpm
+          cp -L csmt.AppImage csmt-${TAG}.AppImage
+          cp -L csmt-image csmt-${TAG}-docker.tar.gz
 
           gh release upload ${TAG} \
             csmt-${TAG}.deb \


### PR DESCRIPTION
## Summary

- Fix glob patterns for copying deb/rpm artifacts from bundler outputs
- The bundlers create symlinks to directories, so `csmt.deb/*.deb` works but `find csmt.deb -name "*.deb"` returns the symlink itself

Tested locally - all artifact copy commands now work correctly.