### PR TITLE
refactor: generalize path extraction with unified TreePath type

### DIFF
--- a/csmt.cabal
+++ b/csmt.cabal
@@ -70,6 +70,7 @@ library
     CSMT.Hashes.Types
     CSMT.Insertion
     CSMT.Interface
+    CSMT.Path
     CSMT.Proof.Completeness
     CSMT.Proof.Insertion
     Data.Serialize.Extra

--- a/src/csmt/CSMT/Deletion.hs
+++ b/src/csmt/CSMT/Deletion.hs
@@ -17,48 +17,40 @@
 module CSMT.Deletion
     ( deleting
     , newDeletionPath
-    , DeletionPath (..)
+    , DeletionPath
     , deletionPathToOps
     )
 where
 
 import CSMT.Interface
-    ( Direction (..)
-    , FromKV (..)
+    ( FromKV (..)
     , Hashing (..)
     , Indirect (..)
     , Key
-    , addWithDirection
-    , compareKeys
-    , oppositeDirection
     )
-import Control.Monad (guard)
-import Control.Monad.Trans.Maybe (MaybeT (..))
+import CSMT.Path
+    ( TreePath (..)
+    , extractPath
+    , pathToOps
+    )
 import Database.KV.Transaction
     ( GCompare
     , Selector
     , Transaction
     , delete
     , insert
-    , query
     )
 
 -- |
 -- A path through the tree to a value being deleted.
 --
--- * 'Value' - The leaf node containing the value to delete
--- * 'Branch' - An internal node along the path, recording the sibling
---   that will need to be updated after deletion
+-- This is now a type alias for 'TreePath' from "CSMT.Path".
+-- The constructors are:
 --
--- This structure captures the entire path from root to leaf, which is
--- needed to properly update parent hashes after deletion.
-data DeletionPath a where
-    -- | A leaf node with its jump path and value
-    Value :: Key -> a -> DeletionPath a
-    -- | A branch node with jump path, direction taken, child path, and sibling
-    Branch
-        :: Key -> Direction -> DeletionPath a -> Indirect a -> DeletionPath a
-    deriving (Show, Eq)
+-- * 'PathLeaf' - The leaf node containing the value to delete
+-- * 'PathBranch' - An internal node along the path, recording the sibling
+--   that will need to be updated after deletion
+type DeletionPath a = TreePath a
 
 -- |
 -- Delete a key-value pair from the CSMT.
@@ -100,40 +92,10 @@ applyOp csmtSel (k, Just i) = insert csmtSel k i
 -- insert/delete operations. When a branch loses one child, its sibling's
 -- jump path is extended to maintain the compact representation.
 deletionPathToOps
-    :: forall a
-     . Hashing a
+    :: Hashing a
     -> DeletionPath a
     -> [(Key, Maybe (Indirect a))]
-deletionPathToOps hashing = snd . go []
-  where
-    go
-        :: Key
-        -> DeletionPath a
-        -> (Maybe (Indirect a), [(Key, Maybe (Indirect a))])
-    go k (Value _ _v) = (Nothing, [(k, Nothing)])
-    go k (Branch j d v i) =
-        let
-            (msb, xs) = go (k <> j <> [d]) v
-        in
-            case msb of
-                Just i' ->
-                    let h = addWithDirection hashing d i' i
-                        i'' = Indirect{jump = j, value = h}
-                    in  ( Just i''
-                        , [(k, Just i'')] <> xs
-                        )
-                Nothing ->
-                    let i' =
-                            Indirect
-                                { jump = j <> [oppositeDirection d] <> jump i
-                                , value = value i
-                                }
-                    in  ( Just i'
-                        , [ (k, Just i')
-                          , (k <> j <> [oppositeDirection d], Nothing)
-                          ]
-                            <> xs
-                        )
+deletionPathToOps = pathToOps
 
 -- |
 -- Build a deletion path for the given key.
@@ -141,26 +103,8 @@ deletionPathToOps hashing = snd . go []
 -- Traverses the tree from root to the target key, recording each branch
 -- along the way. Returns 'Nothing' if the key does not exist in the tree.
 newDeletionPath
-    :: forall a d ops cf m
-     . (Monad m, GCompare d)
+    :: (Monad m, GCompare d)
     => Selector d Key (Indirect a)
     -> Key
     -> Transaction m cf d ops (Maybe (DeletionPath a))
-newDeletionPath csmtSel = runMaybeT . go []
-  where
-    go
-        :: Key
-        -> Key
-        -> MaybeT (Transaction m cf d ops) (DeletionPath a)
-    go current remaining = do
-        Indirect{jump = j, value = v} <- MaybeT $ query csmtSel current
-        let (_common, other, remaining') = compareKeys j remaining
-        guard $ null other
-        case remaining' of
-            [] -> pure $ Value j v
-            (r : remaining'') -> do
-                let current' = current <> j
-                sibling <-
-                    MaybeT $ query csmtSel (current' <> [oppositeDirection r])
-                p <- go (current' <> [r]) remaining''
-                pure $ Branch j r p sibling
+newDeletionPath = extractPath

--- a/src/csmt/CSMT/Path.hs
+++ b/src/csmt/CSMT/Path.hs
@@ -1,0 +1,251 @@
+-- |
+-- Module      : CSMT.Path
+-- Description : Unified path extraction for Compact Sparse Merkle Trees
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- This module provides a unified abstraction for extracting paths from CSMTs.
+-- Both deletion and proof generation traverse an existing path from root to a
+-- target key, collecting sibling information. This module factors out that
+-- common pattern.
+--
+-- == Overview
+--
+-- When performing operations on a CSMT, we often need to traverse from the root
+-- to a specific key, recording information about each node along the way:
+--
+-- * __Deletion__: We need siblings to update parent hashes after removing a node
+-- * __Proof generation__: We need siblings to construct Merkle inclusion proofs
+--
+-- The 'TreePath' type captures this traversal structure, which can then be
+-- interpreted for different purposes:
+--
+-- * Convert to database operations via 'pathToOps' (for deletion)
+-- * Convert to proof steps via 'pathToProofSteps' (for proof generation)
+--
+-- == Example
+--
+-- Given a tree with keys @[L, L]@ and @[L, R]@:
+--
+-- @
+-- mPath <- extractPath csmtSel [L, L]
+-- case mPath of
+--     Nothing -> -- key not found
+--     Just path -> do
+--         let ops = pathToOps hashing path  -- for deletion
+--         let (rootJump, leafVal, steps) = pathToProofSteps path  -- for proofs
+-- @
+module CSMT.Path
+    ( -- * Path Type
+      TreePath (..)
+
+      -- * Path Extraction
+    , extractPath
+
+      -- * Path Interpretation
+    , pathToOps
+    , pathToProofSteps
+    )
+where
+
+import CSMT.Interface
+    ( Direction (..)
+    , Hashing (..)
+    , Indirect (..)
+    , Key
+    , addWithDirection
+    , compareKeys
+    , oppositeDirection
+    )
+import Control.Monad (guard)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Database.KV.Transaction
+    ( GCompare
+    , Selector
+    , Transaction
+    , query
+    )
+
+-- |
+-- A path through the CSMT from root to a target key.
+--
+-- This recursive structure captures the entire traversal from root to leaf,
+-- including all sibling references needed for operations that modify or
+-- verify the tree.
+--
+-- == Structure
+--
+-- * 'PathLeaf' - Terminal node containing the target value
+-- * 'PathBranch' - Internal node recording the direction taken and sibling
+--
+-- == Invariants
+--
+-- * The path always leads to an existing key in the tree
+-- * Each 'PathBranch' records the sibling at that branch point
+-- * Jump paths are stored to support path compression
+data TreePath a
+    = -- | A leaf node reached at the end of the path.
+      --
+      -- * First argument: jump path prefix at this node
+      -- * Second argument: the value stored at this leaf
+      PathLeaf Key a
+    | -- | A branch node along the path to the target.
+      --
+      -- * First argument: jump path prefix at this node
+      -- * Second argument: direction taken toward target ('L' or 'R')
+      -- * Third argument: the child subtree (rest of path)
+      -- * Fourth argument: the sibling's indirect reference (for hash updates)
+      PathBranch Key Direction (TreePath a) (Indirect a)
+    deriving (Show, Eq)
+
+-- |
+-- Extract a path for the given key from the CSMT.
+--
+-- Traverses the tree from root to the target key, recording each branch
+-- and its sibling along the way.
+--
+-- == Return value
+--
+-- * @'Just' path@ - The key exists and @path@ captures the full traversal
+-- * 'Nothing' - The key does not exist in the tree (path diverges or is missing)
+--
+-- == Algorithm
+--
+-- 1. Start at the root node
+-- 2. At each node, verify the jump path matches the remaining key
+-- 3. If key is exhausted, we've reached the leaf ('PathLeaf')
+-- 4. Otherwise, follow the next direction bit, record the sibling, and recurse
+extractPath
+    :: forall a d ops cf m
+     . (Monad m, GCompare d)
+    => Selector d Key (Indirect a)
+    -- ^ Selector for the CSMT column
+    -> Key
+    -- ^ The key to find a path for
+    -> Transaction m cf d ops (Maybe (TreePath a))
+extractPath csmtSel = runMaybeT . go []
+  where
+    go
+        :: Key
+        -> Key
+        -> MaybeT (Transaction m cf d ops) (TreePath a)
+    go current remaining = do
+        Indirect{jump = j, value = v} <- MaybeT $ query csmtSel current
+        let (_common, other, remaining') = compareKeys j remaining
+        guard $ null other
+        case remaining' of
+            [] -> pure $ PathLeaf j v
+            (r : remaining'') -> do
+                let current' = current <> j
+                sibling <-
+                    MaybeT $ query csmtSel (current' <> [oppositeDirection r])
+                p <- go (current' <> [r]) remaining''
+                pure $ PathBranch j r p sibling
+
+-- |
+-- Convert a path to a list of database operations for deletion.
+--
+-- Traverses the path bottom-up, computing updated hashes and generating
+-- insert\/delete operations.
+--
+-- == Operations generated
+--
+-- * @(key, Nothing)@ - Delete the node at @key@
+-- * @(key, Just indirect)@ - Insert or update the node at @key@
+--
+-- == Tree compaction
+--
+-- When a branch loses one child (the deleted node), the remaining sibling's
+-- jump path is extended to absorb the now-unnecessary branch point. This
+-- maintains the compact representation where only necessary branch points exist.
+--
+-- == Example
+--
+-- For a path to key @[L, R]@ in a tree with sibling at @[L, L]@:
+--
+-- @
+-- pathToOps hashing path
+-- -- Returns operations to:
+-- --   1. Delete [L, R]
+-- --   2. Update root to point directly to [L, L] with extended jump
+-- --   3. Delete the old [L] branch node
+-- @
+pathToOps
+    :: forall a
+     . Hashing a
+    -- ^ Hash functions for computing updated node values
+    -> TreePath a
+    -- ^ The path to convert
+    -> [(Key, Maybe (Indirect a))]
+    -- ^ List of (key, operation) pairs to apply atomically
+pathToOps hashing = snd . go []
+  where
+    go
+        :: Key
+        -> TreePath a
+        -> (Maybe (Indirect a), [(Key, Maybe (Indirect a))])
+    go k (PathLeaf _ _v) = (Nothing, [(k, Nothing)])
+    go k (PathBranch j d v i) =
+        let
+            (msb, xs) = go (k <> j <> [d]) v
+        in
+            case msb of
+                Just i' ->
+                    let h = addWithDirection hashing d i' i
+                        i'' = Indirect{jump = j, value = h}
+                    in  ( Just i''
+                        , [(k, Just i'')] <> xs
+                        )
+                Nothing ->
+                    let i' =
+                            Indirect
+                                { jump = j <> [oppositeDirection d] <> jump i
+                                , value = value i
+                                }
+                    in  ( Just i'
+                        , [ (k, Just i')
+                          , (k <> j <> [oppositeDirection d], Nothing)
+                          ]
+                            <> xs
+                        )
+
+-- |
+-- Convert a path to proof steps for Merkle inclusion proofs.
+--
+-- Returns the components needed to construct an 'InclusionProof':
+--
+-- == Return value
+--
+-- A tuple of @(rootJump, leafValue, steps)@ where:
+--
+-- * @rootJump@ - The jump path at the root node
+-- * @leafValue@ - The value stored at the target leaf
+-- * @steps@ - Proof steps ordered from leaf to root
+--
+-- == Step format
+--
+-- Each step is @(bitsConsumed, sibling)@ where:
+--
+-- * @bitsConsumed@ - Number of key bits used at this level (1 + jump length)
+-- * @sibling@ - The sibling's indirect reference for hash verification
+--
+-- == Ordering
+--
+-- Steps are ordered leaf-to-root to match the verification algorithm in
+-- 'CSMT.Proof.Insertion.computeRootHash', which processes the key from
+-- the leaf end backward toward the root.
+pathToProofSteps
+    :: TreePath a
+    -> (Key, a, [(Int, Indirect a)])
+    -- ^ @(rootJump, leafValue, steps)@ - components for proof construction
+pathToProofSteps path = (rootJump, leafVal, reverse revSteps)
+  where
+    (rootJump, leafVal, revSteps) = go path
+
+    go (PathLeaf nodeJump leafValue) = (nodeJump, leafValue, [])
+    go (PathBranch nodeJump _dir child sibling) =
+        let (childJump, childLeafVal, childRevSteps) = go child
+            -- Bits consumed = 1 (for direction) + length of child's jump
+            consumed = 1 + length childJump
+            step = (consumed, sibling)
+        in  (nodeJump, childLeafVal, step : childRevSteps)

--- a/src/csmt/CSMT/Proof/Insertion.hs
+++ b/src/csmt/CSMT/Proof/Insertion.hs
@@ -28,12 +28,13 @@ import CSMT.Interface
     , Indirect (..)
     , Key
     , addWithDirection
-    , oppositeDirection
+    )
+import CSMT.Path
+    ( extractPath
+    , pathToProofSteps
     )
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
-import Data.List (isPrefixOf)
 
-import Control.Monad (guard)
 import Database.KV.Transaction
     ( GCompare
     , Selector
@@ -101,33 +102,25 @@ buildInclusionProof FromKV{fromK, fromV} kvSel csmtSel hashing k =
         v <- MaybeT $ query kvSel k
         let key = fromK k
             value = fromV v
-        rootIndirect@(Indirect rootJump _) <- MaybeT $ query csmtSel []
-        guard $ isPrefixOf rootJump key
-        steps <- go rootJump $ drop (length rootJump) key
-        let proofData =
+        rootIndirect <- MaybeT $ query csmtSel []
+        treePath <- MaybeT $ extractPath csmtSel key
+        let (rootJump, _leafValue, rawSteps) = pathToProofSteps treePath
+            steps = map toProofStep rawSteps
+            proofData =
                 InclusionProof
                     { proofKey = key
                     , proofValue = value
                     , proofRootHash = rootHash hashing rootIndirect
-                    , proofSteps = reverse steps
+                    , proofSteps = steps
                     , proofRootJump = rootJump
                     }
         pure (v, proofData)
   where
-    go _ [] = pure []
-    go u (x : ks) = do
-        Indirect jump _ <- MaybeT $ query csmtSel (u <> [x])
-        guard $ isPrefixOf jump ks
-        stepSibling <- MaybeT $ query csmtSel (u <> [oppositeDirection x])
-        let step =
-                ProofStep
-                    { stepConsumed = 1 + length jump
-                    , stepSibling
-                    }
-        (step :)
-            <$> go
-                (u <> (x : jump))
-                (drop (length jump) ks)
+    toProofStep (consumed, sibling) =
+        ProofStep
+            { stepConsumed = consumed
+            , stepSibling = sibling
+            }
 
 -- |
 -- Verify an inclusion proof is internally consistent.

--- a/test-lib/CSMT/Test/Lib.hs
+++ b/test-lib/CSMT/Test/Lib.hs
@@ -67,7 +67,7 @@ import CSMT.Backend.Pure
     , runPure
     )
 import CSMT.Deletion
-    ( DeletionPath (..)
+    ( DeletionPath
     , deleting
     , newDeletionPath
     )

--- a/test/CSMT/DeletionSpec.hs
+++ b/test/CSMT/DeletionSpec.hs
@@ -15,10 +15,10 @@ import CSMT.Backend.Pure
     , runPureTransaction
     )
 import CSMT.Deletion
-    ( DeletionPath (..)
-    , deletionPathToOps
+    ( deletionPathToOps
     , newDeletionPath
     )
+import CSMT.Path (TreePath (..))
 import CSMT.Interface (Key)
 import CSMT.Test.Lib
     ( deleteWord64
@@ -52,7 +52,7 @@ spec = do
                         $ runPureTransaction word64Codecs
                         $ newDeletionPath StandaloneCSMTCol []
               in
-                mp `shouldBe` Just (Value [] 1)
+                mp `shouldBe` Just (PathLeaf [] 1)
         it "constructs a deletion path for a tree with siblings"
             $ let
                 rs0 = insertWord64 emptyInMemoryDB [L] (1 :: Word64)
@@ -61,14 +61,14 @@ spec = do
               in
                 mp
                     `shouldBe` Just
-                        (Branch [] L (Value [] 1) (node [] 2))
+                        (PathBranch [] L (PathLeaf [] 1) (node [] 2))
         it "constructs a deletion path for a tree with jumps"
             $ let
                 rs0 = insertWord64 emptyInMemoryDB [L, L] (1 :: Word64)
                 rs1 = insertWord64 rs0 [L, R] (2 :: Word64)
                 mp = mkDeletionPath word64Codecs rs1 [L, L]
               in
-                mp `shouldBe` Just (Branch [L] L (Value [] 1) (node [] 2))
+                mp `shouldBe` Just (PathBranch [L] L (PathLeaf [] 1) (node [] 2))
         it "constructs a deletion path for a deeper tree with jumps"
             $ let
                 rs0 = insertWord64 emptyInMemoryDB [L, L, R] (1 :: Word64)
@@ -82,36 +82,36 @@ spec = do
                 do
                     mp0
                         `shouldBe` Just
-                            ( Branch
+                            ( PathBranch
                                 []
                                 L
-                                ( Branch
+                                ( PathBranch
                                     []
                                     L
-                                    (Value [R] 1)
+                                    (PathLeaf [R] 1)
                                     (node [L] 2)
                                 )
                                 (node [L, R] 3)
                             )
                     mp1
                         `shouldBe` Just
-                            ( Branch
+                            ( PathBranch
                                 []
                                 L
-                                ( Branch
+                                ( PathBranch
                                     []
                                     R
-                                    (Value [L] 2)
+                                    (PathLeaf [L] 2)
                                     (node [R] 1)
                                 )
                                 (node [L, R] 3)
                             )
                     mp2
                         `shouldBe` Just
-                            ( Branch
+                            ( PathBranch
                                 []
                                 R
-                                (Value [L, R] 3)
+                                (PathLeaf [L, R] 3)
                                 (node [] 4)
                             )
                     rs3 `shouldBe` rs1
@@ -128,36 +128,36 @@ spec = do
                 do
                     mp0
                         `shouldBe` Just
-                            ( Branch
+                            ( PathBranch
                                 []
                                 L
-                                ( Branch
+                                ( PathBranch
                                     [L]
                                     L
-                                    (Value [] 1)
+                                    (PathLeaf [] 1)
                                     (node [] 2)
                                 )
                                 (node [R, R] 3)
                             )
                     mp1
                         `shouldBe` Just
-                            ( Branch
+                            ( PathBranch
                                 []
                                 L
-                                ( Branch
+                                ( PathBranch
                                     [L]
                                     R
-                                    (Value [] 2)
+                                    (PathLeaf [] 2)
                                     (node [] 1)
                                 )
                                 (node [R, R] 3)
                             )
                     mp2
                         `shouldBe` Just
-                            ( Branch
+                            ( PathBranch
                                 []
                                 R
-                                (Value [R, R] 3)
+                                (PathLeaf [R, R] 3)
                                 (node [L] 3)
                             )
 
@@ -257,10 +257,10 @@ spec = do
               in
                 mp
                     `shouldBe` Just
-                        ( Branch
+                        ( PathBranch
                             []
                             L
-                            (Value [R] 2)
+                            (PathLeaf [R] 2)
                             (node [L] 3)
                         )
         it "computes the right ops to delete [L,R] from [[L, R], [R, L]]"


### PR DESCRIPTION
## Summary

- Extract common path traversal logic from deletion and proof generation into new `CSMT.Path` module
- Add `TreePath` type with `PathLeaf` and `PathBranch` constructors
- Add `extractPath` for generic CSMT path extraction
- Add `pathToOps` for deletion operations  
- Add `pathToProofSteps` for proof generation
- Refactor `Deletion` to use `TreePath` (`DeletionPath` is now a type alias)
- Refactor `Proof.Insertion` to use `extractPath` + `pathToProofSteps`

## Test plan

- [x] All 86 existing tests pass
- [x] Deletion tests verify path extraction and operations
- [x] Proof tests verify inclusion proof generation and verification

Closes #1