### PR TITLE
fix: expose transactional MTS constructors

### DIFF
--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -1,10 +1,20 @@
 -- | CSMT implementation of the MTS interface.
 --
 -- Defines @CsmtImpl@ phantom type with type family instances
--- and a constructor that wraps CSMT operations into
+-- and constructors that wrap CSMT operations into
 -- 'MerkleTreeStore'.
+--
+-- Two constructors are provided:
+--
+-- * 'csmtMerkleTreeStoreT' — operations live in the
+--   'Transaction' monad, composable within a single atomic
+--   transaction.
+-- * 'csmtMerkleTreeStore' — convenience wrapper that commits
+--   each operation in its own transaction (suitable for simple
+--   use cases and tests).
 module CSMT.MTS
     ( CsmtImpl
+    , csmtMerkleTreeStoreT
     , csmtMerkleTreeStore
     )
 where
@@ -37,7 +47,10 @@ import CSMT.Proof.Insertion
     )
 import Data.ByteString (ByteString)
 import Database.KV.Database (Database)
-import Database.KV.Transaction (runTransactionUnguarded)
+import Database.KV.Transaction
+    ( Transaction
+    , runTransactionUnguarded
+    )
 import MTS.Interface
     ( MerkleTreeStore (..)
     , MtsCompletenessProof
@@ -46,6 +59,7 @@ import MTS.Interface
     , MtsLeaf
     , MtsProof
     , MtsValue
+    , hoistMTS
     )
 
 -- | Phantom type tag for the CSMT implementation.
@@ -58,7 +72,86 @@ type instance MtsProof CsmtImpl = InclusionProof Hash
 type instance MtsLeaf CsmtImpl = Indirect Hash
 type instance MtsCompletenessProof CsmtImpl = CompletenessProof
 
--- | Build a 'MerkleTreeStore' for CSMT.
+-- | Build a transactional 'MerkleTreeStore' for CSMT.
+--
+-- Operations live in the 'Transaction' monad so multiple
+-- calls can be composed into a single atomic transaction:
+--
+-- @
+-- runTransactionUnguarded db $ do
+--     mtsInsert store k1 v1
+--     mtsDelete store k2
+--     mtsRootHash store
+-- @
+csmtMerkleTreeStoreT
+    :: (Monad m)
+    => FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> MerkleTreeStore
+        CsmtImpl
+        ( Transaction
+            m
+            StandaloneCF
+            (Standalone ByteString ByteString Hash)
+            StandaloneOp
+        )
+csmtMerkleTreeStoreT fromKV hashing =
+    MerkleTreeStore
+        { mtsInsert =
+            inserting fromKV hashing StandaloneKVCol StandaloneCSMTCol
+        , mtsDelete =
+            deleting fromKV hashing StandaloneKVCol StandaloneCSMTCol
+        , mtsRootHash =
+            root hashing StandaloneCSMTCol
+        , mtsMkProof = \k -> do
+            mp <-
+                buildInclusionProof
+                    fromKV
+                    StandaloneKVCol
+                    StandaloneCSMTCol
+                    hashing
+                    k
+            case mp of
+                Nothing -> pure Nothing
+                Just (_, proof) -> do
+                    mr <- root hashing StandaloneCSMTCol
+                    pure $ case mr of
+                        Nothing -> Nothing
+                        Just r -> Just (r, proof)
+        , mtsVerifyProof = \v proof ->
+            pure
+                $ proofValue proof == fromV fromKV v
+                    && verifyInclusionProof hashing proof
+        , mtsFoldProof =
+            computeRootHash hashing
+        , mtsBatchInsert =
+            mapM_
+                ( uncurry
+                    ( inserting
+                        fromKV
+                        hashing
+                        StandaloneKVCol
+                        StandaloneCSMTCol
+                    )
+                )
+        , mtsCollectLeaves =
+            collectValues StandaloneCSMTCol []
+        , mtsMkCompletenessProof =
+            generateProof StandaloneCSMTCol []
+        , mtsVerifyCompletenessProof = \leaves proof -> do
+            currentRoot <- root hashing StandaloneCSMTCol
+            let computed =
+                    foldProof (combineHash hashing) leaves proof
+            pure $ case (currentRoot, computed) of
+                (Just r, Just indirect) ->
+                    rootHash hashing indirect == r
+                _ -> False
+        }
+
+-- | Build an IO 'MerkleTreeStore' for CSMT.
+--
+-- Each operation commits in its own transaction. For atomic
+-- multi-operation sequences, use 'csmtMerkleTreeStoreT' instead.
 csmtMerkleTreeStore
     :: (MonadFail m)
     => (forall b. m b -> IO b)
@@ -71,61 +164,6 @@ csmtMerkleTreeStore
     -> Hashing Hash
     -> MerkleTreeStore CsmtImpl IO
 csmtMerkleTreeStore run db fromKV hashing =
-    MerkleTreeStore
-        { mtsInsert = \k v ->
-            run
-                $ runTransactionUnguarded db
-                $ inserting fromKV hashing StandaloneKVCol StandaloneCSMTCol k v
-        , mtsDelete =
-            run
-                . runTransactionUnguarded db
-                . deleting fromKV hashing StandaloneKVCol StandaloneCSMTCol
-        , mtsRootHash =
-            run
-                $ runTransactionUnguarded db
-                $ root hashing StandaloneCSMTCol
-        , mtsMkProof = \k ->
-            run
-                $ runTransactionUnguarded db
-                $ do
-                    mp <-
-                        buildInclusionProof fromKV StandaloneKVCol StandaloneCSMTCol hashing k
-                    case mp of
-                        Nothing -> pure Nothing
-                        Just (_, proof) -> do
-                            mr <- root hashing StandaloneCSMTCol
-                            pure $ case mr of
-                                Nothing -> Nothing
-                                Just r -> Just (r, proof)
-        , mtsVerifyProof = \v proof ->
-            pure
-                $ proofValue proof == fromV fromKV v
-                    && verifyInclusionProof hashing proof
-        , mtsFoldProof =
-            computeRootHash hashing
-        , mtsBatchInsert =
-            run
-                . runTransactionUnguarded db
-                . mapM_
-                    ( uncurry
-                        (inserting fromKV hashing StandaloneKVCol StandaloneCSMTCol)
-                    )
-        , mtsCollectLeaves =
-            run
-                $ runTransactionUnguarded db
-                $ collectValues StandaloneCSMTCol []
-        , mtsMkCompletenessProof =
-            run
-                $ runTransactionUnguarded db
-                $ generateProof StandaloneCSMTCol []
-        , mtsVerifyCompletenessProof = \leaves proof -> do
-            currentRoot <-
-                run
-                    $ runTransactionUnguarded db
-                    $ root hashing StandaloneCSMTCol
-            let computed = foldProof (combineHash hashing) leaves proof
-            pure $ case (currentRoot, computed) of
-                (Just r, Just indirect) ->
-                    rootHash hashing indirect == r
-                _ -> False
-        }
+    hoistMTS
+        (run . runTransactionUnguarded db)
+        (csmtMerkleTreeStoreT fromKV hashing)

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -1,17 +1,32 @@
 -- | MPF implementation of the MTS interface.
 --
 -- Defines @MpfImpl@ phantom type with type family instances
--- and a constructor that wraps MPF operations into
+-- and constructors that wrap MPF operations into
 -- 'MerkleTreeStore'.
+--
+-- Two constructors are provided:
+--
+-- * 'mpfMerkleTreeStoreT' — operations live in the
+--   'Transaction' monad, composable within a single atomic
+--   transaction.
+-- * 'mpfMerkleTreeStore' — convenience wrapper that commits
+--   each operation in its own transaction (suitable for simple
+--   use cases and tests).
 module MPF.MTS
     ( MpfImpl
+    , mpfMerkleTreeStoreT
     , mpfMerkleTreeStore
     )
 where
 
+import Control.Monad.Trans.Class (lift)
 import Data.ByteString (ByteString)
 import Database.KV.Database (Database)
-import Database.KV.Transaction (query, runTransactionUnguarded)
+import Database.KV.Transaction
+    ( Transaction
+    , query
+    , runTransactionUnguarded
+    )
 import MPF.Backend.Standalone
     ( MPFStandalone (..)
     , MPFStandaloneCF
@@ -39,6 +54,7 @@ import MTS.Interface
     , MtsLeaf
     , MtsProof
     , MtsValue
+    , hoistMTS
     )
 
 -- | Phantom type tag for the MPF implementation.
@@ -51,7 +67,95 @@ type instance MtsProof MpfImpl = MPFProof MPFHash
 type instance MtsLeaf MpfImpl = HexIndirect MPFHash
 type instance MtsCompletenessProof MpfImpl = ()
 
--- | Build a 'MerkleTreeStore' for MPF.
+-- | Compute the MPF root hash from the root node.
+mpfRootFromNode
+    :: MPFHashing MPFHash -> HexIndirect MPFHash -> MPFHash
+mpfRootFromNode hashing i =
+    if hexIsLeaf i
+        then leafHash hashing (hexJump i) (hexValue i)
+        else hexValue i
+
+-- | Build a transactional 'MerkleTreeStore' for MPF.
+--
+-- Operations live in the 'Transaction' monad so multiple
+-- calls can be composed into a single atomic transaction:
+--
+-- @
+-- runTransactionUnguarded db $ do
+--     mtsInsert store k1 v1
+--     mtsDelete store k2
+--     mtsRootHash store
+-- @
+mpfMerkleTreeStoreT
+    :: (MonadFail m)
+    => FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> MerkleTreeStore
+        MpfImpl
+        ( Transaction
+            m
+            MPFStandaloneCF
+            (MPFStandalone ByteString ByteString MPFHash)
+            MPFStandaloneOp
+        )
+mpfMerkleTreeStoreT fromKV hashing =
+    MerkleTreeStore
+        { mtsInsert =
+            inserting
+                fromKV
+                hashing
+                MPFStandaloneKVCol
+                MPFStandaloneMPFCol
+        , mtsDelete =
+            deleting
+                fromKV
+                hashing
+                MPFStandaloneKVCol
+                MPFStandaloneMPFCol
+        , mtsRootHash = do
+            mi <- query MPFStandaloneMPFCol ([] :: HexKey)
+            pure $ fmap (mpfRootFromNode hashing) mi
+        , mtsMkProof = \k -> do
+            mp <-
+                mkMPFInclusionProof
+                    fromKV
+                    hashing
+                    MPFStandaloneMPFCol
+                    k
+            case mp of
+                Nothing -> pure Nothing
+                Just proof -> do
+                    mi <-
+                        query MPFStandaloneMPFCol ([] :: HexKey)
+                    pure $ case mi of
+                        Nothing -> Nothing
+                        Just i ->
+                            Just (mpfRootFromNode hashing i, proof)
+        , mtsVerifyProof =
+            verifyMPFInclusionProof
+                fromKV
+                MPFStandaloneMPFCol
+                hashing
+        , mtsFoldProof =
+            foldMPFProof hashing
+        , mtsBatchInsert =
+            insertingBatch
+                fromKV
+                hashing
+                MPFStandaloneKVCol
+                MPFStandaloneMPFCol
+        , mtsCollectLeaves =
+            lift $ fail "MPF completeness proofs not implemented"
+        , mtsMkCompletenessProof =
+            lift $ fail "MPF completeness proofs not implemented"
+        , mtsVerifyCompletenessProof = \_ _ ->
+            lift $ fail "MPF completeness proofs not implemented"
+        }
+
+-- | Build an IO 'MerkleTreeStore' for MPF.
+--
+-- Each operation commits in its own transaction. For atomic
+-- multi-operation sequences, use 'mpfMerkleTreeStoreT' instead.
 mpfMerkleTreeStore
     :: (MonadFail m)
     => (forall b. m b -> IO b)
@@ -64,62 +168,6 @@ mpfMerkleTreeStore
     -> MPFHashing MPFHash
     -> MerkleTreeStore MpfImpl IO
 mpfMerkleTreeStore run db fromKV hashing =
-    MerkleTreeStore
-        { mtsInsert = \k v ->
-            run
-                $ runTransactionUnguarded db
-                $ inserting fromKV hashing MPFStandaloneKVCol MPFStandaloneMPFCol k v
-        , mtsDelete =
-            run
-                . runTransactionUnguarded db
-                . deleting fromKV hashing MPFStandaloneKVCol MPFStandaloneMPFCol
-        , mtsRootHash =
-            run
-                $ runTransactionUnguarded db
-                $ do
-                    mi <- query MPFStandaloneMPFCol ([] :: HexKey)
-                    pure $ case mi of
-                        Nothing -> Nothing
-                        Just i ->
-                            Just
-                                $ if hexIsLeaf i
-                                    then leafHash hashing (hexJump i) (hexValue i)
-                                    else hexValue i
-        , mtsMkProof = \k ->
-            run
-                $ runTransactionUnguarded db
-                $ do
-                    mp <- mkMPFInclusionProof fromKV hashing MPFStandaloneMPFCol k
-                    case mp of
-                        Nothing -> pure Nothing
-                        Just proof -> do
-                            mi <- query MPFStandaloneMPFCol ([] :: HexKey)
-                            pure $ case mi of
-                                Nothing -> Nothing
-                                Just i ->
-                                    let r =
-                                            if hexIsLeaf i
-                                                then leafHash hashing (hexJump i) (hexValue i)
-                                                else hexValue i
-                                    in  Just (r, proof)
-        , mtsVerifyProof = \v proof ->
-            run
-                $ runTransactionUnguarded db
-                $ verifyMPFInclusionProof fromKV MPFStandaloneMPFCol hashing v proof
-        , mtsFoldProof =
-            foldMPFProof hashing
-        , mtsBatchInsert =
-            run
-                . runTransactionUnguarded db
-                . insertingBatch
-                    fromKV
-                    hashing
-                    MPFStandaloneKVCol
-                    MPFStandaloneMPFCol
-        , mtsCollectLeaves =
-            fail "MPF completeness proofs not implemented"
-        , mtsMkCompletenessProof =
-            fail "MPF completeness proofs not implemented"
-        , mtsVerifyCompletenessProof = \_ _ ->
-            fail "MPF completeness proofs not implemented"
-        }
+    hoistMTS
+        (run . runTransactionUnguarded db)
+        (mpfMerkleTreeStoreT fromKV hashing)

--- a/lib/mts/MTS/Interface.hs
+++ b/lib/mts/MTS/Interface.hs
@@ -6,6 +6,7 @@
 -- by just the implementation tag and the monad.
 module MTS.Interface
     ( MerkleTreeStore (..)
+    , hoistMTS
     , MtsKey
     , MtsValue
     , MtsHash
@@ -61,3 +62,25 @@ data MerkleTreeStore imp m = MerkleTreeStore
         -> m Bool
     -- ^ Verify a completeness proof against leaves
     }
+
+-- | Transform the monad of a 'MerkleTreeStore' via a natural
+-- transformation. Use this to run a transactional store in 'IO'
+-- by supplying @run . runTransactionUnguarded db@.
+hoistMTS
+    :: (forall a. m a -> n a)
+    -> MerkleTreeStore imp m
+    -> MerkleTreeStore imp n
+hoistMTS f s =
+    MerkleTreeStore
+        { mtsInsert = \k v -> f (mtsInsert s k v)
+        , mtsDelete = f . mtsDelete s
+        , mtsRootHash = f (mtsRootHash s)
+        , mtsMkProof = f . mtsMkProof s
+        , mtsVerifyProof = \v p -> f (mtsVerifyProof s v p)
+        , mtsFoldProof = mtsFoldProof s
+        , mtsBatchInsert = f . mtsBatchInsert s
+        , mtsCollectLeaves = f (mtsCollectLeaves s)
+        , mtsMkCompletenessProof = f (mtsMkCompletenessProof s)
+        , mtsVerifyCompletenessProof =
+            \ls p -> f (mtsVerifyCompletenessProof s ls p)
+        }


### PR DESCRIPTION
## Summary

- Add `hoistMTS` to `MTS.Interface` — natural transformation over the record monad
- Add `csmtMerkleTreeStoreT` and `mpfMerkleTreeStoreT` returning `MerkleTreeStore impl (Transaction ...)` so consumers can compose multiple operations into a single atomic transaction
- Rewrite `csmtMerkleTreeStore` and `mpfMerkleTreeStore` as `hoistMTS (run . runTransactionUnguarded db)` over the transactional versions

Closes #66

## Test plan

- [x] All 183 unit tests pass
- [x] `just ci` green (hlint, fourmolu, build, tests)