### PR TITLE
fix: sanitize nix store paths in asciinema cast files

### DIFF
--- a/docs/assets/asciinema/basic-ops.cast
+++ b/docs/assets/asciinema/basic-ops.cast
@@ -1,4 +1,4 @@
-{"version": 2, "width": 80, "height": 24, "timestamp": 1770038178, "env": {"SHELL": "/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/bash", "TERM": "tmux-256color"}}
+{"version": 2, "width": 80, "height": 24, "timestamp": 1770038178, "env": {"SHELL": "/bin/bash", "TERM": "tmux-256color"}}
 [0.015752, "o", "# CSMT Basic Operations Demo\r\n\r\n"]
 [1.021725, "o", "## Insert key-value pairs\r\n"]
 [1.52824, "o", "$ csmt <<< \"i hello world\"\r\n"]

--- a/docs/assets/asciinema/proof-ops.cast
+++ b/docs/assets/asciinema/proof-ops.cast
@@ -1,4 +1,4 @@
-{"version": 2, "width": 80, "height": 24, "timestamp": 1770038730, "env": {"SHELL": "/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/bash", "TERM": "tmux-256color"}}
+{"version": 2, "width": 80, "height": 24, "timestamp": 1770038730, "env": {"SHELL": "/bin/bash", "TERM": "tmux-256color"}}
 [0.033322, "o", "# CSMT Proof Operations Demo\r\n\r\n"]
 [1.033257, "o", "## Setup: Insert data\r\n"]
 [1.536693, "o", "$ csmt <<< \"i mykey myvalue\"\r\n"]


### PR DESCRIPTION
## Summary

- Replace hardcoded nix store bash path with `/bin/bash` in asciinema `.cast` file headers
- Fixes `fixed-output derivations must not reference store paths` error when fetching this repo as a `source-repository-package` with `--sha256:` hash pinning

The SHELL env field contained `/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/bash`. When nix's fetchgit builder uses the same bash derivation, nix detects a "reference" in the fixed-output derivation output and rejects the build.