### PR TITLE
feat: anchor proofs to their root hash

### DIFF
--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -90,13 +90,19 @@ csmtMerkleTreeStore run db fromKV hashing =
                 $ do
                     mp <-
                         buildInclusionProof fromKV StandaloneKVCol StandaloneCSMTCol hashing k
-                    pure $ fmap snd mp
+                    case mp of
+                        Nothing -> pure Nothing
+                        Just (_, proof) -> do
+                            mr <- root hashing StandaloneCSMTCol
+                            pure $ case mr of
+                                Nothing -> Nothing
+                                Just r -> Just (r, proof)
         , mtsVerifyProof = \v proof ->
             pure
                 $ proofValue proof == fromV fromKV v
                     && verifyInclusionProof hashing proof
-        , mtsFoldProof = \_ proof ->
-            computeRootHash hashing proof
+        , mtsFoldProof =
+            computeRootHash hashing
         , mtsBatchInsert =
             run
                 . runTransactionUnguarded db

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -85,16 +85,29 @@ mpfMerkleTreeStore run db fromKV hashing =
                                 $ if hexIsLeaf i
                                     then leafHash hashing (hexJump i) (hexValue i)
                                     else hexValue i
-        , mtsMkProof =
+        , mtsMkProof = \k ->
             run
-                . runTransactionUnguarded db
-                . mkMPFInclusionProof fromKV hashing MPFStandaloneMPFCol
+                $ runTransactionUnguarded db
+                $ do
+                    mp <- mkMPFInclusionProof fromKV hashing MPFStandaloneMPFCol k
+                    case mp of
+                        Nothing -> pure Nothing
+                        Just proof -> do
+                            mi <- query MPFStandaloneMPFCol ([] :: HexKey)
+                            pure $ case mi of
+                                Nothing -> Nothing
+                                Just i ->
+                                    let r =
+                                            if hexIsLeaf i
+                                                then leafHash hashing (hexJump i) (hexValue i)
+                                                else hexValue i
+                                    in  Just (r, proof)
         , mtsVerifyProof = \v proof ->
             run
                 $ runTransactionUnguarded db
                 $ verifyMPFInclusionProof fromKV MPFStandaloneMPFCol hashing v proof
-        , mtsFoldProof = \_ proof ->
-            foldMPFProof hashing (fromHexV fromKV undefined) proof
+        , mtsFoldProof =
+            foldMPFProof hashing
         , mtsBatchInsert =
             run
                 . runTransactionUnguarded db

--- a/lib/mpf/MPF/Proof/Insertion.hs
+++ b/lib/mpf/MPF/Proof/Insertion.hs
@@ -92,6 +92,8 @@ data MPFProof a = MPFProof
     , mpfProofRootPrefix :: HexKey
     , mpfProofLeafSuffix :: HexKey
     -- ^ The remaining key suffix at the leaf level
+    , mpfProofValueHash :: a
+    -- ^ The hashed value at the leaf
     }
     deriving (Show, Eq)
 
@@ -121,6 +123,7 @@ mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
         let key = fromHexK k
         HexIndirect
             { hexJump = rootJump
+            , hexValue = rootValue
             , hexIsLeaf = rootIsLeaf
             } <-
             MaybeT $ query sel []
@@ -133,21 +136,24 @@ mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
                         { mpfProofSteps = []
                         , mpfProofRootPrefix = []
                         , mpfProofLeafSuffix = rootJump
+                        , mpfProofValueHash = rootValue
                         }
             else do
-                (steps, leafSuffix) <-
+                (steps, leafSuffix, valHash) <-
                     go [] rootJump remainingAfterRoot
                 pure
                     $ MPFProof
                         { mpfProofSteps = reverse steps
                         , mpfProofRootPrefix = rootJump
                         , mpfProofLeafSuffix = leafSuffix
+                        , mpfProofValueHash = valHash
                         }
   where
-    go _ _ [] = pure ([], [])
+    go _ _ [] = error "mkMPFInclusionProof: key not found"
     go u branchJump (x : ks) = do
         HexIndirect
             { hexJump = childJump
+            , hexValue = childValue
             , hexIsLeaf
             } <-
             MaybeT
@@ -236,14 +242,14 @@ mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
                                 nodeHashes
                             }
         if hexIsLeaf
-            then pure ([step], childJump)
+            then pure ([step], childJump, childValue)
             else do
-                (restSteps, leafSuffix) <-
+                (restSteps, leafSuffix, valHash) <-
                     go
                         (u <> branchJump <> [x])
                         childJump
                         remaining
-                pure (step : restSteps, leafSuffix)
+                pure (step : restSteps, leafSuffix, valHash)
 
     computeNodeHash
         HexIndirect
@@ -336,21 +342,21 @@ computeNodeHash'
 --   hash (computed from suffix + value)
 -- * 'ProofStepFork': our hash + one neighbor branch
 --   hash (computed from prefix + merkle root)
-foldMPFProof :: MPFHashing a -> a -> MPFProof a -> a
+foldMPFProof :: MPFHashing a -> MPFProof a -> a
 foldMPFProof
     hashing
-    valueHash
-    MPFProof{mpfProofSteps, mpfProofLeafSuffix} =
-        case mpfProofSteps of
-            [] ->
-                leafHash hashing mpfProofLeafSuffix valueHash
-            steps ->
-                let leafNodeHash =
-                        leafHash
-                            hashing
-                            mpfProofLeafSuffix
-                            valueHash
-                in  foldl' step leafNodeHash steps
+    MPFProof{mpfProofSteps, mpfProofLeafSuffix, mpfProofValueHash} =
+        let valueHash = mpfProofValueHash
+        in  case mpfProofSteps of
+                [] ->
+                    leafHash hashing mpfProofLeafSuffix valueHash
+                steps ->
+                    let leafNodeHash =
+                            leafHash
+                                hashing
+                                mpfProofLeafSuffix
+                                valueHash
+                    in  foldl' step leafNodeHash steps
       where
         step acc proofStep =
             case proofStep of
@@ -475,9 +481,7 @@ verifyMPFInclusionProof
                             if hexIsLeaf
                                 then lh hexJump hexValue
                                 else hexValue
-                    in  rootNodeHash
-                            == foldMPFProof
-                                hashing
-                                valueHash
-                                proof
+                    in  mpfProofValueHash proof == valueHash
+                            && rootNodeHash
+                                == foldMPFProof hashing proof
             Nothing -> False

--- a/lib/mts/MTS/Interface.hs
+++ b/lib/mts/MTS/Interface.hs
@@ -42,11 +42,11 @@ data MerkleTreeStore imp m = MerkleTreeStore
     -- ^ Delete a key
     , mtsRootHash :: m (Maybe (MtsHash imp))
     -- ^ Query the current root hash
-    , mtsMkProof :: MtsKey imp -> m (Maybe (MtsProof imp))
-    -- ^ Generate a membership proof
+    , mtsMkProof :: MtsKey imp -> m (Maybe (MtsHash imp, MtsProof imp))
+    -- ^ Generate a membership proof anchored to the current root hash
     , mtsVerifyProof :: MtsValue imp -> MtsProof imp -> m Bool
     -- ^ Verify a membership proof for a value
-    , mtsFoldProof :: MtsHash imp -> MtsProof imp -> MtsHash imp
+    , mtsFoldProof :: MtsProof imp -> MtsHash imp
     -- ^ Compute root hash from a proof
     , mtsBatchInsert :: [(MtsKey imp, MtsValue imp)] -> m ()
     -- ^ Batch insert multiple key-value pairs

--- a/lib/mts/MTS/Properties.hs
+++ b/lib/mts/MTS/Properties.hs
@@ -12,6 +12,7 @@ module MTS.Properties
     , propEmptyTreeNoRoot
     , propSingleInsertHasRoot
     , propWrongValueRejects
+    , propProofAnchoredToRoot
     , propCompletenessRoundTrip
     , propCompletenessEmpty
     , propCompletenessAfterDelete
@@ -51,7 +52,7 @@ propInsertVerify mkStore gen =
         mp <- mtsMkProof store k
         case mp of
             Nothing -> pure False
-            Just proof -> mtsVerifyProof store v proof
+            Just (_, proof) -> mtsVerifyProof store v proof
 
 -- | Insert N pairs, all verify.
 propMultipleInsertAllVerify
@@ -71,7 +72,7 @@ propMultipleInsertAllVerify mkStore gen =
                     mp <- mtsMkProof store k
                     case mp of
                         Nothing -> pure False
-                        Just proof ->
+                        Just (_, proof) ->
                             mtsVerifyProof store v proof
                 )
                 kvs
@@ -116,7 +117,7 @@ propDeleteRemovesKey mkStore gen =
         mp <- mtsMkProof store k
         case mp of
             Nothing -> pure True
-            Just proof ->
+            Just (_, proof) ->
                 not <$> mtsVerifyProof store v proof
 
 -- | Insert 3 distinct keys, delete one, other two still verify.
@@ -147,13 +148,13 @@ propDeletePreservesSiblings mkStore gen1 gen2 gen3 =
                                 mp <- mtsMkProof store k1
                                 case mp of
                                     Nothing -> pure False
-                                    Just proof ->
+                                    Just (_, proof) ->
                                         mtsVerifyProof store v1 proof
                             r3 <- do
                                 mp <- mtsMkProof store k3
                                 case mp of
                                     Nothing -> pure False
-                                    Just proof ->
+                                    Just (_, proof) ->
                                         mtsVerifyProof store v3 proof
                             pure $ r1 && r3
 
@@ -234,8 +235,32 @@ propWrongValueRejects mkStore gen =
         mp <- mtsMkProof store k
         case mp of
             Nothing -> pure False
-            Just proof ->
+            Just (_, proof) ->
                 not <$> mtsVerifyProof store v' proof
+
+-- | The root hash returned by mtsMkProof matches mtsFoldProof
+-- and mtsRootHash.
+propProofAnchoredToRoot
+    :: ( Show (MtsKey imp)
+       , Show (MtsValue imp)
+       , Eq (MtsHash imp)
+       )
+    => IO (MerkleTreeStore imp IO)
+    -> Gen (MtsKey imp, MtsValue imp)
+    -> Property
+propProofAnchoredToRoot mkStore gen =
+    property $ forAll gen $ \(k, v) -> ioProperty $ do
+        store <- mkStore
+        mtsInsert store k v
+        mp <- mtsMkProof store k
+        case mp of
+            Nothing -> pure False
+            Just (anchoredRoot, proof) -> do
+                currentRoot <- mtsRootHash store
+                let foldedRoot = mtsFoldProof store proof
+                pure
+                    $ currentRoot == Just anchoredRoot
+                        && foldedRoot == anchoredRoot
 
 -- | Insert N pairs, collect leaves, generate completeness
 -- proof, verify it returns True.

--- a/test/MPF/Proof/InsertionSpec.hs
+++ b/test/MPF/Proof/InsertionSpec.hs
@@ -138,7 +138,7 @@ spec = do
                 case mProof of
                     Nothing -> fail "Expected proof"
                     Just proof -> do
-                        let computedRoot = foldMPFProof mpfHashing value proof
+                        let computedRoot = foldMPFProof mpfHashing proof
                         -- The folded proof should produce a non-empty hash
                         renderMPFHash computedRoot `shouldSatisfy` (not . B.null)
 

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -149,6 +149,8 @@ spec = do
             $ propSingleInsertHasRoot mkCsmtStore genBSPair
         it "wrong value rejects"
             $ propWrongValueRejects mkCsmtStore genBSTriple
+        it "proof anchored to root"
+            $ propProofAnchoredToRoot mkCsmtStore genBSPair
         it "completeness round-trip"
             $ propCompletenessRoundTrip mkCsmtStore genBSPairs
         it "completeness empty"
@@ -172,6 +174,8 @@ spec = do
             $ propSingleInsertHasRoot mkMpfStore genBSPair
         it "wrong value rejects"
             $ propWrongValueRejects mkMpfStore genBSTriple
+        it "proof anchored to root"
+            $ propProofAnchoredToRoot mkMpfStore genBSPair
         it "completeness round-trip" pending
         it "completeness empty" pending
         it "completeness after delete" pending


### PR DESCRIPTION
Closes #63

## Summary

- `mtsMkProof` returns `(MtsHash, MtsProof)` — every proof is paired with the root it was computed against
- `mtsFoldProof` simplified to `MtsProof -> MtsHash` — proofs are now self-contained
- `MPFProof` gains `mpfProofValueHash` field, eliminating the `undefined` in MPF.MTS
- New `propProofAnchoredToRoot` property test for both CSMT and MPF

## Motivation

Prerequisite for the write-ahead buffer (#56). Without anchored roots, a flush between proof generation and usage silently invalidates the proof.

## Test plan

- All 183 tests pass (0 failures, 4 pending for unrelated MPF completeness)
- New property verifies anchored root matches `mtsRootHash` and `mtsFoldProof`