### PR TITLE
docs: rebrand documentation from CSMT to MTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,29 @@
-# Changelog for csmt-utxo
+# Changelog for mts
 
-## [0.3.2](https://github.com/paolino/haskell-csmt/compare/v0.3.1...v0.3.2) (2026-02-02)
+## [0.4.0.0](https://github.com/paolino/haskell-mts/compare/v0.3.2...v0.4.0.0) (2026-03-02)
 
+### Features
+
+* rename package from `csmt` to `mts` (Merkle Tree Store)
+* introduce shared `MerkleTreeStore` record with type families (`MTS.Interface`)
+* add 12 shared QuickCheck properties (`MTS.Properties`)
+* add MPF (Merkle Patricia Forest) 16-ary trie implementation
+* MPF batch, chunked, and streaming insertion modes
+* MPF inclusion proofs with Aiken-compatible proof steps
+* CSMT and MPF both provide `MerkleTreeStore` constructors (`csmtMerkleTreeStore`, `mpfMerkleTreeStore`)
+* add completeness proofs to shared MTS interface
+* restructure cabal file into `mts` (shared), `mts:csmt`, `mts:mpf` sub-libraries
+
+## [0.3.2](https://github.com/paolino/haskell-mts/compare/v0.3.1...v0.3.2) (2026-02-02)
 
 ### Bug Fixes
 
-* correct artifact copy commands for bundler outputs ([140e2eb](https://github.com/paolino/haskell-csmt/commit/140e2eb33c6845bf6c0f8009bed7e23b9aa22438))
-* handle bundler output directories in release upload ([eb3632e](https://github.com/paolino/haskell-csmt/commit/eb3632e7ed908e1282484a67fb08a90afbe373eb))
+* correct artifact copy commands for bundler outputs ([140e2eb](https://github.com/paolino/haskell-mts/commit/140e2eb33c6845bf6c0f8009bed7e23b9aa22438))
+* handle bundler output directories in release upload ([eb3632e](https://github.com/paolino/haskell-mts/commit/eb3632e7ed908e1282484a67fb08a90afbe373eb))
 
-## [0.3.1](https://github.com/paolino/haskell-csmt/compare/v0.3.0...v0.3.1) (2026-02-02)
-
+## [0.3.1](https://github.com/paolino/haskell-mts/compare/v0.3.0...v0.3.1) (2026-02-02)
 
 ### Bug Fixes
 
-* add workflow_dispatch to release workflow ([5bacf67](https://github.com/paolino/haskell-csmt/commit/5bacf670c5d59a89b1614e70c7d94016baeb6dcf))
-* read version from manifest instead of version.txt ([5b3b415](https://github.com/paolino/haskell-csmt/commit/5b3b4154f57d0a9286210c0af3b18740b1192af9))
-
-## 0.1.0.0 (2025-10-12)
-- end-point to list containers
-- end-point to report all logs of a container (non-streaming)
-
-## 0.2.0.0 (2025-10-13)
-- streaming logs of a container
-- proxy the full [docker logs API](https://docs.docker.com/reference/api/engine/version/v1.41/#tag/Container/operation/ContainerLogs)
+* add workflow_dispatch to release workflow ([5bacf67](https://github.com/paolino/haskell-mts/commit/5bacf670c5d59a89b1614e70c7d94016baeb6dcf))
+* read version from manifest instead of version.txt ([5b3b415](https://github.com/paolino/haskell-mts/commit/5b3b4154f57d0a9286210c0af3b18740b1192af9))

--- a/README.md
+++ b/README.md
@@ -1,43 +1,79 @@
-# CSMT - Compact Sparse Merkle Tree
+# MTS - Merkle Tree Store
 
-[![CI](https://github.com/paolino/haskell-csmt/actions/workflows/CI.yaml/badge.svg)](https://github.com/paolino/haskell-csmt/actions/workflows/CI.yaml)
-[![Documentation](https://github.com/paolino/haskell-csmt/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/paolino/haskell-csmt/actions/workflows/deploy-docs.yaml)
+[![CI](https://github.com/paolino/haskell-mts/actions/workflows/CI.yaml/badge.svg)](https://github.com/paolino/haskell-mts/actions/workflows/CI.yaml)
+[![Documentation](https://github.com/paolino/haskell-mts/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/paolino/haskell-mts/actions/workflows/deploy-docs.yaml)
 
-A Haskell library implementing a Compact Sparse Merkle Tree (CSMT) data structure with persistent storage backends.
+A Haskell library providing a shared Merkle tree store interface with two
+implementations:
+
+- **CSMT** - Compact Sparse Merkle Tree (binary trie, path compression, CBOR
+  inclusion proofs)
+- **MPF** - Merkle Patricia Forest (16-ary trie, hex nibble keys, Aiken
+  compatible)
+
+Both implementations share a common `MerkleTreeStore` record with 12
+QuickCheck properties proving feature parity.
 
 > **Warning**: This project is in early development and is not production-ready.
 
 ## Features
 
-- **Efficient operations**: Insert, delete, and query with logarithmic complexity
-- **Merkle proofs**: Generate and verify inclusion proofs
-- **Persistent storage**: RocksDB backend for production use
-- **Path compression**: Compact representation reduces storage and improves performance
-- **Preimage storage**: Automatic storage of key-value preimages alongside the tree
+- **Shared interface**: `MerkleTreeStore` record parameterised by
+  implementation tag and monad, with type families for key/value/hash/proof
+  types
+- **Two trie backends**: Binary (CSMT) and 16-ary (MPF), swappable via the
+  shared interface
+- **Merkle proofs**: Inclusion proofs for both implementations; CSMT also
+  supports completeness proofs
+- **Persistent storage**: RocksDB backend for both implementations
+- **Batch and streaming inserts**: MPF supports batch, chunked, and streaming
+  insertion modes
+- **Aiken compatibility**: MPF produces root hashes matching the Aiken
+  reference implementation
+- **CLI tool**: Interactive command-line interface for CSMT operations
+- **TypeScript verifier**: Client-side CSMT proof verification in
+  browser/Node.js
 
 ## Quick Start
 
+### Using the MTS Interface (recommended)
+
 ```haskell
-import CSMT
-import CSMT.Backend.RocksDB
+import MTS.Interface (MerkleTreeStore(..))
+
+-- Works with any implementation
+example :: MerkleTreeStore imp IO -> IO ()
+example store = do
+    mtsInsert store "key" "value"
+    proof <- mtsMkProof store "key"
+    root  <- mtsRootHash store
+    print (proof, root)
+```
+
+### Constructing a CSMT Store
+
+```haskell
+import CSMT.MTS (csmtMerkleTreeStore)
+import CSMT.Hashes (fromKVHashes, hashHashing)
+import CSMT.Backend.RocksDB (withStandaloneRocksDB)
 
 main :: IO ()
-main = withRocksDB "mydb" 256 256 $ \runDB -> do
-    -- Insert key-value pairs
-    runDB $ runTransaction $ do
-        insert fromKVHashes kvCol csmtCol "key1" "value1"
-        insert fromKVHashes kvCol csmtCol "key2" "value2"
+main = withStandaloneRocksDB "mydb" codecs $ \run db ->
+    let store = csmtMerkleTreeStore run db fromKVHashes hashHashing
+    in mtsInsert store "key" "value"
+```
 
-    -- Get root hash
-    mroot <- runDB $ runTransaction $ root csmtCol
-    print mroot
+### Constructing an MPF Store
 
-    -- Generate inclusion proof (returns value and proof)
-    result <- runDB $ runTransaction $
-        generateInclusionProof fromKVHashes kvCol csmtCol "key1"
-    case result of
-        Just (value, proof) -> print proof
-        Nothing -> putStrLn "Key not found"
+```haskell
+import MPF.MTS (mpfMerkleTreeStore)
+import MPF.Hashes (fromHexKVHashes, mpfHashing)
+import MPF.Backend.RocksDB (withMPFStandaloneRocksDB)
+
+main :: IO ()
+main = withMPFStandaloneRocksDB "mydb" codecs $ \run db ->
+    let store = mpfMerkleTreeStore run db fromHexKVHashes mpfHashing
+    in mtsInsert store "key" "value"
 ```
 
 ## Installation
@@ -46,7 +82,7 @@ main = withRocksDB "mydb" 256 256 $ \runDB -> do
 
 ```bash
 nix shell nixpkgs#cachix -c cachix use paolino
-nix shell github:paolino/haskell-csmt --refresh
+nix shell github:paolino/haskell-mts --refresh
 ```
 
 ### Using Cabal
@@ -59,11 +95,11 @@ cabal install
 
 ## CLI Tool
 
-The package includes a CLI for interactive tree operations:
+The `mts` executable provides an interactive CLI for CSMT operations:
 
 ```bash
 export CSMT_DB_PATH=./mydb
-csmt
+mts
 > i key1 value1
 > q key1
 AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
@@ -73,11 +109,7 @@ NrJMih3czFriydMUwvFKFK6VYKZYVjKpKGe1WC4e+VU=
 
 ## Documentation
 
-Full documentation is available at [paolino.github.io/haskell-csmt](https://paolino.github.io/haskell-csmt/)
-
-## Performance
-
-Preliminary benchmarks show ~900 insertions/second on a standard development machine over a 3.5M Cardano UTxO dataset.
+Full documentation at [paolino.github.io/haskell-mts](https://paolino.github.io/haskell-mts/)
 
 ## License
 

--- a/docs/architecture/example.md
+++ b/docs/architecture/example.md
@@ -1,5 +1,9 @@
 # Worked Example
 
+!!! note
+    This example uses the **CSMT** (binary trie) implementation. For MPF
+    concepts, see [MPF (16-ary Trie)](../mpf.md).
+
 This example demonstrates how the CSMT stores data and computes hashes,
 applying the concepts from [Storage](./storage.md).
 

--- a/docs/architecture/inclusion-proof.md
+++ b/docs/architecture/inclusion-proof.md
@@ -1,5 +1,9 @@
 # Inclusion Proof Format
 
+!!! note
+    This page describes the **CSMT** inclusion proof format. For MPF inclusion
+    proofs, see [MPF (16-ary Trie)](../mpf.md#inclusion-proofs).
+
 Inclusion proofs allow verifying that a key-value pair exists in a CSMT without
 access to the full tree. Proofs are serialized using CBOR for compact,
 portable representation.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,8 +1,26 @@
 # Storage Layer
 
-The CSMT uses a dual-column storage model with RocksDB as the backend.
+Both MTS implementations use a dual-column storage model with RocksDB as
+the persistent backend and in-memory backends for testing.
 
-## Column Families
+## Shared Model
+
+Both CSMT and MPF store data in two columns:
+
+| Column | Key | Value | Purpose |
+|--------|-----|-------|---------|
+| KV | User key (`k`) | User value (`v`) | Original key-value pairs |
+| Trie | Derived tree key | Node reference | Merkle tree structure |
+
+The KV column stores original key-value pairs, enabling value retrieval
+and proof generation. The trie column stores the Merkle tree structure
+with implementation-specific node types.
+
+---
+
+## CSMT Storage
+
+### Column Families
 
 ```mermaid
 graph LR
@@ -17,17 +35,17 @@ graph LR
     end
 ```
 
-| Column | Key Type | Value Type | Purpose |
-|--------|----------|------------|---------|
-| KV | User key (`k`) | User value (`v`) | Store original key-value pairs |
-| CSMT | `treePrefix(v) <> fromK(k)` | `Indirect a` | Store Merkle tree nodes |
+| Column | Key Type | Value Type |
+|--------|----------|------------|
+| KV | User key (`k`) | User value (`v`) |
+| CSMT | `treePrefix(v) <> fromK(k)` | `Indirect a` |
 
 The CSMT column key is computed by prepending `treePrefix(value)` to
 `fromK(key)`. When `treePrefix = const []` (the default), this is just
 `fromK(key)`. A non-trivial `treePrefix` groups entries with the same
 prefix into a common subtree, enabling prefix-based completeness proofs.
 
-## CSMT Node Storage
+### CSMT Node Storage
 
 Each node in the CSMT is stored as a key-value pair:
 
@@ -43,7 +61,7 @@ data Indirect a = Indirect
     }
 ```
 
-### Example
+#### Example
 
 For a tree containing keys `[L,L,R,R]` and `[L,R,R,L]`:
 
@@ -56,7 +74,7 @@ CSMT Column:
 
 The root node at `[]` has `jump = [L]` because both keys share the `L` prefix.
 
-## Path Compression
+### Path Compression
 
 The `jump` field enables path compression. Instead of storing every node along
 a path, we store only the nodes where the tree branches, with `jump` indicating
@@ -76,25 +94,9 @@ graph TD
     end
 ```
 
-## Preimage Storage (KV Column)
+### CSMT Hash Composition
 
-The KV column stores the original key-value pairs, enabling:
-
-- Retrieval of original values given a key
-- Proof generation (needs both key and value — the value is required to
-  compute `treePrefix(value)` for the tree key)
-- Value lookup after proof verification
-
-```
-KV Column:
-  "mykey"   -> "myvalue"
-  "another" -> "data"
-```
-
-## Hash Composition
-
-The Merkle tree hash is computed using Blake2b-256. The `Hashing` record defines
-how hashes are combined:
+The Merkle tree hash is computed using Blake2b-256:
 
 ```haskell
 data Hashing a = Hashing
@@ -103,50 +105,16 @@ data Hashing a = Hashing
     }
 ```
 
-### Root/Leaf Hash
+- **Root/Leaf hash**: `blake2b(serialize(jump) ++ serialize(value))` - the jump path is included in the hash
+- **Combine**: `blake2b(serialize(left) ++ serialize(right))` - both children's jump paths and hashes contribute
+- **Direction ordering**: `L` means current node is left, `R` means current node is right
 
-For a single node (leaf or root), the hash is computed by serializing the
-entire `Indirect` structure:
+### CSMT Serialization
 
-```
-rootHash(Indirect{jump, value}) = blake2b(serialize(jump) ++ serialize(value))
-```
+#### Key/Jump Encoding
 
-This means the jump path is **included in the hash**, ensuring path compression
-doesn't change the Merkle root.
-
-### Combining Child Hashes
-
-For internal nodes, the parent hash combines both children's `Indirect` values:
-
-```
-combineHash(left, right) = blake2b(serialize(left) ++ serialize(right))
-```
-
-Both the jump paths and hash values of children contribute to the parent hash.
-
-### Direction-Based Ordering
-
-The `addWithDirection` function determines child ordering based on the
-direction taken to reach the current node:
-
-```haskell
-addWithDirection hashing L left right = combineHash left right
-addWithDirection hashing R left right = combineHash right left
-```
-
-- Direction `L`: current node is on the left, sibling on right
-- Direction `R`: current node is on the right, sibling on left
-
-## Serialization
-
-Keys and Indirect values are serialized to ByteStrings for storage.
-
-### Key/Jump Encoding
-
-Keys (and jumps, which are key infixes) are bitstrings of arbitrary length.
-We use a Word16 big-endian to encode the length in bits, followed by the bits
-packed into bytes (left-aligned).
+Keys are bitstrings encoded as Word16 big-endian length followed by bits
+packed into bytes (left-aligned):
 
 | Key/Jump    | Encoding            |
 |-------------|---------------------|
@@ -157,43 +125,21 @@ packed into bytes (left-aligned).
 | LR          | 0x00 0x02 0x40      |
 | RL          | 0x00 0x02 0x80      |
 | RR          | 0x00 0x02 0xc0      |
-| LLLLLLLL    | 0x00 0x08 0x00      |
-| RRRRRRRR    | 0x00 0x08 0xff      |
-| LLLLLLLLL   | 0x00 0x09 0x00 0x00 |
-| RRRRRRRRR   | 0x00 0x09 0xff 0x80 |
 
-The bit length also determines byte length:
+#### ByteString/Hash Encoding
 
-```haskell
-bytesLength len =
-    let (l, r) = len `divMod` 8
-    in if r == 0 then l else l + 1
-```
+Word16 big-endian length followed by the bytes.
 
-### ByteString/Hash Encoding
+#### Node (Indirect) Encoding
 
-ByteStrings are stored as Word16 big-endian length followed by the bytes.
-Hashes are treated as variable-length bytestrings.
-
-| ByteString | Encoding                           |
-|------------|-----------------------------------|
-| (empty)    | 0x00 0x00                          |
-| "a"        | 0x00 0x01 0x61                     |
-| "abc"      | 0x00 0x03 0x61 0x62 0x63           |
-| "hello"    | 0x00 0x05 0x68 0x65 0x6c 0x6c 0x6f |
-
-### Node (Indirect) Encoding
-
-Nodes are encoded as jump encoding followed by hash encoding:
+Jump encoding followed by hash encoding:
 
 | Node                              | Encoding                                     |
 |-----------------------------------|----------------------------------------------|
 | `{jump: "", value: "abc"}`        | 0x00 0x00 0x00 0x03 0x61 0x62 0x63           |
 | `{jump: "LRL", value: "data"}`    | 0x00 0x03 0x40 0x00 0x04 0x64 0x61 0x74 0x61 |
 
-## Backend Interface
-
-The storage layer is abstracted through the `Standalone` GADT:
+### CSMT Backend Interface
 
 ```haskell
 data Standalone k v a x where
@@ -201,5 +147,105 @@ data Standalone k v a x where
     StandaloneCSMTCol :: Standalone k v a (KV Key (Indirect a))
 ```
 
-This allows the same CSMT operations to work with different storage backends
-(RocksDB, in-memory, etc.) by providing appropriate codecs.
+---
+
+## MPF Storage
+
+### Column Families
+
+```mermaid
+graph LR
+    subgraph "KV Column"
+        MK1[user key] --> MV1[user value]
+        MK2[user key] --> MV2[user value]
+    end
+
+    subgraph "MPF Column"
+        MP1[hex key prefix] --> MI1[HexIndirect]
+        MP2[hex key prefix] --> MI2[HexIndirect]
+    end
+```
+
+| Column | Key Type | Value Type |
+|--------|----------|------------|
+| KV | User key (`k`) | User value (`v`) |
+| MPF | `hexTreePrefix(v) <> fromHexK(k)` | `HexIndirect a` |
+
+### MPF Node Storage
+
+Each node is stored as:
+
+- **Key**: Hex key prefix (list of nibbles from root)
+- **Value**: A `HexIndirect` containing:
+    - `hexJump`: Nibbles to skip (path compression)
+    - `hexValue`: Hash value
+    - `hexIsLeaf`: Node type flag
+
+```haskell
+data HexIndirect a = HexIndirect
+    { hexJump   :: HexKey    -- Path compression (nibbles)
+    , hexValue  :: a          -- Hash value
+    , hexIsLeaf :: Bool       -- True = leaf, False = branch
+    }
+```
+
+The `hexIsLeaf` flag is critical: it determines which hashing scheme is
+applied when computing the node's contribution to the Merkle root.
+
+### 16-Slot Sparse Array
+
+Branch nodes conceptually hold 16 children (one per hex digit 0-15).
+Only non-empty children are stored in the database. The `merkleRoot`
+function reconstructs the full 16-element array with null hashes for
+missing children, then performs pairwise reduction:
+
+```
+16 children -> 8 pairs -> 4 pairs -> 2 pairs -> 1 root
+```
+
+### MPF Serialization
+
+#### HexKey Encoding
+
+Hex keys are encoded as Word16 big-endian nibble count followed by
+packed bytes (2 nibbles per byte, high nibble first). Odd-length keys
+store the last nibble in the high position with low nibble = 0:
+
+```haskell
+putHexKey :: HexKey -> PutM ()
+putHexKey k = do
+    putWord16be (fromIntegral $ length k)
+    putByteString (hexKeyToByteString k)
+```
+
+#### HexIndirect Encoding
+
+HexKey encoding followed by sized ByteString value followed by a
+leaf/branch flag byte (1 = leaf, 0 = branch):
+
+```haskell
+putHexIndirect :: HexIndirect a -> PutM ()
+putHexIndirect HexIndirect{hexJump, hexValue, hexIsLeaf} = do
+    putHexKey hexJump
+    putSizedByteString hexValue
+    putWord8 (if hexIsLeaf then 1 else 0)
+```
+
+### MPF Backend Interface
+
+```haskell
+data MPFStandalone k v a x where
+    MPFStandaloneKVCol  :: MPFStandalone k v a (KV k v)
+    MPFStandaloneMPFCol :: MPFStandalone k v a (KV HexKey (HexIndirect a))
+```
+
+---
+
+## Preimage Storage (KV Column)
+
+Both implementations use the KV column for the same purposes:
+
+- Retrieval of original values given a key
+- Proof generation (CSMT needs the value to compute `treePrefix(value)`;
+  MPF needs it for `hexTreePrefix(value)`)
+- Value lookup after proof verification

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -1,33 +1,44 @@
 # System Overview
 
-The CSMT system provides multiple interfaces for interacting with the tree.
+The MTS system provides a shared interface with two trie implementations
+and multiple ways to interact with them.
 
-## Current Architecture
-
-```mermaid
-graph TD
-    L[CSMT CLI] -->|CSMT Operations| C[CSMT Library]
-    H[Haskell Application] -->|CSMT Operations| C
-    C -->|Read/Write Nodes & Preimages| D[RocksDB Storage]
-```
-
-A CSMT instance consists of:
-
-- **RocksDB Storage**: Persistent backend for tree nodes and preimages
-- **CSMT Library**: Core Haskell implementation of the data structure
-- **CLI Tool**: Interactive command-line interface for tree operations
-
-## Planned Architecture
+## Architecture
 
 ```mermaid
 graph TD
-    A[Client] -->|HTTP Requests| B[CSMT HTTP Service]
-    B -->|CSMT Operations| C[CSMT Library]
-    L[CSMT CLI] -->|CSMT Operations| C
-    H[Haskell Application] -->|CSMT Operations| C
-    C -->|Read/Write Nodes & Preimages| D[RocksDB Storage]
+    CLI[MTS CLI] -->|CSMT ops| CSMT[CSMT Library]
+    App[Haskell Application] -->|MTS Interface| MTS[MerkleTreeStore]
+    MTS --> CSMT
+    MTS --> MPF[MPF Library]
+    CSMT -->|Read/Write| RDB1[RocksDB / In-Memory]
+    MPF -->|Read/Write| RDB2[RocksDB / In-Memory]
+    TS[TypeScript Verifier] -.->|Verify CSMT proofs| Client[Browser / Node.js]
 ```
 
-A future HTTP service will expose the CSMT functionalities via a RESTful API.
+### Layers
 
+| Layer | Description |
+|-------|-------------|
+| **MTS Interface** | Shared `MerkleTreeStore` record with type families. Application code targets this layer. |
+| **CSMT Implementation** | Binary trie with path compression, CBOR proofs, completeness proofs, CLI. |
+| **MPF Implementation** | 16-ary trie with hex nibble keys, batch/streaming inserts, Aiken-compatible hashes. |
+| **Storage Backends** | RocksDB (persistent) and in-memory (testing) for both implementations. |
 
+### Components
+
+- **MTS Interface** (`MTS.Interface`, `MTS.Properties`): Shared record and
+  QuickCheck properties. No storage dependency.
+- **CSMT Library** (`mts:csmt`): Binary trie implementation with CLI,
+  TypeScript verifier, and completeness proofs.
+- **MPF Library** (`mts:mpf`): 16-ary trie implementation with batch inserts
+  and Aiken compatibility.
+- **CLI Tool** (`mts` executable): Interactive command-line interface for CSMT
+  operations. Uses `CSMT_DB_PATH` for the RocksDB database path.
+- **TypeScript Verifier** (`@paolino/csmt-verify`): Client-side CSMT proof
+  verification for browser/Node.js.
+
+## Planned
+
+- HTTP service exposing MTS operations via a RESTful API
+- MPF completeness proofs

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,13 +1,13 @@
 # Concepts
 
-This page explains the key concepts behind Compact Sparse Merkle Trees.
+This page explains the key concepts behind MTS and its two trie implementations.
 
 ## Merkle Trees
 
-A Merkle tree is a binary tree where:
+A Merkle tree is a tree where:
 
 - Each leaf node contains the hash of a data block
-- Each internal node contains the hash of its two children
+- Each internal node contains the hash of its children
 
 ```mermaid
 graph TD
@@ -27,6 +27,24 @@ This structure enables **Merkle proofs** - compact proofs that a specific piece 
 
 With these three hashes, anyone can recompute the root and verify the proof.
 
+## MTS: The Shared Interface
+
+MTS defines a common `MerkleTreeStore` record that abstracts over the trie
+implementation. Type families determine the concrete key, value, hash, proof,
+leaf, and completeness proof types for each backend:
+
+| Operation | Type |
+|-----------|------|
+| `mtsInsert` | `MtsKey imp -> MtsValue imp -> m ()` |
+| `mtsDelete` | `MtsKey imp -> m ()` |
+| `mtsRootHash` | `m (Maybe (MtsHash imp))` |
+| `mtsMkProof` | `MtsKey imp -> m (Maybe (MtsProof imp))` |
+| `mtsVerifyProof` | `MtsValue imp -> MtsProof imp -> m Bool` |
+| `mtsBatchInsert` | `[(MtsKey imp, MtsValue imp)] -> m ()` |
+
+Application code written against `MerkleTreeStore imp m` works with either
+CSMT or MPF. See [MTS Interface](interface.md) for the full API.
+
 ## Sparse Merkle Trees
 
 A Sparse Merkle Tree (SMT) is a Merkle tree where:
@@ -37,9 +55,9 @@ A Sparse Merkle Tree (SMT) is a Merkle tree where:
 
 For a 256-bit key, a naive SMT would have 2^256 possible leaves - far too large to store explicitly.
 
-## Compact Sparse Merkle Trees
+## CSMT: Compact Sparse Merkle Tree
 
-A **Compact** SMT optimizes storage by:
+The CSMT is a **binary trie** that optimizes storage through path compression:
 
 1. **Path compression**: Empty subtrees are not stored
 2. **Jump paths**: Instead of storing each node on the path, we store a "jump" directly to where the data diverges
@@ -50,52 +68,86 @@ Consider inserting keys `LLRR` and `LRRL`:
 
 **Without compression** (naive SMT):
 ```
-Root → L → L → R → R → value1
-     ↘ R → R → L → value2
+Root -> L -> L -> R -> R -> value1
+     -> R -> R -> L -> value2
 ```
 
 **With compression** (CSMT):
 ```
-Root → L (jump to divergence point)
-       ├── L,RR → value1  (jump = RR)
-       └── R,RL → value2  (jump = RL)
+Root -> L (jump to divergence point)
+       +-- L,RR -> value1  (jump = RR)
+       +-- R,RL -> value2  (jump = RL)
 ```
 
 The CSMT stores only the nodes where paths actually diverge, plus "jump" metadata indicating how many levels to skip.
 
-## Key Components
+### CSMT Key Components
 
-### Keys
+**Keys**: Sequences of directions (`L` = left = 0, `R` = right = 1). A 256-bit hash becomes a 256-element path.
 
-Keys are represented as sequences of directions (`L` = left = 0, `R` = right = 1). A 256-bit hash becomes a 256-element path through the tree.
+**Indirect references**: Each node stores an `Indirect` value containing a `jump` (path prefix to skip) and a `value` (hash).
 
-### Indirect References
+**Hashing**: Blake2b-256. Internal node hashes are computed by hashing the serialized left and right children.
 
-Each node stores an `Indirect` value containing:
+For CSMT-specific details, see [CSMT (Binary Trie)](csmt.md).
 
-- **jump**: The path prefix to skip (path compression)
-- **value**: Either a hash (for internal nodes) or the actual value hash (for leaves)
+## MPF: Merkle Patricia Forest
 
-### Hashing
+The MPF is a **16-ary trie** where each node branches on a hex nibble (4 bits)
+rather than a single bit. This gives a much shallower tree for the same key
+length: a 32-byte key produces a trie of depth 64 (nibbles) rather than 256
+(bits).
 
-The library uses Blake2b-256 for hashing. Internal node hashes are computed by hashing the concatenation of the encoded left and right children.
+### Hex Nibble Keys
+
+Keys are represented as sequences of `HexDigit` values (0-15). A
+`ByteString` key is converted to a `HexKey` by splitting each byte into its
+high and low nibbles:
+
+```
+byte 0xa3 -> [HexDigit 0xa, HexDigit 0x3]
+```
+
+### 16-ary Branching
+
+Each branch node holds a sparse 16-element array of children (one per
+nibble). Path compression works similarly to CSMT: a `hexJump` field on
+each `HexIndirect` node records the key suffix to skip.
+
+Nodes are tagged as **leaf** (`hexIsLeaf = True`) or **branch**
+(`hexIsLeaf = False`), which determines the hashing scheme.
+
+### MPF Hashing
+
+MPF uses a different hash construction from CSMT to achieve Aiken
+compatibility:
+
+- **Leaf hash**: `blake2b(hashHead || hashTail || valueDigest)` where
+  `hashHead`/`hashTail` encode the suffix nibbles with even/odd length
+  handling
+- **Branch hash**: `blake2b(nibbleBytes(prefix) || merkleRoot(children))`
+  where `merkleRoot` reduces the 16-slot sparse array via pairwise hashing
+- **Merkle root**: Pairwise reduction of 16 child hashes (missing children
+  use a null hash of 32 zero bytes)
+
+For MPF-specific details, see [MPF (16-ary Trie)](mpf.md).
 
 ## Proofs
 
 ### Inclusion Proofs
 
-An inclusion proof demonstrates that a key-value pair exists in the tree. It contains:
+An inclusion proof demonstrates that a key-value pair exists in the tree.
+Both CSMT and MPF support inclusion proofs through the shared
+`mtsMkProof`/`mtsVerifyProof` interface, though the internal proof
+format differs.
 
-- The key and value being proven
-- The expected root hash
-- Sibling hashes along the path from leaf to root
-- Jump paths at each level
+**CSMT proofs** are CBOR-encoded and contain the key, value hash, root hash,
+sibling hashes along the path, and jump paths at each level. See
+[Inclusion Proof Format](architecture/inclusion-proof.md) for the wire
+format specification.
 
-To verify, recompute the root hash from the value and siblings, then compare
-with the expected root.
-
-See [Inclusion Proof Format](architecture/inclusion-proof.md) for the complete
-CBOR wire format specification.
+**MPF proofs** contain the key, value, a sequence of proof steps (each with
+a node type tag, sibling hash, and SMT proof hashes), and the root hash.
 
 ### Completeness Proofs
 
@@ -108,25 +160,22 @@ a given set of entries is **all** entries under that prefix. It consists of:
 2. A sequence of merge operations to reconstruct the subtree
 3. Sibling hashes at the boundary to connect back to the root
 
+Completeness proofs are currently implemented for CSMT only. MPF
+completeness proofs are planned.
+
 ## Storage Model
 
-The CSMT uses two storage columns:
+Both implementations use a dual-column storage model:
 
-| Column | Key | Value |
-|--------|-----|-------|
-| KV | Original key | Original value |
-| CSMT | `treePrefix(value) <> fromK(key)` | Indirect (jump + hash) |
+| Column | Key | Value | Purpose |
+|--------|-----|-------|---------|
+| KV | User key | User value | Original key-value pairs |
+| Trie | Derived tree key | Node (jump + hash) | Merkle tree structure |
 
-The tree key in CSMTCol is computed as `treePrefix(value) <> fromK(key)`,
-where `treePrefix` is a configurable function that derives a prefix from
-the value. When `treePrefix = const []` (the default), the tree key is
-simply `fromK(key)`, preserving the original behavior.
+The tree key is derived from the user key (and optionally a prefix from
+the value) using the `FromKV`/`FromHexKV` conversion records. This dual
+storage allows efficient tree operations, original value retrieval, and
+proof generation.
 
-This dual storage allows:
-
-- Efficient tree operations via the CSMT column
-- Retrieval of original values via the KV column
-- Proof generation using both columns
-- **Prefix-based queries**: all entries sharing a `treePrefix` are grouped
-  in the same subtree, enabling completeness proofs over subsets (e.g. all
-  UTxOs at a given address)
+See [Storage Layer](architecture/storage.md) for implementation-specific
+details.

--- a/docs/csmt.md
+++ b/docs/csmt.md
@@ -1,0 +1,104 @@
+# CSMT (Binary Trie)
+
+The Compact Sparse Merkle Tree is MTS's binary trie implementation. It uses
+single-bit branching (L/R directions) with path compression via jump fields.
+
+!!! info
+    This page covers CSMT-specific details. For the shared interface, see
+    [MTS Interface](interface.md). For general Merkle tree concepts, see
+    [Concepts](concepts.md).
+
+## Overview
+
+CSMT is the original implementation in this package. It provides:
+
+- Binary trie with path compression (`Indirect` nodes with `jump` fields)
+- CBOR-encoded inclusion proofs (see
+  [Inclusion Proof Format](architecture/inclusion-proof.md))
+- Completeness proofs over prefix-grouped subtrees
+- Secondary indexing via configurable `treePrefix`
+- CLI tool for interactive operations (see [CLI Manual](manual.md))
+- TypeScript proof verifier for browser/Node.js (see
+  [TypeScript Verifier](typescript.md))
+
+## Key Types
+
+### `FromKV` - Key/Value Conversion
+
+```haskell
+data FromKV k v a = FromKV
+    { fromK      :: k -> Key        -- User key to binary path
+    , fromV      :: v -> a           -- User value to hash
+    , treePrefix :: v -> Key         -- Optional prefix for secondary indexing
+    }
+```
+
+The default `fromKVHashes` hashes both key and value with Blake2b-256 and
+uses no prefix (`treePrefix = const []`).
+
+### `Indirect` - Tree Nodes
+
+```haskell
+data Indirect a = Indirect
+    { jump  :: Key    -- Path compression: bits to skip
+    , value :: a      -- Hash value
+    }
+```
+
+### `Hashing` - Hash Operations
+
+```haskell
+data Hashing a = Hashing
+    { rootHash    :: Indirect a -> a
+    , combineHash :: Indirect a -> Indirect a -> a
+    }
+```
+
+## Storage
+
+CSMT uses two columns:
+
+| Column | Key | Value |
+|--------|-----|-------|
+| KV | User key (`k`) | User value (`v`) |
+| CSMT | `treePrefix(v) <> fromK(k)` | `Indirect a` (jump + hash) |
+
+See [Storage Layer](architecture/storage.md) for serialization details.
+
+## Inclusion Proofs
+
+CSMT inclusion proofs are CBOR-encoded and self-contained. They include
+the key, value hash, root hash, proof steps (sibling hashes), and root
+jump path. Verification is pure computation.
+
+See [Inclusion Proof Format](architecture/inclusion-proof.md) for the
+CDDL specification and verification algorithm.
+
+## Completeness Proofs
+
+CSMT supports completeness proofs via the `CSMT.Proof.Completeness`
+module. When `treePrefix` groups entries by a common prefix, a
+completeness proof demonstrates that a given set of leaves is the
+**entire** contents of that subtree:
+
+1. Collect all leaves under the prefix (`collectValues`)
+2. Generate a proof (`generateProof`)
+3. Verify by folding the proof and comparing the reconstructed root
+
+## CLI Tool
+
+The `mts` executable provides an interactive CLI for CSMT operations.
+It reads from `CSMT_DB_PATH` and supports insert, delete, query, root
+hash, and proof generation/verification.
+
+See [CLI Manual](manual.md) for full usage.
+
+## Benchmarks
+
+Preliminary benchmarks show ~900 insertions/second on a standard
+development machine over a 3.5M Cardano UTxO dataset.
+
+## Worked Example
+
+See [Worked Example](architecture/example.md) for a step-by-step
+walkthrough of CSMT storage and hash computation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,65 +1,96 @@
 !!! warning
     This project is in early development and is not production-ready. Use at your own risk.
 
-# CSMT - Compact Sparse Merkle Tree
+# MTS - Merkle Tree Store
 
-## What is CSMT?
+## What is MTS?
 
-A Compact Sparse Merkle Tree is a space-efficient variant of a Merkle tree optimized for sparse key spaces. It enables cryptographic proofs of inclusion (or exclusion) while minimizing storage requirements through path compression.
+MTS (Merkle Tree Store) is a Haskell library providing a shared interface for
+authenticated key-value stores backed by Merkle tries. It ships with two
+implementations:
+
+- **CSMT** - Compact Sparse Merkle Tree: a binary trie with path compression,
+  CBOR-encoded inclusion proofs, and completeness proofs via secondary
+  indexing.
+- **MPF** - Merkle Patricia Forest: a 16-ary trie using hex nibble keys,
+  with batch/streaming inserts and root hashes compatible with the Aiken
+  reference implementation.
+
+Both implementations conform to a single `MerkleTreeStore` record type
+parameterised by an implementation tag and a monad, so application code
+can be written once and run against either backend.
 
 ## Features
 
-This package provides:
-
-- **Haskell Library**: A CSMT implementation with persistent storage backends, offering efficient insertion, deletion, and proof generation for applications requiring verifiable data structures.
-- **Secondary Indexing**: Configurable `treePrefix` allows grouping entries by a value-derived prefix (e.g. address), enabling completeness proofs over subsets of the tree.
-- **CLI Tool**: Interactive command-line interface for tree operations including adding/removing elements, generating proofs, and verifying membership.
-- **Preimage Storage**: Automatic storage of key-value preimages in sync with the CSMT, enabling value retrieval alongside proof verification.
-
-## Performance
-
-Preliminary benchmarks indicate that the CSMT library sustains a throughput of 900 insertions per second on a standard development machine over a 3.5M cardano UTxOs dataset.
-
-There is room for optimization via parallel insertions, but these results are promising for an initial implementation.
+- **Shared interface**: `MerkleTreeStore` record with type families for key,
+  value, hash, proof, leaf, and completeness proof types
+  ([MTS Interface](interface.md))
+- **12 QuickCheck properties**: Verify feature parity across implementations
+  (insert-verify, order independence, batch equivalence, completeness
+  round-trip, etc.)
+- **Two trie backends**: Binary (CSMT) and 16-ary (MPF), each with RocksDB
+  and in-memory storage
+- **Merkle proofs**: Inclusion proofs for both implementations; CSMT also
+  supports completeness proofs over prefix-grouped subtrees
+- **Batch and streaming inserts**: MPF supports `insertingBatch`,
+  `insertingChunked`, and `insertingStream` for large datasets
+- **Aiken compatibility**: MPF produces root hashes matching the Aiken
+  `MerkleTree` implementation (verified against the 30-fruit test vector)
+- **CLI tool**: Interactive command-line interface for CSMT tree operations
+- **TypeScript verifier**: Client-side CSMT proof verification for
+  browser/Node.js
 
 ## Quick Start
+
+=== "MTS Interface"
+    ```haskell
+    import MTS.Interface (MerkleTreeStore(..))
+
+    example :: MerkleTreeStore imp IO -> IO ()
+    example store = do
+        mtsInsert store "key" "value"
+        proof <- mtsMkProof store "key"
+        root  <- mtsRootHash store
+        print (proof, root)
+    ```
 
 === "CLI"
     ```bash
     export CSMT_DB_PATH=./mydb
-    csmt
+    mts
     > i key1 value1
     > q key1
     AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
     ```
 
-=== "Library"
-    ```haskell
-    import CSMT
-    import CSMT.Backend.RocksDB
-
-    main = withRocksDB "mydb" 256 256 $ \runDB -> do
-        runDB $ runTransaction $
-            insert fromKVHashes kvCol csmtCol "key" "value"
-    ```
-
 ## Status
 
-### Library
-- [x] Insertion and deletion
-- [x] Proof generation and verification
-- [x] Persistent storage (RocksDB)
-- [x] Comprehensive tests
-- [x] Insertion benchmarks
-- [ ] Deletion/proof benchmarks
-- [ ] Production-grade testing
-- [ ] Raw key support (vs hashed keys)
+### Shared Interface (`mts`)
+- [x] `MerkleTreeStore` record with type families
+- [x] 12 shared QuickCheck properties
+- [x] CSMT passes all 12 properties
+- [x] MPF passes 9 of 12 (completeness proofs pending)
 
-### CLI Tool
-- [x] Add/remove elements
-- [x] Query elements
-- [x] Generate and verify proofs
+### CSMT Implementation (`mts:csmt`)
+- [x] Insertion and deletion
+- [x] Inclusion proof generation and verification (CBOR)
+- [x] Completeness proofs (prefix-based subtrees)
+- [x] Persistent storage (RocksDB)
+- [x] Secondary indexing via `treePrefix`
+- [x] CLI tool
+- [x] TypeScript proof verifier
+- [x] Insertion benchmarks
+
+### MPF Implementation (`mts:mpf`)
+- [x] Insertion and deletion
+- [x] Inclusion proof generation and verification
+- [x] Batch, chunked, and streaming inserts
+- [x] Aiken-compatible root hashes
+- [x] Persistent storage (RocksDB)
+- [ ] Completeness proofs
+- [ ] Benchmarks
 
 ### Planned
 - [ ] HTTP service with RESTful API
-- [ ] Parallel batch insertions
+- [ ] MPF completeness proofs
+- [ ] Production-grade testing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,30 +5,30 @@ There is currently no releasing in place, but you can install via the provided a
 ## Docker images
 
 ```bash
-gh run download -n csmt-image
-i=$(docker load < csmt-image | sed -e 's/Loaded image: //')
+gh run download -n mts-image
+i=$(docker load < mts-image | sed -e 's/Loaded image: //')
 docker run $i
 ```
 
-## Arx self-executable bundles
+## AppImage bundles
 
 ```bash
-gh run download -n csmt.arx
-./csmt.arx
+gh run download -n mts.AppImage
+./mts.AppImage
 ```
 
 ## RPM packages
 
 ```bash
-gh run download -n csmt-rpm
-sudo rpm -i csmt.rpm
+gh run download -n mts-rpm
+sudo rpm -i mts.rpm
 ```
 
 ## DEB packages
 
 ```bash
-gh run download -n csmt-deb
-sudo dpkg -i csmt.deb
+gh run download -n mts-deb
+sudo dpkg -i mts.deb
 ```
 
 ## Building from source
@@ -46,7 +46,7 @@ You can build with nix
 
 ```bash
 nix shell nixpkgs#cachix -c cachix use paolino
-nix shell github:paolino/csmt --refresh
+nix shell github:paolino/haskell-mts --refresh
 ```
 
 Or via cabal provided you have a working Haskell environment and rocksdb development files installed.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -1,0 +1,148 @@
+# MTS Interface
+
+The shared `MerkleTreeStore` interface lets application code work with any
+trie implementation without depending on CSMT or MPF internals.
+
+## Type Families
+
+Each implementation defines a phantom type tag (e.g. `CsmtImpl`, `MpfImpl`)
+and provides type family instances:
+
+```haskell
+type family MtsKey imp               -- Key type
+type family MtsValue imp             -- Value type
+type family MtsHash imp              -- Hash type
+type family MtsProof imp             -- Inclusion proof type
+type family MtsLeaf imp              -- Leaf type (for completeness proofs)
+type family MtsCompletenessProof imp -- Completeness proof type
+```
+
+### CSMT Type Instances
+
+| Family | Type |
+|--------|------|
+| `MtsKey CsmtImpl` | `ByteString` |
+| `MtsValue CsmtImpl` | `ByteString` |
+| `MtsHash CsmtImpl` | `Hash` (Blake2b-256) |
+| `MtsProof CsmtImpl` | `InclusionProof Hash` |
+| `MtsLeaf CsmtImpl` | `Indirect Hash` |
+| `MtsCompletenessProof CsmtImpl` | `CompletenessProof` |
+
+### MPF Type Instances
+
+| Family | Type |
+|--------|------|
+| `MtsKey MpfImpl` | `ByteString` |
+| `MtsValue MpfImpl` | `ByteString` |
+| `MtsHash MpfImpl` | `MPFHash` (Blake2b-256) |
+| `MtsProof MpfImpl` | `MPFProof MPFHash` |
+| `MtsLeaf MpfImpl` | `HexIndirect MPFHash` |
+| `MtsCompletenessProof MpfImpl` | `()` (not yet implemented) |
+
+## MerkleTreeStore Record
+
+The `MerkleTreeStore` record provides 10 operations:
+
+```haskell
+data MerkleTreeStore imp m = MerkleTreeStore
+    { mtsInsert       :: MtsKey imp -> MtsValue imp -> m ()
+    , mtsDelete       :: MtsKey imp -> m ()
+    , mtsRootHash     :: m (Maybe (MtsHash imp))
+    , mtsMkProof      :: MtsKey imp -> m (Maybe (MtsProof imp))
+    , mtsVerifyProof  :: MtsValue imp -> MtsProof imp -> m Bool
+    , mtsFoldProof    :: MtsHash imp -> MtsProof imp -> MtsHash imp
+    , mtsBatchInsert  :: [(MtsKey imp, MtsValue imp)] -> m ()
+    , mtsCollectLeaves :: m [MtsLeaf imp]
+    , mtsMkCompletenessProof
+        :: m (Maybe (MtsCompletenessProof imp))
+    , mtsVerifyCompletenessProof
+        :: [MtsLeaf imp] -> MtsCompletenessProof imp -> m Bool
+    }
+```
+
+## Constructors
+
+### `csmtMerkleTreeStore`
+
+Build a CSMT-backed store. Requires a natural transformation from the
+database monad to `IO`, a `Database` handle, a `FromKV` record, and a
+`Hashing` record:
+
+```haskell
+csmtMerkleTreeStore
+    :: (MonadFail m)
+    => (forall b. m b -> IO b)
+    -> Database m StandaloneCF (Standalone ByteString ByteString Hash) StandaloneOp
+    -> FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> MerkleTreeStore CsmtImpl IO
+```
+
+### `mpfMerkleTreeStore`
+
+Build an MPF-backed store. Same pattern, with MPF-specific types:
+
+```haskell
+mpfMerkleTreeStore
+    :: (MonadFail m)
+    => (forall b. m b -> IO b)
+    -> Database m MPFStandaloneCF (MPFStandalone ByteString ByteString MPFHash) MPFStandaloneOp
+    -> FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> MerkleTreeStore MpfImpl IO
+```
+
+## Usage Example
+
+From the test suite (`MTS.PropertySpec`), showing how to construct both
+stores:
+
+```haskell
+-- CSMT store using in-memory backend
+mkCsmtStore :: IO (MerkleTreeStore CsmtImpl IO)
+mkCsmtStore = do
+    ref <- newIORef emptyInMemoryDB
+    let run action = do
+            db <- readIORef ref
+            let (a, db') = runPure db action
+            writeIORef ref db'
+            pure a
+    pure $ csmtMerkleTreeStore run (pureDatabase csmtCodecs)
+                               fromKVHashes hashHashing
+
+-- MPF store using in-memory backend
+mkMpfStore :: IO (MerkleTreeStore MpfImpl IO)
+mkMpfStore = do
+    ref <- newIORef emptyMPFInMemoryDB
+    let run action = do
+            db <- readIORef ref
+            let (a, db') = runMPFPure db action
+            writeIORef ref db'
+            pure a
+    pure $ mpfMerkleTreeStore run (mpfPureDatabase mpfCodecs)
+                              fromHexKVBS mpfHashing
+```
+
+## Shared QuickCheck Properties
+
+The `MTS.Properties` module provides 12 properties that any
+`MerkleTreeStore` implementation should satisfy:
+
+| # | Property | Description |
+|---|----------|-------------|
+| 1 | `propInsertVerify` | Insert k v, then verify k v returns True |
+| 2 | `propMultipleInsertAllVerify` | Insert N pairs, all verify |
+| 3 | `propInsertionOrderIndependence` | Same keys in any order produce the same root hash |
+| 4 | `propDeleteRemovesKey` | Insert k v, delete k, verify fails |
+| 5 | `propDeletePreservesSiblings` | Delete one key, other keys still verify |
+| 6 | `propBatchEqualsSequential` | Batch insert produces same root as sequential |
+| 7 | `propInsertDeleteAllEmpty` | Insert N, delete all N, root is Nothing |
+| 8 | `propEmptyTreeNoRoot` | Empty tree has no root hash |
+| 9 | `propSingleInsertHasRoot` | Single insert produces a root hash |
+| 10 | `propWrongValueRejects` | Verify with wrong value returns False |
+| 11 | `propCompletenessRoundTrip` | Insert N, completeness proof verifies |
+| 12 | `propCompletenessEmpty` | Empty tree has no completeness proof |
+| 13 | `propCompletenessAfterDelete` | Completeness proof verifies after partial deletion |
+
+CSMT passes all 13 properties. MPF passes properties 1-10; completeness
+properties (11-13) are pending implementation.

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,212 +1,201 @@
 # Library API
 
-This page covers using the CSMT library in Haskell applications.
+This page covers using the MTS library in Haskell applications. There are
+three levels of API:
 
-## Overview
+1. **MTS Interface** (recommended) - Implementation-agnostic
+2. **CSMT Direct API** - CSMT-specific operations
+3. **MPF Direct API** - MPF-specific operations
 
-The library provides:
+## 1. MTS Interface API (Recommended)
 
-- `CSMT` - Main module re-exporting the public API
-- `CSMT.Hashes` - Blake2b-256 based operations
-- `CSMT.Backend.RocksDB` - Persistent storage backend
-- `CSMT.Backend.Pure` - In-memory backend for testing
+The `MerkleTreeStore` record provides a uniform API for both
+implementations. See [MTS Interface](interface.md) for the full type
+definition.
 
-## Basic Setup
-
-### With RocksDB (Production)
-
-```haskell
-import CSMT
-import CSMT.Hashes
-import CSMT.Backend.RocksDB
-import CSMT.Backend.Standalone
-
--- Open database and run operations
-main :: IO ()
-main = withRocksDB "path/to/db" 256 256 $ \(RunRocksDB runDB) -> do
-    db <- runDB $ standaloneRocksDBDatabase codecs
-    -- Use db for transactions
-```
-
-### With Pure Backend (Testing)
+### Basic Usage
 
 ```haskell
-import CSMT
-import CSMT.Backend.Pure
-import CSMT.Backend.Standalone
+import MTS.Interface (MerkleTreeStore(..))
 
--- Run in-memory operations
-example :: (result, InMemoryDB)
-example = runPure emptyInMemoryDB $ do
-    runPureTransaction codecs $ do
-        -- Your operations here
+example :: MerkleTreeStore imp IO -> IO ()
+example store = do
+    -- Insert
+    mtsInsert store "key1" "value1"
+    mtsInsert store "key2" "value2"
+
+    -- Root hash
+    mroot <- mtsRootHash store
+    print mroot
+
+    -- Inclusion proof
+    mp <- mtsMkProof store "key1"
+    case mp of
+        Nothing -> putStrLn "Key not found"
+        Just proof -> do
+            ok <- mtsVerifyProof store "value1" proof
+            print ok  -- True
+
+    -- Batch insert
+    mtsBatchInsert store [("key3", "value3"), ("key4", "value4")]
+
+    -- Delete
+    mtsDelete store "key1"
 ```
 
-## Core Operations
+### Constructing Stores
 
-### Inserting Values
+See [MTS Interface](interface.md#constructors) for `csmtMerkleTreeStore`
+and `mpfMerkleTreeStore` constructor signatures and examples.
+
+## 2. CSMT Direct API
+
+For CSMT-specific features (completeness proofs, CBOR proof format, CLI
+integration), use the `mts:csmt` sub-library directly.
+
+### Modules
+
+| Module | Purpose |
+|--------|---------|
+| `CSMT` | Re-exports the public API |
+| `CSMT.Hashes` | Blake2b-256 operations, `fromKVHashes`, `hashHashing` |
+| `CSMT.Interface` | `FromKV`, `Hashing`, `Indirect`, `root` |
+| `CSMT.Insertion` | `inserting` |
+| `CSMT.Deletion` | `deleting` |
+| `CSMT.Proof.Insertion` | `buildInclusionProof`, `verifyInclusionProof`, `computeRootHash` |
+| `CSMT.Proof.Completeness` | `generateProof`, `collectValues`, `foldProof` |
+| `CSMT.Backend.RocksDB` | RocksDB persistent backend |
+| `CSMT.Backend.Pure` | In-memory backend for testing |
+| `CSMT.Backend.Standalone` | Column selectors and codecs |
+| `CSMT.MTS` | `CsmtImpl`, `csmtMerkleTreeStore` |
+
+### Insert and Delete
 
 ```haskell
-import CSMT.Hashes (insert, fromKVHashes)
+import CSMT.Hashes (fromKVHashes)
+import CSMT.Insertion (inserting)
+import CSMT.Deletion (deleting)
 
--- Insert a key-value pair
-insertExample :: Transaction m cf d ops ()
-insertExample =
-    insert fromKVHashes kvCol csmtCol "mykey" "myvalue"
+-- In a transaction context:
+inserting fromKVHashes hashing StandaloneKVCol StandaloneCSMTCol "key" "value"
+deleting  fromKVHashes hashing StandaloneKVCol StandaloneCSMTCol "key"
 ```
 
-The `insert` function:
-
-1. Stores the key-value pair in the KV column
-2. Computes the tree key as `treePrefix(value) <> fromK(key)`
-3. Computes the value hash
-4. Updates the CSMT structure at the tree key
-5. Recomputes affected node hashes
-
-### Deleting Values
+### Inclusion Proofs
 
 ```haskell
-import CSMT.Hashes (delete, fromKVHashes)
+import CSMT.Proof.Insertion (buildInclusionProof, verifyInclusionProof)
 
--- Delete a key
-deleteExample :: Transaction m cf d ops ()
-deleteExample =
-    delete fromKVHashes kvCol csmtCol "mykey"
+-- Generate (in transaction)
+result <- buildInclusionProof fromKVHashes StandaloneKVCol StandaloneCSMTCol hashing "key"
+-- result :: Maybe (ByteString, InclusionProof Hash)
+
+-- Verify (pure)
+verifyInclusionProof hashing proof  -- :: Bool
 ```
 
-Deletion:
-
-1. Looks up the value from the KV column (needed to compute the tree key
-   via `treePrefix(value) <> fromK(key)`)
-2. Removes the key from the KV column
-3. Updates the tree structure (may compact nodes)
-4. Recomputes affected hashes
-
-### Querying the Root
+### Completeness Proofs
 
 ```haskell
-import CSMT.Hashes (root)
+import CSMT.Proof.Completeness (generateProof, collectValues, foldProof)
 
--- Get current root hash
-getRootExample :: Transaction m cf d ops (Maybe ByteString)
-getRootExample = root csmtCol
+-- Collect leaves under a prefix
+leaves <- collectValues StandaloneCSMTCol prefix
+
+-- Generate proof
+mproof <- generateProof StandaloneCSMTCol prefix
+
+-- Verify
+let computed = foldProof (combineHash hashing) leaves proof
 ```
 
-Returns `Nothing` if the tree is empty.
-
-## Merkle Proofs
-
-### Generating Inclusion Proofs
-
-```haskell
-import CSMT.Hashes (generateInclusionProof, fromKVHashes)
-
--- Generate proof for a key
-proofExample :: Transaction m cf d ops (Maybe (ByteString, ByteString))
-proofExample =
-    generateInclusionProof fromKVHashes kvCol csmtCol "mykey"
-```
-
-Returns `Maybe (value, proofBytes)`:
-
-- Looks up the value from the KV column
-- Returns both the value and serialized proof
-- Returns `Nothing` if the key doesn't exist
-
-This ensures the proof is always consistent with the current tree state.
-
-### Verifying Inclusion Proofs
-
-```haskell
-import CSMT.Hashes (verifyInclusionProof)
-
--- Verify a proof (pure function, no database access needed)
-verifyExample :: ByteString -> Bool
-verifyExample proofBytes = verifyInclusionProof proofBytes
-```
-
-Returns `True` if the proof is internally consistent. The proof is self-contained
-with the key, value hash, and root hash embedded.
-
-To verify against a trusted root, parse the proof and compare `proofRootHash`
-with your known root.
-
-## Custom Key/Value Types
-
-The library supports custom types via `FromKV`:
+### Custom Key/Value Types
 
 ```haskell
 import CSMT.Interface (FromKV(..))
 
--- Define conversion for your types
 myFromKV :: FromKV MyKey MyValue Hash
 myFromKV = FromKV
-    { fromK = myKeyToPath      -- Convert key to tree path
-    , fromV = myValueToHash    -- Convert value to hash
-    , treePrefix = const []    -- No prefix (default)
+    { fromK      = myKeyToPath
+    , fromV      = myValueToHash
+    , treePrefix = const []
     }
 ```
 
-The `treePrefix` field allows secondary indexing by prepending a prefix
-derived from the value to the tree key. For example, to index UTxOs by
-address:
+The `treePrefix` field enables secondary indexing by prepending a prefix
+derived from the value to the tree key.
+
+### Column Selectors
+
+CSMT uses type-safe GADT column selectors:
+
+- `StandaloneKVCol` - Key-value column
+- `StandaloneCSMTCol` - CSMT tree column
+
+## 3. MPF Direct API
+
+For MPF-specific features (batch/streaming inserts, hex key manipulation),
+use the `mts:mpf` sub-library directly.
+
+### Modules
+
+| Module | Purpose |
+|--------|---------|
+| `MPF` | Re-exports the public API |
+| `MPF.Hashes` | Blake2b-256 operations, `fromHexKVHashes`, `mpfHashing` |
+| `MPF.Interface` | `FromHexKV`, `HexIndirect`, `HexKey`, `HexDigit` |
+| `MPF.Insertion` | `inserting`, `insertingBatch`, `insertingChunked`, `insertingStream` |
+| `MPF.Deletion` | `deleting` |
+| `MPF.Proof.Insertion` | `mkMPFInclusionProof`, `verifyMPFInclusionProof`, `foldMPFProof` |
+| `MPF.Backend.RocksDB` | RocksDB persistent backend |
+| `MPF.Backend.Pure` | In-memory backend for testing |
+| `MPF.Backend.Standalone` | Column selectors and codecs |
+| `MPF.MTS` | `MpfImpl`, `mpfMerkleTreeStore` |
+
+### Insert Modes
 
 ```haskell
-addressIndexed :: FromKV TxIn TxOut Hash
-addressIndexed = FromKV
-    { fromK = txInToKey
-    , fromV = txOutToHash
-    , treePrefix = addressToKey . extractAddress
-    }
+import MPF.Insertion (inserting, insertingBatch, insertingChunked, insertingStream)
+
+-- Sequential (small datasets)
+inserting fromKV hashing kvCol mpfCol key value
+
+-- Batch (medium datasets, O(n log n))
+insertingBatch fromKV hashing kvCol mpfCol [(k1, v1), (k2, v2)]
+
+-- Chunked (large datasets, bounded memory)
+insertingChunked fromKV hashing kvCol mpfCol chunkSize pairs
+
+-- Streaming (very large datasets, ~16x lower peak memory)
+insertingStream fromKV hashing kvCol mpfCol pairs
 ```
 
-This makes the tree key `treePrefix(value) <> fromK(key)`, enabling
-completeness proofs over all entries sharing a prefix.
-
-## Codecs
-
-For storage, define codecs using Prisms:
+### Hex Key Operations
 
 ```haskell
-import CSMT.Backend.Standalone (StandaloneCodecs(..))
-import Control.Lens (prism')
+import MPF.Interface (byteStringToHexKey, hexKeyToByteString, HexDigit(..), HexKey)
 
-myCodecs :: StandaloneCodecs MyKey MyValue Hash
-myCodecs = StandaloneCodecs
-    { keyCodec = prism' encodeKey decodeKey
-    , valueCodec = prism' encodeValue decodeValue
-    , nodeCodec = prism' encodeHash decodeHash
-    }
+let key = byteStringToHexKey "hello"  -- [HexDigit 6, HexDigit 8, ...]
+let bs  = hexKeyToByteString key       -- round-trips back
 ```
 
-## Column Selectors
+### Column Selectors
 
-Operations use type-safe column selectors from `CSMT.Backend.Standalone`:
+MPF uses its own GADT column selectors:
 
-```haskell
-import CSMT.Backend.Standalone (Standalone(..))
-
--- Use directly as selectors
-insert fromKVHashes StandaloneKVCol StandaloneCSMTCol key value
-delete fromKVHashes StandaloneKVCol StandaloneCSMTCol key
-generateInclusionProof fromKVHashes StandaloneKVCol StandaloneCSMTCol key
-```
-
-The GADT constructors serve as selectors:
-
-- `StandaloneKVCol` - Selects the key-value column
-- `StandaloneCSMTCol` - Selects the CSMT tree column
+- `MPFStandaloneKVCol` - Key-value column
+- `MPFStandaloneMPFCol` - MPF tree column
 
 ## Error Handling
 
-Most operations return `Maybe` or are in a `Transaction` monad:
-
-- `Nothing` typically means "key not found"
+- `Nothing` from proof/root operations means "key not found" or "tree empty"
 - Invalid proofs return `False` from verification
 - Database errors surface as exceptions
+- MPF completeness proof operations currently `fail`
 
 ## Performance Tips
 
-1. **Batch operations**: Group multiple inserts/deletes in a single transaction
-2. **Column family tuning**: Adjust `maxFiles` parameters for your workload
-3. **Parallel insertion**: Future versions will support parallel batch inserts
+1. **Use the MTS interface** when you don't need implementation-specific features
+2. **Batch inserts** for MPF are significantly faster than sequential for large datasets
+3. **Streaming inserts** reduce peak memory by ~16x by processing subtrees independently
+4. **Group transactions** to amortize RocksDB write overhead

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,5 +1,9 @@
 # Manual
 
+!!! note
+    The `mts` CLI operates on a **CSMT** instance. MPF does not currently
+    have a dedicated CLI.
+
 ## Demos
 
 ### Basic Operations
@@ -30,7 +34,7 @@ Generate and verify self-contained inclusion proofs:
 
 ## CLI Usage
 
-The CSMT library comes with a command-line interface (CLI) tool that allows users to interact with the Compact Sparse Merkle Tree. The CLI provides various commands to perform operations such as adding and removing elements, generating proofs, and verifying membership within the tree.
+The MTS package includes a command-line interface (CLI) tool for interacting with the CSMT tree. The CLI provides commands for adding/removing elements, generating proofs, and verifying membership.
 
 CLI works in interactive mode by default. You can also pass commands directly as stdin as we are doing in this manual.
 
@@ -61,7 +65,7 @@ Setup the environment variable `CSMT_DB_PATH` to point to a directory where the 
 
 === "Input"
     ```bash
-    csmt <<$
+    mts <<$
     i key1 value1
     q key1
     $
@@ -79,7 +83,7 @@ Now the database contains the value for `key1`, and you can query its inclusion 
 
 === "Input"
     ```bash
-    csmt <<$
+    mts <<$
     v AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
     $
     ```
@@ -96,7 +100,7 @@ Currently you cannot inspect the keys, but you can ask for the values:
 
 === "Input"
     ```bash
-    csmt <<< 'w key1'
+    mts <<< 'w key1'
     ```
 === "Output"
     ```text
@@ -109,7 +113,7 @@ You can delete keys as well:
 
 === "Input"
     ```bash
-    csmt <<< 'd key1'
+    mts <<< 'd key1'
     ```
 === "Output"
     ```text
@@ -118,7 +122,7 @@ You can delete keys as well:
 Now if you try to query for the inclusion proof of `key1` again:
 === "Input"
     ```bash
-    csmt <<< 'q key1'
+    mts <<< 'q key1'
     ```
 === "Output"
     ```text
@@ -131,7 +135,7 @@ Or if you try to get the value for `key1`:
 
 === "Input"
     ```bash
-    csmt <<< 'w key1'
+    mts <<< 'w key1'
     ```
 === "Output"
     ```text
@@ -144,7 +148,7 @@ You can get the current root of the CSMT tree with the `r` command:
 
 === "Input"
     ```bash
-    csmt <<< 'r'
+    mts <<< 'r'
     ```
 === "Output"
     ```text
@@ -155,7 +159,7 @@ If you insert some keys first:
 
 === "Input"
     ```bash
-    csmt <<$
+    mts <<$
     i key1 value1
     r
     i key2 value2

--- a/docs/mpf.md
+++ b/docs/mpf.md
@@ -1,0 +1,162 @@
+# MPF (16-ary Trie)
+
+The Merkle Patricia Forest is MTS's 16-ary trie implementation. It uses
+hex nibble branching with Aiken-compatible hashing.
+
+!!! info
+    This page covers MPF-specific details. For the shared interface, see
+    [MTS Interface](interface.md). For general concepts, see
+    [Concepts](concepts.md).
+
+## Overview
+
+MPF provides:
+
+- 16-ary trie with hex nibble keys (4 bits per level, depth 64 for
+  32-byte keys)
+- Path compression via `hexJump` fields on `HexIndirect` nodes
+- Leaf/branch distinction (`hexIsLeaf` flag) for different hash schemes
+- Aiken-compatible root hashes (verified against 30-fruit test vector)
+- Batch, chunked, and streaming insertion modes
+- Inclusion proofs with SMT proof steps
+
+## Key Types
+
+### `HexDigit` and `HexKey`
+
+```haskell
+newtype HexDigit = HexDigit { unHexDigit :: Word8 }  -- 0-15
+type HexKey = [HexDigit]
+```
+
+A `ByteString` is converted to a `HexKey` by splitting each byte into
+high and low nibbles:
+
+```haskell
+byteStringToHexKey :: ByteString -> HexKey
+-- byte 0xa3 -> [HexDigit 0xa, HexDigit 0x3]
+```
+
+### `HexIndirect` - Tree Nodes
+
+```haskell
+data HexIndirect a = HexIndirect
+    { hexJump   :: HexKey   -- Path compression: nibbles to skip
+    , hexValue  :: a         -- Hash value
+    , hexIsLeaf :: Bool      -- True = leaf node, False = branch node
+    }
+```
+
+The `hexIsLeaf` flag determines which hashing scheme is applied.
+
+### `FromHexKV` - Key/Value Conversion
+
+```haskell
+data FromHexKV k v a = FromHexKV
+    { fromHexK      :: k -> HexKey    -- User key to nibble path
+    , fromHexV      :: v -> a          -- User value to hash
+    , hexTreePrefix :: v -> HexKey     -- Optional prefix for secondary indexing
+    }
+```
+
+The default `fromHexKVHashes` hashes the key with Blake2b-256, converts
+to nibbles, and hashes the value.
+
+### `MPFHashing` - Hash Operations
+
+```haskell
+data MPFHashing a = MPFHashing
+    { leafHash   :: HexKey -> a -> a
+    , merkleRoot :: [Maybe a] -> a
+    , branchHash :: HexKey -> a -> a
+    }
+```
+
+## Hashing Scheme
+
+MPF uses a specific hashing scheme for Aiken compatibility:
+
+### Leaf Hash
+
+```
+leafHash(suffix, valueDigest):
+    if even(length(suffix)):
+        hashHead = 0xff
+        hashTail = packHexKey(suffix)
+    else:
+        hashHead = 0x00 || first_nibble
+        hashTail = packHexKey(remaining_nibbles)
+    return blake2b(hashHead || hashTail || valueDigest)
+```
+
+### Branch Hash
+
+```
+branchHash(prefix, children):
+    merkle = pairwiseReduce(children)  -- 16 slots, nullHash for missing
+    return blake2b(nibbleBytes(prefix) || merkle)
+```
+
+### Merkle Root (Pairwise Reduction)
+
+The 16-slot sparse array is reduced to a single hash by pairwise
+concatenation and hashing:
+
+```
+[h0, h1, h2, ..., h15]
+-> [hash(h0||h1), hash(h2||h3), ..., hash(h14||h15)]
+-> [hash(h01||h23), hash(h45||h67), ..., hash(h12_13||h14_15)]
+-> [hash(h0123||h4567), hash(h8_11||h12_15)]
+-> hash(h0_7||h8_15)
+```
+
+Missing children use a null hash (32 zero bytes).
+
+## Insertion Modes
+
+MPF supports multiple insertion strategies:
+
+| Mode | Function | Complexity | Use Case |
+|------|----------|------------|----------|
+| Sequential | `inserting` | O(n * depth) | Small datasets |
+| Batch | `insertingBatch` | O(n log n) | Medium datasets |
+| Chunked | `insertingChunked` | Bounded memory | Large datasets |
+| Streaming | `insertingStream` | ~16x lower peak memory | Very large datasets |
+
+Streaming insertion groups keys by their first hex digit, processing
+each of the 16 subtrees independently.
+
+## Inclusion Proofs
+
+MPF inclusion proofs contain:
+
+- The key and value
+- A sequence of proof steps, each with:
+    - Node type (leaf or branch)
+    - Sibling hash
+    - SMT proof: 4 intermediate hashes from the 16-element pairwise
+      reduction tree
+- The root hash
+
+The SMT proof encodes the path through the binary reduction of the
+16-slot array, collecting the opposite subtree's root at each of 4
+levels.
+
+## Aiken Compatibility
+
+MPF produces root hashes matching the Aiken `MerkleTree` reference
+implementation. This is verified by the 30-fruit test vector from the
+Aiken test suite:
+
+```
+Expected root: 4acd78f345a686361df77541b2e0b533f53362e36620a1fdd3a13e0b61a3b078
+```
+
+The test inserts 30 fruit key-value pairs (e.g. `"apple[uid: 58]"` ->
+hash of the emoji) and verifies the resulting root hash matches exactly.
+
+## Completeness Proofs
+
+MPF completeness proofs are not yet implemented. The `mtsCollectLeaves`,
+`mtsMkCompletenessProof`, and `mtsVerifyCompletenessProof` fields
+currently raise an error.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,5 +1,9 @@
 # TypeScript Verifier
 
+!!! note
+    The TypeScript verifier supports **CSMT** proofs only. MPF proof
+    verification is not yet available in TypeScript.
+
 A TypeScript library for verifying CSMT inclusion proofs client-side.
 This enables browser and Node.js applications to verify proofs without
 a Haskell runtime.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: CSMT Documentation
-site_url: https://paolino.github.io/haskell-csmt/
-repo_url: https://github.com/paolino/haskell-csmt
+site_name: MTS Documentation
+site_url: https://paolino.github.io/haskell-mts/
+repo_url: https://github.com/paolino/haskell-mts
 
 theme:
   name: material
@@ -42,6 +42,10 @@ nav:
   - Getting Started:
     - Installation: installation.md
     - Concepts: concepts.md
+  - MTS Interface: interface.md
+  - Implementations:
+    - CSMT (Binary Trie): csmt.md
+    - MPF (16-ary Trie): mpf.md
   - Architecture:
     - System: architecture/system.md
     - Storage: architecture/storage.md


### PR DESCRIPTION
## Summary

- Comprehensive documentation rewrite for the haskell-csmt -> haskell-mts rename
- All docs rebrand to MTS with dual-implementation (CSMT + MPF) coverage
- Three new pages: `interface.md`, `csmt.md`, `mpf.md`
- All URLs updated from haskell-csmt to haskell-mts
- CHANGELOG cleaned up (removed bogus entries, added v0.4.0.0)
- mkdocs builds clean with no errors