### PR TITLE
feat: completeness proofs with prefix inclusion

### DIFF
--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -34,9 +34,9 @@ import CSMT.Interface
     , root
     )
 import CSMT.Proof.Completeness
-    ( CompletenessProof
+    ( CompletenessProof (..)
     , collectValues
-    , foldProof
+    , foldCompletenessProof
     , generateProof
     )
 import CSMT.Proof.Insertion
@@ -70,7 +70,7 @@ type instance MtsValue CsmtImpl = ByteString
 type instance MtsHash CsmtImpl = Hash
 type instance MtsProof CsmtImpl = InclusionProof Hash
 type instance MtsLeaf CsmtImpl = Indirect Hash
-type instance MtsCompletenessProof CsmtImpl = CompletenessProof
+type instance MtsCompletenessProof CsmtImpl = CompletenessProof Hash
 
 -- | Build a transactional 'MerkleTreeStore' for CSMT.
 --
@@ -141,10 +141,10 @@ csmtMerkleTreeStoreT fromKV hashing =
         , mtsVerifyCompletenessProof = \leaves proof -> do
             currentRoot <- root hashing StandaloneCSMTCol
             let computed =
-                    foldProof (combineHash hashing) leaves proof
+                    foldCompletenessProof hashing [] leaves proof
             pure $ case (currentRoot, computed) of
-                (Just r, Just indirect) ->
-                    rootHash hashing indirect == r
+                (Just r, Just computedRoot) ->
+                    computedRoot == r
                 _ -> False
         }
 

--- a/lib/csmt/CSMT/Proof/Completeness.hs
+++ b/lib/csmt/CSMT/Proof/Completeness.hs
@@ -6,15 +6,22 @@
 -- Copyright   : (c) Paolo Veronelli, 2024
 -- License     : Apache-2.0
 --
--- This module provides functionality for completeness proofs - proving
--- that a set of values comprises the entire tree contents.
+-- This module provides completeness proofs - proving that a set of
+-- values comprises ALL leaves under a given prefix in the tree.
 --
--- A completeness proof is a sequence of merge operations that, when
--- applied to a list of leaf values, produces the root hash. This allows
--- clients to verify they have received all values in the tree.
+-- A completeness proof contains:
+--
+-- * Merge operations that reconstruct the subtree root from leaves
+-- * Inclusion proof steps anchoring the subtree root to the tree root
+--
+-- The verifier provides the prefix and a trusted root hash. The fold
+-- function derives the root jump internally from the prefix, the
+-- subtree jump (from the merge ops result), and the step consumed
+-- counts.
 module CSMT.Proof.Completeness
-    ( CompletenessProof
-    , foldProof
+    ( CompletenessProof (..)
+    , foldCompletenessProof
+    , foldMergeOps
     , collectValues
     , generateProof
     , queryPrefix
@@ -23,11 +30,15 @@ where
 
 import CSMT.Interface
     ( Direction (..)
+    , Hashing (..)
     , Indirect (..)
     , Key
+    , addWithDirection
     , compareKeys
+    , oppositeDirection
     , prefix
     )
+import CSMT.Proof.Insertion (ProofStep (..))
 import Data.Map.Strict qualified as Map
 import Database.KV.Transaction
     ( GCompare
@@ -37,33 +48,38 @@ import Database.KV.Transaction
     )
 
 -- |
--- A completeness proof as a sequence of merge operations.
+-- A completeness proof for a subtree under a given prefix.
 --
--- Each pair (i, j) indicates that values at indices i and j should be
--- combined to produce a parent hash. The final result should match the root.
-type CompletenessProof = [(Int, Int)]
+-- Contains merge operations to reconstruct the subtree root from
+-- leaves, and inclusion steps to anchor the subtree root to the
+-- tree root. The prefix is not stored — the verifier already knows
+-- it. The root jump is derived during verification.
+data CompletenessProof a = CompletenessProof
+    { cpMergeOps :: [(Int, Int)]
+    -- ^ Merge operations: each @(i, j)@ combines leaves at those
+    -- indices. Applied to the leaf list, these reconstruct the
+    -- subtree root.
+    , cpInclusionSteps :: [ProofStep a]
+    -- ^ Inclusion proof steps from the subtree root outward to
+    -- the tree root. Empty when the prefix covers the whole tree
+    -- (prefix = []) or when the root jump subsumes the prefix.
+    }
+    deriving (Show, Eq)
 
 -- | A function to compose two indirect values into a combined hash.
 type Compose a = Indirect a -> Indirect a -> a
 
 -- |
--- Verify a completeness proof by folding the merge operations.
+-- Fold merge operations over a list of leaves.
 --
--- Takes a list of leaf values and applies the proof's merge operations
--- to compute the root. Returns 'Nothing' if the proof is invalid.
---
--- This function is intended for client-side verification where the client
--- receives the list of all values and the proof.
-foldProof
+-- Returns the subtree root as an 'Indirect', or 'Nothing' if the
+-- proof is invalid (e.g. key comparison fails).
+foldMergeOps
     :: Compose a
-    -- ^ Function to compose two Indirect values
     -> [Indirect a]
-    -- ^ List of indirect values (leaves of the CSMT)
-    -> CompletenessProof
-    -- ^ Proof steps (merge operations to apply)
+    -> [(Int, Int)]
     -> Maybe (Indirect a)
-    -- ^ Computed root, or Nothing if proof is invalid
-foldProof compose values = go (Map.fromList $ zip [0 ..] values)
+foldMergeOps compose values = go (Map.fromList $ zip [0 ..] values)
   where
     go m [] = Just $ m Map.! 0
     go m ((i, j) : xs) =
@@ -85,9 +101,78 @@ foldProof compose values = go (Map.fromList $ zip [0 ..] values)
                         go m' xs
                 _ -> Nothing
 
--- | Error type for malformed trees (unused, kept for documentation).
-data TreeWithDifferentLengthsError = TreeWithDifferentLengthsError
-    deriving (Show)
+-- |
+-- Verify a completeness proof by computing the tree root hash.
+--
+-- The verifier provides the prefix (which they chose) and the
+-- leaves (which they received). The root jump is derived from
+-- the prefix, the subtree jump, and the inclusion step consumed
+-- counts.
+--
+-- Returns 'Nothing' if the proof is malformed.
+foldCompletenessProof
+    :: Hashing a
+    -> Key
+    -- ^ The prefix this proof covers (verifier provides this)
+    -> [Indirect a]
+    -- ^ Leaves under the prefix
+    -> CompletenessProof a
+    -> Maybe a
+    -- ^ Computed tree root hash
+foldCompletenessProof
+    hashing
+    prefixKey
+    leaves
+    CompletenessProof{cpMergeOps, cpInclusionSteps} = do
+        subtreeRoot <- case leaves of
+            [single] | null cpMergeOps -> Just single
+            _ -> foldMergeOps (combineHash hashing) leaves cpMergeOps
+        let Indirect subtreeJump subtreeValue = subtreeRoot
+            fullKey = prefixKey ++ subtreeJump
+            totalConsumed =
+                sum (map stepConsumed cpInclusionSteps)
+            rootJumpLen = length fullKey - totalConsumed
+            rootJump = take rootJumpLen fullKey
+            keyAfterRoot = drop rootJumpLen fullKey
+            rootValue =
+                foldInclusionSteps
+                    hashing
+                    subtreeValue
+                    (reverse keyAfterRoot)
+                    cpInclusionSteps
+        pure $ rootHash hashing (Indirect rootJump rootValue)
+
+-- |
+-- Fold inclusion steps from subtree outward to root.
+--
+-- Consumes key bits in reverse (from subtree toward root) and
+-- combines with sibling hashes at each level. Same logic as
+-- 'computeRootHash' from "CSMT.Proof.Insertion".
+foldInclusionSteps
+    :: Hashing a -> a -> Key -> [ProofStep a] -> a
+foldInclusionSteps _ acc _ [] = acc
+foldInclusionSteps
+    hashing
+    acc
+    revKey
+    (ProofStep{stepConsumed, stepSibling} : rest) =
+        let (consumedRev, remainingRev) = splitAt stepConsumed revKey
+            consumed = reverse consumedRev
+        in  case consumed of
+                (direction : stepJump) ->
+                    foldInclusionSteps
+                        hashing
+                        ( addWithDirection
+                            hashing
+                            direction
+                            (Indirect stepJump acc)
+                            stepSibling
+                        )
+                        remainingRev
+                        rest
+                [] ->
+                    error
+                        "foldInclusionSteps: invalid step with zero consumed bits"
 
 -- |
 -- Collect all leaf values from a subtree rooted at a prefix.
@@ -135,29 +220,38 @@ collectValues sel = navigate []
 -- |
 -- Generate a completeness proof for a subtree rooted at a prefix.
 --
--- Navigates from the tree root to the target prefix, then generates
--- a sequence of merge operations that, when applied to the collected
--- leaf values, will produce the subtree root hash.
+-- Navigates from the tree root to the target prefix, collecting
+-- inclusion proof steps (sibling hashes) at each branch. Then
+-- generates merge operations for the subtree below the prefix.
 generateProof
     :: forall m d a cf op
      . (Monad m, GCompare d)
     => Selector d Key (Indirect a)
     -> Key
-    -> Transaction m cf d op (Maybe CompletenessProof)
-generateProof sel targetPrefix =
-    fmap fst <$> navigate 0 [] targetPrefix
+    -> Transaction m cf d op (Maybe (CompletenessProof a))
+generateProof sel targetPrefix = do
+    result <- navigate 0 [] targetPrefix []
+    pure $ case result of
+        Nothing -> Nothing
+        Just (mergeOps, _, inclusionSteps) ->
+            Just
+                CompletenessProof
+                    { cpMergeOps = mergeOps
+                    , cpInclusionSteps = reverse inclusionSteps
+                    }
   where
     navigate
         :: Int
         -> Key
         -> Key
+        -> [ProofStep a]
         -> Transaction
             m
             cf
             d
             op
-            (Maybe (CompletenessProof, (Int, Int)))
-    navigate n currentKey remainingPrefix = do
+            (Maybe ([(Int, Int)], (Int, Int), [ProofStep a]))
+    navigate n currentKey remainingPrefix steps = do
         mi <- query sel currentKey
         case mi of
             Nothing -> pure Nothing
@@ -165,15 +259,51 @@ generateProof sel targetPrefix =
                 let (_, prefixRest, jumpRest) =
                         compareKeys remainingPrefix fullJump
                 in  case prefixRest of
-                        -- Prefix consumed: generate proof below
-                        [] -> go n currentKey fullJump
+                        -- Prefix consumed: generate merge ops below
+                        [] -> do
+                            r <- go n currentKey fullJump
+                            pure $ case r of
+                                Nothing -> Nothing
+                                Just (ops, idx) ->
+                                    Just (ops, idx, steps)
                         -- Jump consumed, prefix continues
                         (d : rest)
-                            | null jumpRest ->
-                                navigate
-                                    n
-                                    (currentKey <> fullJump <> [d])
-                                    rest
+                            | null jumpRest -> do
+                                -- Collect sibling for inclusion proof
+                                let sibKey =
+                                        currentKey
+                                            <> fullJump
+                                            <> [oppositeDirection d]
+                                msib <- query sel sibKey
+                                case msib of
+                                    Nothing -> pure Nothing
+                                    Just sib -> do
+                                        -- Query child to get its jump
+                                        let childKey =
+                                                currentKey
+                                                    <> fullJump
+                                                    <> [d]
+                                        mchild <- query sel childKey
+                                        case mchild of
+                                            Nothing -> pure Nothing
+                                            Just (Indirect childJump _) ->
+                                                let step =
+                                                        ProofStep
+                                                            { stepConsumed =
+                                                                1
+                                                                    + length
+                                                                        childJump
+                                                            , stepSibling =
+                                                                sib
+                                                            }
+                                                in  navigate
+                                                        n
+                                                        ( currentKey
+                                                            <> fullJump
+                                                            <> [d]
+                                                        )
+                                                        rest
+                                                        (step : steps)
                             -- Divergence: no entries under this prefix
                             | otherwise -> pure Nothing
     go
@@ -185,9 +315,9 @@ generateProof sel targetPrefix =
             cf
             d
             op
-            (Maybe (CompletenessProof, (Int, Int)))
-    go n key jump = do
-        let base = key <> jump
+            (Maybe ([(Int, Int)], (Int, Int)))
+    go n key jmp = do
+        let base = key <> jmp
             leftKey = base <> [L]
             rightKey = base <> [R]
         ml <- goChild n leftKey
@@ -213,12 +343,12 @@ generateProof sel targetPrefix =
             cf
             d
             op
-            (Maybe (CompletenessProof, (Int, Int)))
+            (Maybe ([(Int, Int)], (Int, Int)))
     goChild n key = do
         mi <- query sel key
         case mi of
             Nothing -> pure Nothing
-            Just (Indirect jump _) -> go n key jump
+            Just (Indirect jmp _) -> go n key jmp
 
 -- |
 -- Query the effective subtree root at a prefix.

--- a/lib/mpf/MPF/Insertion.hs
+++ b/lib/mpf/MPF/Insertion.hs
@@ -9,6 +9,7 @@ module MPF.Insertion
     , insertingStream
     , mkMPFCompose
     , scanMPFCompose
+    , fetchChildTree
     , MPFCompose (..)
     )
 where

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -34,11 +34,16 @@ import MPF.Backend.Standalone
     )
 import MPF.Deletion (deleting)
 import MPF.Hashes (MPFHash, MPFHashing (..))
-import MPF.Insertion (inserting, insertingBatch)
+import MPF.Insertion (MPFCompose, inserting, insertingBatch)
 import MPF.Interface
     ( FromHexKV (..)
     , HexIndirect (..)
     , HexKey
+    )
+import MPF.Proof.Completeness
+    ( collectMPFLeaves
+    , foldMPFCompletenessProof
+    , generateMPFCompletenessProof
     )
 import MPF.Proof.Insertion
     ( MPFProof
@@ -65,7 +70,7 @@ type instance MtsValue MpfImpl = ByteString
 type instance MtsHash MpfImpl = MPFHash
 type instance MtsProof MpfImpl = MPFProof MPFHash
 type instance MtsLeaf MpfImpl = HexIndirect MPFHash
-type instance MtsCompletenessProof MpfImpl = ()
+type instance MtsCompletenessProof MpfImpl = MPFCompose MPFHash
 
 -- | Compute the MPF root hash from the root node.
 mpfRootFromNode
@@ -145,11 +150,18 @@ mpfMerkleTreeStoreT fromKV hashing =
                 MPFStandaloneKVCol
                 MPFStandaloneMPFCol
         , mtsCollectLeaves =
-            lift $ fail "MPF completeness proofs not implemented"
+            collectMPFLeaves MPFStandaloneMPFCol
         , mtsMkCompletenessProof =
-            lift $ fail "MPF completeness proofs not implemented"
-        , mtsVerifyCompletenessProof = \_ _ ->
-            lift $ fail "MPF completeness proofs not implemented"
+            generateMPFCompletenessProof MPFStandaloneMPFCol
+        , mtsVerifyCompletenessProof = \leaves proof -> do
+            mi <- query MPFStandaloneMPFCol ([] :: HexKey)
+            let currentRoot = fmap (mpfRootFromNode hashing) mi
+                computed =
+                    foldMPFCompletenessProof hashing leaves proof
+            pure $ case (currentRoot, computed) of
+                (Just r, Just computedRoot) ->
+                    computedRoot == r
+                _ -> False
         }
 
 -- | Build an IO 'MerkleTreeStore' for MPF.

--- a/lib/mpf/MPF/Proof/Completeness.hs
+++ b/lib/mpf/MPF/Proof/Completeness.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Module      : MPF.Proof.Completeness
+-- Description : Completeness proofs for MPFs
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- This module provides completeness proofs for Merkle Patricia
+-- Forests. A completeness proof proves that a set of leaves
+-- comprises ALL leaves in the tree.
+--
+-- The proof is an 'MPFCompose' tree structure that can be scanned
+-- to recompute the root hash. The verifier checks that the leaves
+-- in the proof match the provided leaves, and that the computed
+-- root hash matches the trusted root.
+module MPF.Proof.Completeness
+    ( collectMPFLeaves
+    , generateMPFCompletenessProof
+    , foldMPFCompletenessProof
+    , extractLeaves
+    )
+where
+
+import Data.List (sort)
+import Data.Map.Strict qualified as Map
+import Database.KV.Transaction
+    ( GCompare
+    , Selector
+    , Transaction
+    , query
+    )
+import MPF.Hashes (MPFHashing (..))
+import MPF.Insertion (MPFCompose (..), fetchChildTree, scanMPFCompose)
+import MPF.Interface
+    ( HexDigit (..)
+    , HexIndirect (..)
+    , HexKey
+    , mkLeafIndirect
+    , prefixHex
+    )
+
+-- |
+-- Collect all leaf values from the MPF trie.
+--
+-- Returns leaves with their full key path as 'hexJump' and
+-- their value hash as 'hexValue'.
+collectMPFLeaves
+    :: (Monad m, GCompare d)
+    => Selector d HexKey (HexIndirect a)
+    -> Transaction m cf d op [HexIndirect a]
+collectMPFLeaves sel = navigate []
+  where
+    navigate currentKey = do
+        mi <- query sel currentKey
+        case mi of
+            Nothing -> pure []
+            Just HexIndirect{hexJump, hexValue, hexIsLeaf}
+                | hexIsLeaf ->
+                    pure [mkLeafIndirect hexJump hexValue]
+                | otherwise -> do
+                    let base = currentKey <> hexJump
+                    concat
+                        <$> mapM
+                            ( \d -> do
+                                cs <- navigate (base <> [d])
+                                pure
+                                    $ map
+                                        (prefixHex (hexJump ++ [d]))
+                                        cs
+                            )
+                            allDigits
+    allDigits = [HexDigit n | n <- [0 .. 15]]
+
+-- |
+-- Generate a completeness proof for the entire MPF trie.
+--
+-- Returns the trie as an 'MPFCompose' tree, or 'Nothing' if
+-- the tree is empty.
+generateMPFCompletenessProof
+    :: (Monad m, GCompare d)
+    => Selector d HexKey (HexIndirect a)
+    -> Transaction m cf d op (Maybe (MPFCompose a))
+generateMPFCompletenessProof sel = do
+    mi <- query sel []
+    case mi of
+        Nothing -> pure Nothing
+        Just HexIndirect{hexJump, hexValue, hexIsLeaf}
+            | hexIsLeaf ->
+                pure
+                    $ Just
+                    $ MPFComposeLeaf
+                    $ mkLeafIndirect hexJump hexValue
+            | otherwise -> do
+                children <- fetchChildTree sel hexJump
+                pure $ Just $ MPFComposeBranch hexJump children
+
+-- |
+-- Verify a completeness proof by computing the tree root hash.
+--
+-- Extracts leaves from the proof, checks they match the provided
+-- leaves (sorted), then scans the proof tree to compute the root
+-- hash. Returns 'Nothing' if the leaves do not match.
+foldMPFCompletenessProof
+    :: (Ord a)
+    => MPFHashing a
+    -> [HexIndirect a]
+    -> MPFCompose a
+    -> Maybe a
+foldMPFCompletenessProof hashing leaves proof =
+    let extracted = extractLeaves proof
+        (rootIndirect, _) = scanMPFCompose hashing proof
+        computedRoot = hexValue rootIndirect
+    in  if sort extracted == sort leaves
+            then Just computedRoot
+            else Nothing
+
+-- |
+-- Extract all leaves from an 'MPFCompose' tree with their full
+-- key paths reconstructed.
+extractLeaves :: MPFCompose a -> [HexIndirect a]
+extractLeaves = go []
+  where
+    go pfx (MPFComposeLeaf HexIndirect{hexJump, hexValue}) =
+        [mkLeafIndirect (pfx ++ hexJump) hexValue]
+    go pfx (MPFComposeBranch jmp children) =
+        concatMap
+            (\(d, c) -> go (pfx ++ jmp ++ [d]) c)
+            (Map.toList children)

--- a/mts.cabal
+++ b/mts.cabal
@@ -128,6 +128,7 @@ library mpf
     MPF.Insertion
     MPF.Interface
     MPF.MTS
+    MPF.Proof.Completeness
     MPF.Proof.Insertion
 
   build-depends:

--- a/test/CSMT/Proof/CompletenessSpec.hs
+++ b/test/CSMT/Proof/CompletenessSpec.hs
@@ -6,15 +6,16 @@ where
 import CSMT
     ( Direction (..)
     , Standalone (StandaloneCSMTCol)
-    , combineHash
     )
 import CSMT.Backend.Pure
     ( runPureTransaction
     )
 import CSMT.Hashes (hashHashing)
+import CSMT.Interface (Hashing (..))
 import CSMT.Proof.Completeness
-    ( collectValues
-    , foldProof
+    ( CompletenessProof (..)
+    , collectValues
+    , foldCompletenessProof
     , generateProof
     )
 import CSMT.Test.Lib
@@ -72,7 +73,7 @@ spec = do
                     runPureTransaction word64Codecs
                         $ generateProof StandaloneCSMTCol []
               in
-                mp `shouldBe` Just []
+                fmap cpMergeOps mp `shouldBe` Just []
         it "can generate proof for larger tree"
             $ let
                 mp = evalPureFromEmptyDB $ do
@@ -83,7 +84,7 @@ spec = do
                     runPureTransaction word64Codecs
                         $ generateProof StandaloneCSMTCol []
               in
-                mp `shouldBe` Just [(0, 1)]
+                fmap cpMergeOps mp `shouldBe` Just [(0, 1)]
         it "can generate proof for even larger tree"
             $ let
                 mp = evalPureFromEmptyDB $ do
@@ -96,7 +97,8 @@ spec = do
                     runPureTransaction word64Codecs
                         $ generateProof StandaloneCSMTCol []
               in
-                mp `shouldBe` Just [(1, 2), (0, 1), (0, 3)]
+                fmap cpMergeOps mp
+                    `shouldBe` Just [(1, 2), (0, 1), (0, 3)]
     describe "verifyProof" $ do
         it "can verify completeness proof for larger tree"
             $ let
@@ -118,9 +120,15 @@ spec = do
               in
                 case mp of
                     Nothing -> error "expected a proof"
-                    Just proof -> do
-                        foldProof (combineHash word64Hashing) values proof
-                            `shouldBe` r
+                    Just proof ->
+                        foldCompletenessProof
+                            word64Hashing
+                            []
+                            values
+                            proof
+                            `shouldBe` fmap
+                                (rootHash word64Hashing)
+                                r
         it "can verify completeness proof for random trees"
             $ property
             $ forAll manyRandomPaths
@@ -137,9 +145,15 @@ spec = do
                         return (mp', r')
                 case mp of
                     Nothing -> error "expected a proof"
-                    Just proof -> do
-                        foldProof (combineHash word64Hashing) (sort values) proof
-                            `shouldBe` r
+                    Just proof ->
+                        foldCompletenessProof
+                            word64Hashing
+                            []
+                            (sort values)
+                            proof
+                            `shouldBe` fmap
+                                (rootHash word64Hashing)
+                                r
         it "can verify completeness proof for random trees of hashes"
             $ property
             $ forAll manyRandomPaths
@@ -156,6 +170,12 @@ spec = do
                         return (mp', r')
                 case mp of
                     Nothing -> error "expected a proof"
-                    Just proof -> do
-                        foldProof (combineHash hashHashing) (sort values) proof
-                            `shouldBe` r
+                    Just proof ->
+                        foldCompletenessProof
+                            hashHashing
+                            []
+                            (sort values)
+                            proof
+                            `shouldBe` fmap
+                                (rootHash hashHashing)
+                                r

--- a/test/CSMT/TreePrefixSpec.hs
+++ b/test/CSMT/TreePrefixSpec.hs
@@ -8,7 +8,6 @@ import CSMT
     , Indirect (..)
     , Key
     , Standalone (StandaloneCSMTCol)
-    , combineHash
     )
 import CSMT.Backend.Pure
     ( InMemoryDB
@@ -17,10 +16,10 @@ import CSMT.Backend.Pure
     , runPure
     , runPureTransaction
     )
-import CSMT.Interface (FromKV (..))
+import CSMT.Interface (FromKV (..), Hashing (..))
 import CSMT.Proof.Completeness
     ( collectValues
-    , foldProof
+    , foldCompletenessProof
     , generateProof
     , queryPrefix
     )
@@ -266,27 +265,36 @@ spec = do
                 forAll (genSomePaths n) $ \keys -> do
                     let kvs = zip keys [1 :: Word64 ..]
                         db = foldl' (\d (k, v) -> insertP k v d) emptyInMemoryDB kvs
-                        verify p =
+                        treeRoot =
+                            fst
+                                $ runPure db
+                                $ runPureTransaction word64Codecs
+                                $ queryPrefix StandaloneCSMTCol []
+                        verifyP p =
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
                                 $ do
                                     c <- collectValues StandaloneCSMTCol p
                                     pr <- generateProof StandaloneCSMTCol p
-                                    r <- queryPrefix StandaloneCSMTCol p
-                                    pure (c, pr, r)
+                                    pure (c, pr)
                     -- Verify both [L] and [R] subtrees
                     mapM_
                         ( \p -> do
-                            let (collected, proof, subtreeRoot) = verify p
+                            let (collected, proof) = verifyP p
                             case proof of
                                 Nothing -> collected `shouldBe` []
                                 Just pr ->
-                                    foldProof
-                                        (combineHash word64Hashing)
+                                    foldCompletenessProof
+                                        word64Hashing
+                                        p
                                         (sort collected)
                                         pr
-                                        `shouldBe` subtreeRoot
+                                        `shouldBe` fmap
+                                            ( rootHash
+                                                word64Hashing
+                                            )
+                                            treeRoot
                         )
                         ([[L], [R]] :: [Key])
 
@@ -297,7 +305,7 @@ spec = do
                 forAll (genSomePaths n) $ \keys -> do
                     let kvs = zip keys [1 :: Word64 ..]
                         db = foldl' (\d (k, v) -> insertP k v d) emptyInMemoryDB kvs
-                        (collected, proof, root) =
+                        (collected, proof, treeRoot) =
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
@@ -309,11 +317,14 @@ spec = do
                     case proof of
                         Nothing -> collected `shouldBe` []
                         Just p ->
-                            foldProof
-                                (combineHash word64Hashing)
+                            foldCompletenessProof
+                                word64Hashing
+                                []
                                 (sort collected)
                                 p
-                                `shouldBe` root
+                                `shouldBe` fmap
+                                    (rootHash word64Hashing)
+                                    treeRoot
 
         it "generateProof is Nothing iff collectValues is empty"
             $ property

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -31,7 +31,7 @@ import MPF.Interface (FromHexKV (..), byteStringToHexKey)
 import MPF.MTS (MpfImpl, mpfMerkleTreeStore)
 import MTS.Interface (MerkleTreeStore)
 import MTS.Properties
-import Test.Hspec (Spec, describe, it, pending)
+import Test.Hspec (Spec, describe, it)
 import Test.QuickCheck
     ( Gen
     , arbitrary
@@ -176,6 +176,9 @@ spec = do
             $ propWrongValueRejects mkMpfStore genBSTriple
         it "proof anchored to root"
             $ propProofAnchoredToRoot mkMpfStore genBSPair
-        it "completeness round-trip" pending
-        it "completeness empty" pending
-        it "completeness after delete" pending
+        it "completeness round-trip"
+            $ propCompletenessRoundTrip mkMpfStore genBSPairs
+        it "completeness empty"
+            $ propCompletenessEmpty mkMpfStore
+        it "completeness after delete"
+            $ propCompletenessAfterDelete mkMpfStore genBSPairs


### PR DESCRIPTION
## Summary

- **CSMT**: Replace `CompletenessProof = [(Int, Int)]` type alias with a proper data type containing merge operations (`cpMergeOps`) and inclusion proof steps (`cpInclusionSteps`). `generateProof` now collects sibling hashes during navigation from root to prefix. `foldCompletenessProof` derives the root jump internally — no redundant data in the proof.
- **MPF**: New `MPF.Proof.Completeness` module using `MPFCompose` as the proof structure. `collectMPFLeaves` traverses the trie, `generateMPFCompletenessProof` builds the compose tree, `foldMPFCompletenessProof` verifies by extracting leaves and scanning to compute root hash.
- Both implementations wired into their respective MTS adapters. All 3 MPF completeness tests enabled (previously `pending`).

Closes #58

## Test plan

- [x] All 183 tests pass (0 failures)
- [x] CSMT completeness tests verify prefix inclusion steps
- [x] MPF completeness round-trip, empty, and after-delete tests pass
- [x] Format check and hlint clean