### PR TITLE
feat: export packHexKey, nibbleBytes, merkleProof from MPF.Hashes

### DIFF
--- a/lib/mpf/MPF/Hashes.hs
+++ b/lib/mpf/MPF/Hashes.hs
@@ -17,6 +17,13 @@ module MPF.Hashes
     , computeMerkleRoot
     , fromHexKVHashes
     , byteStringToHexKey'
+
+      -- * Key Encoding
+    , packHexKey
+    , nibbleBytes
+
+      -- * Merkle Proof
+    , merkleProof
     )
 where
 
@@ -148,3 +155,39 @@ fromHexKVHashes =
 -- | Alias for byteStringToHexKey for convenient import
 byteStringToHexKey' :: ByteString -> HexKey
 byteStringToHexKey' = byteStringToHexKey
+
+-- | SMT proof: 4 intermediate hashes that, together with the
+-- element at position @me@, reconstruct the merkle root.
+--
+-- Binary search through the 16-element pairwise reduction
+-- tree, collecting the opposite subtree's root at each of
+-- 4 levels (pivot starts at 8, halves each step).
+merkleProof :: [Maybe MPFHash] -> Int -> [MPFHash]
+merkleProof children me =
+    let
+        padded = take 16 $ children ++ repeat Nothing
+        hashes = map (fromMaybe nullHash) padded
+    in
+        go hashes me 8 []
+  where
+    go _ _ 0 acc = reverse acc
+    go hs pos pivot acc =
+        let
+            (left, right) = splitAt pivot hs
+        in
+            if pos < pivot
+                then
+                    go
+                        left
+                        pos
+                        (pivot `div` 2)
+                        (subtreeRoot right : acc)
+                else
+                    go
+                        right
+                        (pos - pivot)
+                        (pivot `div` 2)
+                        (subtreeRoot left : acc)
+
+    subtreeRoot :: [MPFHash] -> MPFHash
+    subtreeRoot = pairwiseReduce


### PR DESCRIPTION
## Summary
- Export `packHexKey`, `nibbleBytes` (already defined but not exported)
- Add and export `merkleProof` function for SMT proof generation

Needed by cardano-mpfs-offchain to replace its local MPF copy with `mts:mpf`.