### PR TITLE
fix: replace stale haskell-csmt references

### DIFF
--- a/CI/release.sh
+++ b/CI/release.sh
@@ -50,4 +50,4 @@ cp -L "$tarball" "$releaseTarball"
 
 gh release upload "$release" "$releaseTarball"
 
-echo "Release URL: https://github.com/paolino/haskell-csmt/releases/tag/$release"
+echo "Release URL: https://github.com/paolino/haskell-mts/releases/tag/$release"

--- a/verifiers/typescript/package.json
+++ b/verifiers/typescript/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/paolino/haskell-csmt.git",
+    "url": "https://github.com/paolino/haskell-mts.git",
     "directory": "verifiers/typescript"
   },
   "dependencies": {

--- a/verifiers/typescript/test/fixtures.json
+++ b/verifiers/typescript/test/fixtures.json
@@ -1,5 +1,5 @@
 {
-  "description": "Test fixtures generated from haskell-csmt CLI",
+  "description": "Test fixtures generated from mts CLI",
   "rootHash": "1e98af87b522eead4102425223ef5174599933b9dbe848fa0c4731553a31e6a6",
   "proofs": [
     {


### PR DESCRIPTION
Closes #57

## Summary

- Replace 3 remaining `haskell-csmt` references with `haskell-mts` in CI/release.sh, typescript package.json, and test fixtures

Combined with prior work (repo rename, cabal rename, shared MTS interface, MPF merge, haskell-mpfs archived), this completes the restructuring.