### PR TITLE
fix: Aiken-compatible Leaf/Fork proof steps

### DIFF
--- a/lib/mpf/MPF/Proof/Insertion.hs
+++ b/lib/mpf/MPF/Proof/Insertion.hs
@@ -40,25 +40,41 @@ data MerkleProofItem a
       MPINone
     deriving (Show, Eq)
 
--- | Proof step types for MPF
+-- | Proof step types for MPF.
+--
+-- When a branch has exactly one non-empty sibling:
+--
+-- * If the sibling is a leaf → 'ProofStepLeaf'
+-- * If the sibling is a branch → 'ProofStepFork'
+--
+-- Otherwise → 'ProofStepBranch' with a Merkle proof
+-- over all siblings.
 data MPFProofStep a
     = ProofStepLeaf
-        { pslPrefixLen :: Int
-        -- ^ Length of common prefix
+        { pslBranchJump :: HexKey
+        -- ^ Branch prefix (skip = length of this)
+        , pslOurPosition :: HexDigit
+        -- ^ Our nibble at this branch
         , pslNeighborKeyPath :: HexKey
-        -- ^ Neighbor's remaining key path
+        -- ^ Neighbor leaf's full key path (for CBOR)
+        , pslNeighborNibble :: HexDigit
+        -- ^ Neighbor leaf's nibble at this branch
+        , pslNeighborSuffix :: HexKey
+        -- ^ Neighbor leaf's remaining key suffix
         , pslNeighborValueDigest :: a
-        -- ^ Neighbor's value digest
+        -- ^ Neighbor leaf's value digest
         }
     | ProofStepFork
-        { psfPrefixLen :: Int
-        -- ^ Length of common prefix
+        { psfBranchJump :: HexKey
+        -- ^ Branch prefix (skip = length of this)
+        , psfOurPosition :: HexDigit
+        -- ^ Our nibble at this branch
         , psfNeighborPrefix :: HexKey
         -- ^ Neighbor branch prefix
         , psfNeighborIndex :: HexDigit
-        -- ^ Neighbor's position
+        -- ^ Neighbor's position (nibble)
         , psfMerkleRoot :: a
-        -- ^ Merkle root of branch
+        -- ^ Merkle root of neighbor branch's children
         }
     | ProofStepBranch
         { psbJump :: HexKey
@@ -66,7 +82,7 @@ data MPFProofStep a
         , psbPosition :: HexDigit
         -- ^ Our position (digit) at this branch
         , psbSiblingHashes :: [(HexDigit, a)]
-        -- ^ Sibling NODE hashes at this branch (leafHash applied for leaves)
+        -- ^ Sibling NODE hashes at this branch
         }
     deriving (Show, Eq)
 
@@ -79,7 +95,20 @@ data MPFProof a = MPFProof
     }
     deriving (Show, Eq)
 
--- | Generate a membership proof for a key
+-- | Generate a membership proof for a key.
+--
+-- When a branch has exactly one non-empty sibling:
+--
+-- * If the sibling is a leaf → 'ProofStepLeaf' with
+--   full neighbor details (key path, suffix, value)
+-- * If the sibling is a branch → 'ProofStepFork' with
+--   the neighbor's merkle root
+--
+-- Otherwise → 'ProofStepBranch' with precomputed
+-- node hashes for all siblings (used in Merkle proof).
+--
+-- This 3-way branching matches the Aiken on-chain
+-- validator format byte-for-byte.
 mkMPFInclusionProof
     :: (Monad m, GCompare d)
     => FromHexKV k v a
@@ -87,129 +116,338 @@ mkMPFInclusionProof
     -> Selector d HexKey (HexIndirect a)
     -> k
     -> Transaction m cf d ops (Maybe (MPFProof a))
-mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k = runMaybeT $ do
-    let key = fromHexK k
-    HexIndirect{hexJump = rootJump, hexIsLeaf = rootIsLeaf} <-
-        MaybeT $ query sel []
-    guard $ isPrefixOf rootJump key
-    let remainingAfterRoot = drop (length rootJump) key
-    if rootIsLeaf
-        then
-            -- Single leaf at root, no branch steps needed
-            -- leafSuffix is the node's hexJump (used in leafHash computation)
-            pure
-                $ MPFProof
-                    { mpfProofSteps = []
-                    , mpfProofRootPrefix = [] -- No prefix for single-leaf root
-                    , mpfProofLeafSuffix = rootJump -- The leaf's suffix is its hexJump
-                    }
-        else do
-            -- For branches, we need to track the parent's jump for branchHash
-            -- Root branch's jump is rootJump
-            (steps, leafSuffix) <- go [] rootJump remainingAfterRoot
-            pure
-                $ MPFProof
-                    { mpfProofSteps = reverse steps
-                    , mpfProofRootPrefix = rootJump
-                    , mpfProofLeafSuffix = leafSuffix
-                    }
+mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
+    runMaybeT $ do
+        let key = fromHexK k
+        HexIndirect
+            { hexJump = rootJump
+            , hexIsLeaf = rootIsLeaf
+            } <-
+            MaybeT $ query sel []
+        guard $ isPrefixOf rootJump key
+        let remainingAfterRoot = drop (length rootJump) key
+        if rootIsLeaf
+            then
+                pure
+                    $ MPFProof
+                        { mpfProofSteps = []
+                        , mpfProofRootPrefix = []
+                        , mpfProofLeafSuffix = rootJump
+                        }
+            else do
+                (steps, leafSuffix) <-
+                    go [] rootJump remainingAfterRoot
+                pure
+                    $ MPFProof
+                        { mpfProofSteps = reverse steps
+                        , mpfProofRootPrefix = rootJump
+                        , mpfProofLeafSuffix = leafSuffix
+                        }
   where
-    -- go currentPath currentBranchJump remainingKey
-    -- Returns (steps built bottom-up, leaf's hexJump as suffix)
     go _ _ [] = pure ([], [])
     go u branchJump (x : ks) = do
-        HexIndirect{hexJump = childJump, hexIsLeaf} <-
-            MaybeT $ query sel (u <> branchJump <> [x])
+        HexIndirect
+            { hexJump = childJump
+            , hexIsLeaf
+            } <-
+            MaybeT
+                $ query sel (u <> branchJump <> [x])
         guard $ isPrefixOf childJump ks
         let remaining = drop (length childJump) ks
-        -- Collect sibling information at this branch
-        -- Compute node hashes (leafHash for leaves, branchHash for branches)
-        siblings <-
+        -- Fetch all sibling details (excluding our
+        -- position x)
+        sibDetails <-
             MaybeT
-                $ Just <$> fetchSiblingNodeHashes hashing sel (u <> branchJump) x
-        -- psbJump is the current BRANCH's jump (for branchHash), not the child's
-        let step =
-                ProofStepBranch
-                    { psbJump = branchJump
-                    , psbPosition = x
-                    , psbSiblingHashes = Map.toList siblings
-                    }
+                $ Just
+                    <$> fetchSiblingDetails
+                        sel
+                        (u <> branchJump)
+                        x
+        let nonEmpty = Map.toList sibDetails
+        step <- case nonEmpty of
+            -- Exactly 1 sibling that is a leaf
+            [ ( d
+                    , HexIndirect
+                        { hexJump = sibSuffix
+                        , hexValue = sibVal
+                        , hexIsLeaf = True
+                        }
+                    )
+                ] ->
+                    let fullKey =
+                            u
+                                <> branchJump
+                                <> [d]
+                                <> sibSuffix
+                    in  pure
+                            $ ProofStepLeaf
+                                { pslBranchJump =
+                                    branchJump
+                                , pslOurPosition = x
+                                , pslNeighborKeyPath =
+                                    fullKey
+                                , pslNeighborNibble = d
+                                , pslNeighborSuffix =
+                                    sibSuffix
+                                , pslNeighborValueDigest =
+                                    sibVal
+                                }
+            -- Exactly 1 sibling that is a branch
+            [ ( d
+                    , HexIndirect
+                        { hexJump = sibPrefix
+                        , hexIsLeaf = False
+                        }
+                    )
+                ] -> do
+                    mr <-
+                        MaybeT
+                            $ Just
+                                <$> fetchBranchMerkleRoot
+                                    hashing
+                                    sel
+                                    ( u
+                                        <> branchJump
+                                        <> [d]
+                                    )
+                                    sibPrefix
+                    pure
+                        $ ProofStepFork
+                            { psfBranchJump =
+                                branchJump
+                            , psfOurPosition = x
+                            , psfNeighborPrefix =
+                                sibPrefix
+                            , psfNeighborIndex = d
+                            , psfMerkleRoot = mr
+                            }
+            -- Multiple siblings: branch step with
+            -- Merkle proof
+            _ ->
+                let nodeHashes =
+                        [ (d, computeNodeHash d')
+                        | (d, d') <- nonEmpty
+                        ]
+                in  pure
+                        $ ProofStepBranch
+                            { psbJump = branchJump
+                            , psbPosition = x
+                            , psbSiblingHashes =
+                                nodeHashes
+                            }
         if hexIsLeaf
-            then
-                -- Reached the leaf - suffix for hashing is the leaf's hexJump
-                pure ([step], childJump)
+            then pure ([step], childJump)
             else do
-                -- Descend into child branch, passing child's jump as the new branchJump
                 (restSteps, leafSuffix) <-
-                    go (u <> branchJump <> [x]) childJump remaining
+                    go
+                        (u <> branchJump <> [x])
+                        childJump
+                        remaining
                 pure (step : restSteps, leafSuffix)
 
--- | Fetch all sibling NODE hashes at a branch point (excluding the given digit)
--- For leaf nodes: computes leafHash(suffix, valueHash)
--- For branch nodes: uses the stored branchHash directly
-fetchSiblingNodeHashes
+    computeNodeHash
+        HexIndirect
+            { hexJump
+            , hexValue
+            , hexIsLeaf = isLeaf
+            } =
+            if isLeaf
+                then leafHash hashing hexJump hexValue
+                else hexValue
+
+-- | Fetch all non-empty sibling details at a branch
+-- point (excluding the given digit).
+fetchSiblingDetails
+    :: (Monad m, GCompare d)
+    => Selector d HexKey (HexIndirect a)
+    -> HexKey
+    -> HexDigit
+    -> Transaction m cf d ops (Map HexDigit (HexIndirect a))
+fetchSiblingDetails sel prefix exclude = do
+    let digits =
+            [ HexDigit n
+            | n <- [0 .. 15]
+            , HexDigit n /= exclude
+            ]
+    pairs <- mapM fetchOne digits
+    pure
+        $ Map.fromList
+            [(d, hi) | (d, Just hi) <- pairs]
+  where
+    fetchOne d = do
+        mi <- query sel (prefix <> [d])
+        pure (d, mi)
+
+-- | Compute the merkle root of a branch's children
+-- (16 queries for the child positions).
+fetchBranchMerkleRoot
     :: (Monad m, GCompare d)
     => MPFHashing a
     -> Selector d HexKey (HexIndirect a)
     -> HexKey
-    -> HexDigit
-    -> Transaction m cf d ops (Map HexDigit a)
-fetchSiblingNodeHashes MPFHashing{leafHash} sel prefix exclude = do
-    let digits = [HexDigit n | n <- [0 .. 15], HexDigit n /= exclude]
-    pairs <- mapM fetchOne digits
-    pure $ Map.fromList [(d, h) | (d, Just h) <- pairs]
-  where
-    fetchOne d = do
-        mi <- query sel (prefix <> [d])
-        pure $ case mi of
-            Nothing -> (d, Nothing)
-            Just HexIndirect{hexJump, hexValue, hexIsLeaf}
-                | hexIsLeaf ->
-                    -- Leaf: hexValue is VALUE hash, compute NODE hash
-                    (d, Just $ leafHash hexJump hexValue)
-                | otherwise ->
-                    -- Branch: hexValue is already the BRANCH hash
-                    (d, Just hexValue)
+    -> HexKey
+    -> Transaction m cf d ops a
+fetchBranchMerkleRoot
+    hashing'@MPFHashing{merkleRoot = mr}
+    sel
+    neighborPath
+    neighborPrefix = do
+        children <-
+            mapM
+                fetchChild
+                [HexDigit n | n <- [0 .. 15]]
+        pure $ mr children
+      where
+        fetchChild d = do
+            mi <-
+                query
+                    sel
+                    ( neighborPath
+                        <> neighborPrefix
+                        <> [d]
+                    )
+            pure $ case mi of
+                Nothing -> Nothing
+                Just hi ->
+                    Just
+                        $ computeNodeHash' hashing' hi
 
--- | Fold a proof to compute the root hash
--- Starts with the value hash, computes the leaf hash, then works up through
--- branches applying merkleRoot and branchHash at each level
+-- | Compute the node hash from a 'HexIndirect'.
+computeNodeHash'
+    :: MPFHashing a -> HexIndirect a -> a
+computeNodeHash'
+    MPFHashing{leafHash = lh}
+    HexIndirect{hexJump, hexValue, hexIsLeaf} =
+        if hexIsLeaf
+            then lh hexJump hexValue
+            else hexValue
+
+-- | Fold a proof to compute the root hash.
+--
+-- Starts with the value hash, computes the leaf hash,
+-- then works up through branches.
+--
+-- Each step type reconstructs a sparse 16-element
+-- array differently:
+--
+-- * 'ProofStepBranch': our hash at our position,
+--   sibling hashes at their positions
+-- * 'ProofStepLeaf': our hash + one neighbor leaf
+--   hash (computed from suffix + value)
+-- * 'ProofStepFork': our hash + one neighbor branch
+--   hash (computed from prefix + merkle root)
 foldMPFProof :: MPFHashing a -> a -> MPFProof a -> a
-foldMPFProof hashing valueHash MPFProof{mpfProofSteps, mpfProofLeafSuffix} =
-    case mpfProofSteps of
-        [] ->
-            -- Single leaf at root: compute leaf hash with full suffix
-            leafHash hashing mpfProofLeafSuffix valueHash
-        steps ->
-            -- Multiple levels: fold from leaf up to root
-            -- Steps are ordered leaf-to-root, so foldl' processes in correct order:
-            -- start with leaf hash, combine with leaf's parent siblings, work up
-            let leafNodeHash = leafHash hashing mpfProofLeafSuffix valueHash
-            in  foldl' step leafNodeHash steps
-  where
-    step acc proofStep =
-        case proofStep of
-            ProofStepBranch{psbJump, psbPosition, psbSiblingHashes} ->
-                let siblingMap = Map.fromList psbSiblingHashes
-                    -- Build sparse 16-element array with our hash at psbPosition
-                    -- and sibling hashes at their respective positions
-                    sparseArray =
-                        [ if HexDigit n == psbPosition
-                            then Just acc
-                            else Map.lookup (HexDigit n) siblingMap
-                        | n <- [0 .. 15]
-                        ]
-                    mr = merkleRoot hashing sparseArray
-                in  branchHash hashing psbJump mr
-            ProofStepLeaf{} ->
-                -- Leaf step: handled at termination
-                acc
-            ProofStepFork{psfMerkleRoot} ->
-                -- Fork step: use the provided merkle root
-                psfMerkleRoot
+foldMPFProof
+    hashing
+    valueHash
+    MPFProof{mpfProofSteps, mpfProofLeafSuffix} =
+        case mpfProofSteps of
+            [] ->
+                leafHash hashing mpfProofLeafSuffix valueHash
+            steps ->
+                let leafNodeHash =
+                        leafHash
+                            hashing
+                            mpfProofLeafSuffix
+                            valueHash
+                in  foldl' step leafNodeHash steps
+      where
+        step acc proofStep =
+            case proofStep of
+                ProofStepBranch
+                    { psbJump
+                    , psbPosition
+                    , psbSiblingHashes
+                    } ->
+                        let siblingMap =
+                                Map.fromList
+                                    psbSiblingHashes
+                            sparseArray =
+                                [ if HexDigit n
+                                    == psbPosition
+                                    then Just acc
+                                    else
+                                        Map.lookup
+                                            (HexDigit n)
+                                            siblingMap
+                                | n <- [0 .. 15]
+                                ]
+                            mr =
+                                merkleRoot
+                                    hashing
+                                    sparseArray
+                        in  branchHash
+                                hashing
+                                psbJump
+                                mr
+                ProofStepLeaf
+                    { pslBranchJump
+                    , pslOurPosition
+                    , pslNeighborNibble
+                    , pslNeighborSuffix
+                    , pslNeighborValueDigest
+                    } ->
+                        let neighborHash =
+                                leafHash
+                                    hashing
+                                    pslNeighborSuffix
+                                    pslNeighborValueDigest
+                            sparseArray =
+                                [ if HexDigit n
+                                    == pslOurPosition
+                                    then Just acc
+                                    else
+                                        if HexDigit n
+                                            == pslNeighborNibble
+                                            then
+                                                Just
+                                                    neighborHash
+                                            else Nothing
+                                | n <- [0 .. 15]
+                                ]
+                            mr =
+                                merkleRoot
+                                    hashing
+                                    sparseArray
+                        in  branchHash
+                                hashing
+                                pslBranchJump
+                                mr
+                ProofStepFork
+                    { psfBranchJump
+                    , psfOurPosition
+                    , psfNeighborPrefix
+                    , psfNeighborIndex
+                    , psfMerkleRoot
+                    } ->
+                        let neighborHash =
+                                branchHash
+                                    hashing
+                                    psfNeighborPrefix
+                                    psfMerkleRoot
+                            sparseArray =
+                                [ if HexDigit n
+                                    == psfOurPosition
+                                    then Just acc
+                                    else
+                                        if HexDigit n
+                                            == psfNeighborIndex
+                                            then
+                                                Just
+                                                    neighborHash
+                                            else Nothing
+                                | n <- [0 .. 15]
+                                ]
+                            mr =
+                                merkleRoot
+                                    hashing
+                                    sparseArray
+                        in  branchHash
+                                hashing
+                                psfBranchJump
+                                mr
 
 -- | Verify a membership proof
--- Compares the computed root hash from the proof against the stored root hash
 verifyMPFInclusionProof
     :: (Eq a, Monad m, GCompare d)
     => FromHexKV k v a
@@ -218,17 +456,28 @@ verifyMPFInclusionProof
     -> v
     -> MPFProof a
     -> Transaction m cf d ops Bool
-verifyMPFInclusionProof FromHexKV{fromHexV} sel hashing@MPFHashing{leafHash} v proof = do
-    let valueHash = fromHexV v
-    mv <- query sel []
-    pure $ case mv of
-        Just HexIndirect{hexJump, hexValue, hexIsLeaf} ->
-            -- Compute the root NODE hash from what's stored
-            -- Leaf: hexValue is VALUE hash, need to apply leafHash
-            -- Branch: hexValue is already the BRANCH hash
-            let rootNodeHash =
-                    if hexIsLeaf
-                        then leafHash hexJump hexValue
-                        else hexValue
-            in  rootNodeHash == foldMPFProof hashing valueHash proof
-        Nothing -> False
+verifyMPFInclusionProof
+    FromHexKV{fromHexV}
+    sel
+    hashing@MPFHashing{leafHash = lh}
+    v
+    proof = do
+        let valueHash = fromHexV v
+        mv <- query sel []
+        pure $ case mv of
+            Just
+                HexIndirect
+                    { hexJump
+                    , hexValue
+                    , hexIsLeaf
+                    } ->
+                    let rootNodeHash =
+                            if hexIsLeaf
+                                then lh hexJump hexValue
+                                else hexValue
+                    in  rootNodeHash
+                            == foldMPFProof
+                                hashing
+                                valueHash
+                                proof
+            Nothing -> False


### PR DESCRIPTION
## Summary
- ProofStepLeaf/Fork now carry full neighbor details (branch jump, position, nibble, suffix) matching the Aiken on-chain validator format
- mkMPFInclusionProof detects single-sibling branches and emits Leaf/Fork instead of always Branch
- foldMPFProof correctly reconstructs root hash through all 3 step types
- Byte-identical to TypeScript reference implementation (`proof.toCBOR()`)