### PR TITLE
feat: prefix-scoped MPF operations for dynamic namespaces

### DIFF
--- a/bench/mpf-bench-rocksdb.hs
+++ b/bench/mpf-bench-rocksdb.hs
@@ -74,7 +74,7 @@ isoMPFHash = iso parseMPFHashUnsafe renderMPFHash
         Nothing -> mkMPFHash bs
 
 fromHexKVIdentity :: FromHexKV HexKey MPFHash MPFHash
-fromHexKVIdentity = FromHexKV{fromHexK = id, fromHexV = id}
+fromHexKVIdentity = FromHexKV{fromHexK = id, fromHexV = id, hexTreePrefix = const []}
 
 -- | Insert using streaming with RocksDB
 insertAllRocksDB
@@ -91,6 +91,7 @@ insertAllRocksDB chunkSize testData dbPath = do
             let kvs = [(byteStringToHexKey k, mkMPFHash v) | (k, v) <- chunk]
             runTransactionUnguarded db
                 $ insertingStream
+                    []
                     fromHexKVIdentity
                     mpfHashing
                     MPFStandaloneKVCol
@@ -191,6 +192,7 @@ verifyKeys dbPath kvs = do
         runTransactionUnguarded db $ do
             mProof <-
                 mkMPFInclusionProof
+                    []
                     fromHexKVIdentity
                     mpfHashing
                     MPFStandaloneMPFCol
@@ -199,6 +201,7 @@ verifyKeys dbPath kvs = do
                 Nothing -> pure False
                 Just proof ->
                     verifyMPFInclusionProof
+                        []
                         fromHexKVIdentity
                         MPFStandaloneMPFCol
                         mpfHashing

--- a/lib/mpf/MPF/Deletion.hs
+++ b/lib/mpf/MPF/Deletion.hs
@@ -5,10 +5,11 @@ module MPF.Deletion
     , newMPFDeletionPath
     , MPFDeletionPath (..)
     , deletionPathToOps
+    , deleteSubtree
     )
 where
 
-import Control.Monad (guard)
+import Control.Monad (guard, unless)
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -43,27 +44,30 @@ data MPFDeletionPath a where
         -> MPFDeletionPath a
     deriving (Show, Eq)
 
--- | Delete a key from the MPF structure
+-- | Delete a key from the MPF structure.
+-- The prefix scopes the operation to a subtree.
 deleting
     :: (Monad m, Ord k, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> MPFHashing a
     -> Selector d k v
     -> Selector d HexKey (HexIndirect a)
     -> k
     -> Transaction m cf d ops ()
-deleting FromHexKV{fromHexK, hexTreePrefix} hashing kvSel mpfSel key = do
+deleting prefix FromHexKV{fromHexK, hexTreePrefix} hashing kvSel mpfSel key = do
     mv <- query kvSel key
     case mv of
         Nothing -> pure ()
         Just v -> do
             let treeKey = hexTreePrefix v <> fromHexK key
-            mpath <- newMPFDeletionPath mpfSel treeKey
+            mpath <- newMPFDeletionPath prefix mpfSel treeKey
             case mpath of
                 Nothing -> pure ()
                 Just path -> do
                     delete kvSel key
-                    mapM_ (applyOp mpfSel) $ deletionPathToOps hashing path
+                    mapM_ (applyOp mpfSel) $ deletionPathToOps prefix hashing path
 
 -- | Apply a single deletion operation
 applyOp
@@ -74,13 +78,16 @@ applyOp
 applyOp mpfSel (k, Nothing) = delete mpfSel k
 applyOp mpfSel (k, Just i) = insert mpfSel k i
 
--- | Convert a deletion path to database operations
+-- | Convert a deletion path to database operations.
+-- The prefix determines where storage keys are rooted.
 deletionPathToOps
     :: forall a
-     . MPFHashing a
+     . HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> MPFHashing a
     -> MPFDeletionPath a
     -> [(HexKey, Maybe (HexIndirect a))]
-deletionPathToOps hashing@MPFHashing{leafHash} = snd . go []
+deletionPathToOps prefix hashing@MPFHashing{leafHash} = snd . go prefix
   where
     -- \| Compute the NODE hash from a HexIndirect
     -- Leaf: compute leafHash from value hash
@@ -162,14 +169,17 @@ deletionPathToOps hashing@MPFHashing{leafHash} = snd . go []
                                     , [(k, Just i''), (k <> j <> [d], Nothing)] <> ops
                                     )
 
--- | Build a deletion path by traversing the trie
+-- | Build a deletion path by traversing the trie.
+-- The prefix scopes the query to a subtree.
 newMPFDeletionPath
     :: forall a d ops cf m
      . (Monad m, GCompare d)
-    => Selector d HexKey (HexIndirect a)
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> Selector d HexKey (HexIndirect a)
     -> HexKey
     -> Transaction m cf d ops (Maybe (MPFDeletionPath a))
-newMPFDeletionPath mpfSel = runMaybeT . go []
+newMPFDeletionPath prefix mpfSel = runMaybeT . go prefix
   where
     go
         :: HexKey
@@ -189,6 +199,27 @@ newMPFDeletionPath mpfSel = runMaybeT . go []
                 subpath <- go (current' <> [r]) remaining''
                 pure $ MPFDPBranch j r subpath siblings
 
+-- | Delete all nodes under a prefix (entire namespace).
+-- Walks the trie from @prefix@, deleting every node encountered.
+deleteSubtree
+    :: (Monad m, GCompare d)
+    => Selector d HexKey (HexIndirect a)
+    -> HexKey
+    -> Transaction m cf d ops ()
+deleteSubtree mpfSel = go
+  where
+    go current = do
+        mi <- query mpfSel current
+        case mi of
+            Nothing -> pure ()
+            Just HexIndirect{hexJump, hexIsLeaf} -> do
+                delete mpfSel current
+                unless hexIsLeaf $ do
+                    let base = current <> hexJump
+                    mapM_
+                        (\d -> go (base <> [d]))
+                        [HexDigit n | n <- [0 .. 15]]
+
 -- | Fetch all sibling nodes at a branch point (excluding the given digit)
 fetchSiblings
     :: (Monad m, GCompare d)
@@ -196,11 +227,11 @@ fetchSiblings
     -> HexKey
     -> HexDigit
     -> Transaction m cf d ops (Map HexDigit (HexIndirect a))
-fetchSiblings mpfSel prefix exclude = do
+fetchSiblings mpfSel pfx exclude = do
     let digits = [HexDigit n | n <- [0 .. 15], HexDigit n /= exclude]
     pairs <- mapM fetchOne digits
     pure $ Map.fromList [(d, i) | (d, Just i) <- pairs]
   where
     fetchOne d = do
-        mi <- query mpfSel (prefix <> [d])
+        mi <- query mpfSel (pfx <> [d])
         pure (d, mi)

--- a/lib/mpf/MPF/Insertion.hs
+++ b/lib/mpf/MPF/Insertion.hs
@@ -44,34 +44,41 @@ data MPFCompose a
       MPFComposeBranch HexKey (Map HexDigit (MPFCompose a))
     deriving (Show, Eq)
 
--- | Insert a key-value pair into the MPF structure
+-- | Insert a key-value pair into the MPF structure.
+-- The prefix scopes the operation to a subtree.
 inserting
     :: (Monad m, Ord k, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> MPFHashing a
     -> Selector d k v
     -> Selector d HexKey (HexIndirect a)
     -> k
     -> v
     -> Transaction m cf d ops ()
-inserting FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol k v = do
+inserting prefix FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol k v = do
     insert kvCol k v
     let treeKey = hexTreePrefix v <> fromHexK k
-    c <- mkMPFCompose mpfCol treeKey (fromHexV v)
-    mapM_ (uncurry $ insert mpfCol) $ snd $ scanMPFCompose hashing c
+    c <- mkMPFCompose mpfCol prefix treeKey (fromHexV v)
+    mapM_ (uncurry $ insert mpfCol)
+        $ snd
+        $ scanMPFCompose prefix hashing c
 
--- | Batch insert multiple key-value pairs into an empty MPF structure
--- This is much faster than sequential inserts as it builds the tree in one pass
--- using divide-and-conquer (O(n log n) vs O(n²))
+-- | Batch insert multiple key-value pairs into an empty MPF structure.
+-- This is much faster than sequential inserts as it builds the tree
+-- in one pass using divide-and-conquer (O(n log n) vs O(n²)).
 insertingBatch
     :: (Monad m, Ord k, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> MPFHashing a
     -> Selector d k v
     -> Selector d HexKey (HexIndirect a)
     -> [(k, v)]
     -> Transaction m cf d ops ()
-insertingBatch FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol kvs = do
+insertingBatch prefix FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol kvs = do
     -- Insert all key-value pairs into the KV store
     mapM_ (uncurry $ insert kvCol) kvs
     -- Build the MPF tree in one pass and insert all nodes
@@ -79,18 +86,24 @@ insertingBatch FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol
         compose = buildComposeFromList hexKvs
     case compose of
         Nothing -> pure () -- Empty list
-        Just c -> mapM_ (uncurry $ insert mpfCol) $ snd $ scanMPFCompose hashing c
+        Just c ->
+            mapM_ (uncurry $ insert mpfCol)
+                $ snd
+                $ scanMPFCompose prefix hashing c
 
--- | Chunked insert for very large datasets (millions of items)
--- Processes items in chunks to bound memory usage. Works with any backend.
+-- | Chunked insert for very large datasets (millions of items).
+-- Processes items in chunks to bound memory usage. Works with any
+-- backend.
 --
--- For truly large datasets (10M+), use this with the RocksDB backend which
--- persists data to disk between chunks, keeping memory bounded.
+-- For truly large datasets (10M+), use this with the RocksDB backend
+-- which persists data to disk between chunks, keeping memory bounded.
 --
 -- Returns the number of chunks processed.
 insertingChunked
     :: (Monad m, Ord k, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> MPFHashing a
     -> Selector d k v
     -> Selector d HexKey (HexIndirect a)
@@ -98,14 +111,14 @@ insertingChunked
     -- ^ Chunk size (e.g., 50000)
     -> [(k, v)]
     -> Transaction m cf d ops Int
-insertingChunked fhkv hashing kvCol mpfCol chunkSize kvs = do
+insertingChunked prefix fhkv hashing kvCol mpfCol chunkSize kvs = do
     let chunks = chunksOf chunkSize kvs
     go 0 chunks
   where
     go !n [] = pure n
     go !n (chunk : rest) = do
         -- Insert this chunk item by item
-        mapM_ (uncurry (inserting fhkv hashing kvCol mpfCol)) chunk
+        mapM_ (uncurry (inserting prefix fhkv hashing kvCol mpfCol)) chunk
         -- Continue with rest
         go (n + 1) rest
 
@@ -116,20 +129,23 @@ chunksOf n xs =
     let (chunk, rest) = splitAt n xs
     in  chunk : chunksOf n rest
 
--- | Streaming batch insert for very large datasets
--- Groups items by first hex digit and processes each group separately,
--- reducing peak memory by ~16x compared to full batch insert.
--- Still requires O(n) memory for the input list and one group at a time.
+-- | Streaming batch insert for very large datasets.
+-- Groups items by first hex digit and processes each group
+-- separately, reducing peak memory by ~16x compared to full batch
+-- insert. Still requires O(n) memory for the input list and one
+-- group at a time.
 insertingStream
     :: forall m k v a d cf ops
      . (Monad m, Ord k, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> MPFHashing a
     -> Selector d k v
     -> Selector d HexKey (HexIndirect a)
     -> [(k, v)]
     -> Transaction m cf d ops ()
-insertingStream FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol kvs = do
+insertingStream prefix FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol kvs = do
     -- Insert all key-value pairs into the KV store first
     mapM_ (uncurry $ insert kvCol) kvs
 
@@ -151,7 +167,7 @@ insertingStream FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCo
                 mr = merkleRoot hashing childHashes
                 rootValue = branchHash hashing [] mr
                 rootNode = mkBranchIndirect [] rootValue
-            insert mpfCol [] rootNode
+            insert mpfCol prefix rootNode
   where
     processGroup
         :: (HexDigit, [(HexKey, a)])
@@ -160,9 +176,10 @@ insertingStream FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCo
         case buildComposeFromList items of
             Nothing -> pure (digit, Nothing)
             Just compose -> do
-                let (rootInd, inserts) = scanMPFCompose hashing compose
-                -- Write all nodes for this subtree with digit prefix
-                mapM_ (\(k, v) -> insert mpfCol ([digit] <> k) v) inserts
+                let (rootInd, inserts) =
+                        scanMPFCompose (prefix <> [digit]) hashing compose
+                -- Write all nodes for this subtree
+                mapM_ (uncurry $ insert mpfCol) inserts
                 pure (digit, Just rootInd)
 
 -- | Group by first hex digit, keeping remaining key
@@ -182,17 +199,17 @@ buildComposeFromList [(key, value)] =
     Just $ MPFComposeLeaf $ mkLeafIndirect key value
 buildComposeFromList kvs =
     -- Multiple elements: find common prefix, then branch
-    let prefix = commonPrefixAll (map fst kvs)
-        prefixLen = length prefix
+    let pfx = commonPrefixAll (map fst kvs)
+        pfxLen = length pfx
         -- Strip prefix and group by first digit
-        stripped = [(drop prefixLen k, v) | (k, v) <- kvs]
+        stripped = [(drop pfxLen k, v) | (k, v) <- kvs]
         -- Group by first digit
         grouped = groupByFirstDigit stripped
         -- Recursively build children
         children = Map.mapMaybe buildComposeFromList grouped
     in  if Map.null children
             then Nothing
-            else Just $ MPFComposeBranch prefix children
+            else Just $ MPFComposeBranch pfx children
 
 -- | Find the common prefix of all keys
 commonPrefixAll :: [HexKey] -> HexKey
@@ -216,15 +233,18 @@ groupByFirstDigit = foldl' addToGroup Map.empty
     addToGroup acc (d : rest, v) =
         Map.insertWith (++) d [(rest, v)] acc
 
--- | Build a compose tree by traversing the existing trie
+-- | Build a compose tree by traversing the existing trie.
+-- The prefix scopes the query to a subtree.
 mkMPFCompose
     :: forall a d ops cf m
      . (Monad m, GCompare d)
     => Selector d HexKey (HexIndirect a)
     -> HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> HexKey
     -> a
     -> Transaction m cf d ops (MPFCompose a)
-mkMPFCompose mpfCol key h = go key [] pure
+mkMPFCompose mpfCol prefix key h = go key prefix pure
   where
     go
         :: HexKey
@@ -279,20 +299,20 @@ fetchSiblings
     -> HexKey
     -> HexDigit
     -> Transaction m cf d ops (Map HexDigit (MPFCompose a))
-fetchSiblings mpfCol prefix exclude = do
+fetchSiblings mpfCol pfx exclude = do
     let allDigits = [HexDigit n | n <- [0 .. 15], HexDigit n /= exclude]
     pairs <- mapM fetchSibling allDigits
     Map.fromList <$> sequence [wrapNode d i | (d, Just i) <- pairs]
   where
     fetchSibling d = do
-        mi <- query mpfCol (prefix <> [d])
+        mi <- query mpfCol (pfx <> [d])
         pure (d, mi)
     wrapNode d HexIndirect{hexIsLeaf, hexJump, hexValue}
         | hexIsLeaf =
             pure (d, MPFComposeLeaf $ mkLeafIndirect hexJump hexValue)
         | otherwise = do
             -- Branch: fetch its children to rebuild structure
-            children <- fetchChildTree mpfCol (prefix <> [d] <> hexJump)
+            children <- fetchChildTree mpfCol (pfx <> [d] <> hexJump)
             pure (d, MPFComposeBranch hexJump children)
 
 -- | Fetch all children of a branch node and wrap them as MPFCompose
@@ -301,28 +321,32 @@ fetchChildTree
     => Selector d HexKey (HexIndirect a)
     -> HexKey
     -> Transaction m cf d ops (Map HexDigit (MPFCompose a))
-fetchChildTree mpfCol prefix = do
+fetchChildTree mpfCol pfx = do
     let allDigits = [HexDigit n | n <- [0 .. 15]]
     pairs <- mapM fetchChild allDigits
     Map.fromList <$> sequence [wrapNode d node | (d, Just node) <- pairs]
   where
     fetchChild d = do
-        mi <- query mpfCol (prefix <> [d])
+        mi <- query mpfCol (pfx <> [d])
         pure (d, mi)
     wrapNode d HexIndirect{hexIsLeaf, hexJump, hexValue}
         | hexIsLeaf =
             pure (d, MPFComposeLeaf $ mkLeafIndirect hexJump hexValue)
         | otherwise = do
             -- Recursively fetch children for nested branches
-            children <- fetchChildTree mpfCol (prefix <> [d] <> hexJump)
+            children <- fetchChildTree mpfCol (pfx <> [d] <> hexJump)
             pure (d, MPFComposeBranch hexJump children)
 
--- | Scan a compose tree and produce the resulting hash and list of inserts
+-- | Scan a compose tree and produce the resulting hash and list of
+-- inserts. The prefix determines where nodes are stored in the
+-- database.
 scanMPFCompose
-    :: MPFHashing a
+    :: HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> MPFHashing a
     -> MPFCompose a
     -> (HexIndirect a, [(HexKey, HexIndirect a)])
-scanMPFCompose MPFHashing{leafHash, merkleRoot, branchHash} = go []
+scanMPFCompose prefix MPFHashing{leafHash, merkleRoot, branchHash} = go prefix
   where
     go k (MPFComposeLeaf i) =
         -- NEW leaf: compute leaf hash from value hash, store value hash

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -4,22 +4,23 @@
 -- and constructors that wrap MPF operations into
 -- 'MerkleTreeStore'.
 --
--- Two constructors are provided:
+-- Four constructors are provided:
 --
--- * 'mpfMerkleTreeStoreT' — operations live in the
---   'Transaction' monad, composable within a single atomic
---   transaction.
+-- * 'mpfMerkleTreeStoreT' — prefix-scoped transactional store,
+--   composable within a single atomic transaction.
 -- * 'mpfMerkleTreeStore' — convenience wrapper that commits
---   each operation in its own transaction (suitable for simple
---   use cases and tests).
+--   each operation in its own transaction.
+-- * 'mpfNamespacedMTST' — transactional namespaced store.
+-- * 'mpfNamespacedMTS' — IO namespaced store.
 module MPF.MTS
     ( MpfImpl
     , mpfMerkleTreeStoreT
     , mpfMerkleTreeStore
+    , mpfNamespacedMTST
+    , mpfNamespacedMTS
     )
 where
 
-import Control.Monad.Trans.Class (lift)
 import Data.ByteString (ByteString)
 import Database.KV.Database (Database)
 import Database.KV.Transaction
@@ -32,7 +33,7 @@ import MPF.Backend.Standalone
     , MPFStandaloneCF
     , MPFStandaloneOp
     )
-import MPF.Deletion (deleting)
+import MPF.Deletion (deleteSubtree, deleting)
 import MPF.Hashes (MPFHash, MPFHashing (..))
 import MPF.Insertion (MPFCompose, inserting, insertingBatch)
 import MPF.Interface
@@ -57,9 +58,12 @@ import MTS.Interface
     , MtsHash
     , MtsKey
     , MtsLeaf
+    , MtsPrefix
     , MtsProof
     , MtsValue
+    , NamespacedMTS (..)
     , hoistMTS
+    , hoistNamespacedMTS
     )
 
 -- | Phantom type tag for the MPF implementation.
@@ -71,6 +75,7 @@ type instance MtsHash MpfImpl = MPFHash
 type instance MtsProof MpfImpl = MPFProof MPFHash
 type instance MtsLeaf MpfImpl = HexIndirect MPFHash
 type instance MtsCompletenessProof MpfImpl = MPFCompose MPFHash
+type instance MtsPrefix MpfImpl = HexKey
 
 -- | Compute the MPF root hash from the root node.
 mpfRootFromNode
@@ -80,7 +85,8 @@ mpfRootFromNode hashing i =
         then leafHash hashing (hexJump i) (hexValue i)
         else hexValue i
 
--- | Build a transactional 'MerkleTreeStore' for MPF.
+-- | Build a transactional 'MerkleTreeStore' for MPF scoped to a
+-- prefix.
 --
 -- Operations live in the 'Transaction' monad so multiple
 -- calls can be composed into a single atomic transaction:
@@ -93,7 +99,9 @@ mpfRootFromNode hashing i =
 -- @
 mpfMerkleTreeStoreT
     :: (MonadFail m)
-    => FromHexKV ByteString ByteString MPFHash
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV ByteString ByteString MPFHash
     -> MPFHashing MPFHash
     -> MerkleTreeStore
         MpfImpl
@@ -103,26 +111,29 @@ mpfMerkleTreeStoreT
             (MPFStandalone ByteString ByteString MPFHash)
             MPFStandaloneOp
         )
-mpfMerkleTreeStoreT fromKV hashing =
+mpfMerkleTreeStoreT prefix fromKV hashing =
     MerkleTreeStore
         { mtsInsert =
             inserting
+                prefix
                 fromKV
                 hashing
                 MPFStandaloneKVCol
                 MPFStandaloneMPFCol
         , mtsDelete =
             deleting
+                prefix
                 fromKV
                 hashing
                 MPFStandaloneKVCol
                 MPFStandaloneMPFCol
         , mtsRootHash = do
-            mi <- query MPFStandaloneMPFCol ([] :: HexKey)
+            mi <- query MPFStandaloneMPFCol prefix
             pure $ fmap (mpfRootFromNode hashing) mi
         , mtsMkProof = \k -> do
             mp <-
                 mkMPFInclusionProof
+                    prefix
                     fromKV
                     hashing
                     MPFStandaloneMPFCol
@@ -131,13 +142,14 @@ mpfMerkleTreeStoreT fromKV hashing =
                 Nothing -> pure Nothing
                 Just proof -> do
                     mi <-
-                        query MPFStandaloneMPFCol ([] :: HexKey)
+                        query MPFStandaloneMPFCol prefix
                     pure $ case mi of
                         Nothing -> Nothing
                         Just i ->
                             Just (mpfRootFromNode hashing i, proof)
         , mtsVerifyProof =
             verifyMPFInclusionProof
+                prefix
                 fromKV
                 MPFStandaloneMPFCol
                 hashing
@@ -145,16 +157,17 @@ mpfMerkleTreeStoreT fromKV hashing =
             foldMPFProof hashing
         , mtsBatchInsert =
             insertingBatch
+                prefix
                 fromKV
                 hashing
                 MPFStandaloneKVCol
                 MPFStandaloneMPFCol
         , mtsCollectLeaves =
-            collectMPFLeaves MPFStandaloneMPFCol
+            collectMPFLeaves MPFStandaloneMPFCol prefix
         , mtsMkCompletenessProof =
-            generateMPFCompletenessProof MPFStandaloneMPFCol
+            generateMPFCompletenessProof MPFStandaloneMPFCol prefix
         , mtsVerifyCompletenessProof = \leaves proof -> do
-            mi <- query MPFStandaloneMPFCol ([] :: HexKey)
+            mi <- query MPFStandaloneMPFCol prefix
             let currentRoot = fmap (mpfRootFromNode hashing) mi
                 computed =
                     foldMPFCompletenessProof hashing leaves proof
@@ -164,11 +177,56 @@ mpfMerkleTreeStoreT fromKV hashing =
                 _ -> False
         }
 
--- | Build an IO 'MerkleTreeStore' for MPF.
+-- | Build an IO 'MerkleTreeStore' for MPF scoped to a prefix.
 --
 -- Each operation commits in its own transaction. For atomic
 -- multi-operation sequences, use 'mpfMerkleTreeStoreT' instead.
 mpfMerkleTreeStore
+    :: (MonadFail m)
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> (forall b. m b -> IO b)
+    -> Database
+        m
+        MPFStandaloneCF
+        (MPFStandalone ByteString ByteString MPFHash)
+        MPFStandaloneOp
+    -> FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> MerkleTreeStore MpfImpl IO
+mpfMerkleTreeStore prefix run db fromKV hashing =
+    hoistMTS
+        (run . runTransactionUnguarded db)
+        (mpfMerkleTreeStoreT prefix fromKV hashing)
+
+-- | Build a transactional 'NamespacedMTS' for MPF.
+--
+-- Each namespace is a prefix-scoped 'MerkleTreeStore'.
+mpfNamespacedMTST
+    :: (MonadFail m)
+    => FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> NamespacedMTS
+        MpfImpl
+        ( Transaction
+            m
+            MPFStandaloneCF
+            (MPFStandalone ByteString ByteString MPFHash)
+            MPFStandaloneOp
+        )
+mpfNamespacedMTST fromKV hashing =
+    NamespacedMTS
+        { nsStore = \prefix ->
+            mpfMerkleTreeStoreT prefix fromKV hashing
+        , nsDelete = \prefix ->
+            deleteSubtree MPFStandaloneMPFCol prefix
+        }
+
+-- | Build an IO 'NamespacedMTS' for MPF.
+--
+-- Each namespace is a prefix-scoped 'MerkleTreeStore' that
+-- commits each operation in its own transaction.
+mpfNamespacedMTS
     :: (MonadFail m)
     => (forall b. m b -> IO b)
     -> Database
@@ -178,8 +236,8 @@ mpfMerkleTreeStore
         MPFStandaloneOp
     -> FromHexKV ByteString ByteString MPFHash
     -> MPFHashing MPFHash
-    -> MerkleTreeStore MpfImpl IO
-mpfMerkleTreeStore run db fromKV hashing =
-    hoistMTS
+    -> NamespacedMTS MpfImpl IO
+mpfNamespacedMTS run db fromKV hashing =
+    hoistNamespacedMTS
         (run . runTransactionUnguarded db)
-        (mpfMerkleTreeStoreT fromKV hashing)
+        (mpfNamespacedMTST fromKV hashing)

--- a/lib/mpf/MPF/Proof/Completeness.hs
+++ b/lib/mpf/MPF/Proof/Completeness.hs
@@ -42,14 +42,17 @@ import MPF.Interface
 
 -- |
 -- Collect all leaf values from the MPF trie.
+-- The prefix scopes the query to a subtree.
 --
 -- Returns leaves with their full key path as 'hexJump' and
 -- their value hash as 'hexValue'.
 collectMPFLeaves
     :: (Monad m, GCompare d)
     => Selector d HexKey (HexIndirect a)
+    -> HexKey
+    -- ^ Prefix (use @[]@ for root)
     -> Transaction m cf d op [HexIndirect a]
-collectMPFLeaves sel = navigate []
+collectMPFLeaves sel prefix = navigate prefix
   where
     navigate currentKey = do
         mi <- query sel currentKey
@@ -74,15 +77,18 @@ collectMPFLeaves sel = navigate []
 
 -- |
 -- Generate a completeness proof for the entire MPF trie.
+-- The prefix scopes the query to a subtree.
 --
 -- Returns the trie as an 'MPFCompose' tree, or 'Nothing' if
 -- the tree is empty.
 generateMPFCompletenessProof
     :: (Monad m, GCompare d)
     => Selector d HexKey (HexIndirect a)
+    -> HexKey
+    -- ^ Prefix (use @[]@ for root)
     -> Transaction m cf d op (Maybe (MPFCompose a))
-generateMPFCompletenessProof sel = do
-    mi <- query sel []
+generateMPFCompletenessProof sel prefix = do
+    mi <- query sel prefix
     case mi of
         Nothing -> pure Nothing
         Just HexIndirect{hexJump, hexValue, hexIsLeaf}
@@ -92,7 +98,7 @@ generateMPFCompletenessProof sel = do
                     $ MPFComposeLeaf
                     $ mkLeafIndirect hexJump hexValue
             | otherwise -> do
-                children <- fetchChildTree sel hexJump
+                children <- fetchChildTree sel (prefix <> hexJump)
                 pure $ Just $ MPFComposeBranch hexJump children
 
 -- |
@@ -109,7 +115,7 @@ foldMPFCompletenessProof
     -> Maybe a
 foldMPFCompletenessProof hashing leaves proof =
     let extracted = extractLeaves proof
-        (rootIndirect, _) = scanMPFCompose hashing proof
+        (rootIndirect, _) = scanMPFCompose [] hashing proof
         computedRoot = hexValue rootIndirect
     in  if sort extracted == sort leaves
             then Just computedRoot

--- a/lib/mpf/MPF/Proof/Insertion.hs
+++ b/lib/mpf/MPF/Proof/Insertion.hs
@@ -98,6 +98,7 @@ data MPFProof a = MPFProof
     deriving (Show, Eq)
 
 -- | Generate a membership proof for a key.
+-- The prefix scopes the query to a subtree.
 --
 -- When a branch has exactly one non-empty sibling:
 --
@@ -113,12 +114,14 @@ data MPFProof a = MPFProof
 -- validator format byte-for-byte.
 mkMPFInclusionProof
     :: (Monad m, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> MPFHashing a
     -> Selector d HexKey (HexIndirect a)
     -> k
     -> Transaction m cf d ops (Maybe (MPFProof a))
-mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
+mkMPFInclusionProof prefix FromHexKV{fromHexK} hashing sel k =
     runMaybeT $ do
         let key = fromHexK k
         HexIndirect
@@ -126,7 +129,7 @@ mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
             , hexValue = rootValue
             , hexIsLeaf = rootIsLeaf
             } <-
-            MaybeT $ query sel []
+            MaybeT $ query sel prefix
         guard $ isPrefixOf rootJump key
         let remainingAfterRoot = drop (length rootJump) key
         if rootIsLeaf
@@ -140,7 +143,7 @@ mkMPFInclusionProof FromHexKV{fromHexK} hashing sel k =
                         }
             else do
                 (steps, leafSuffix, valHash) <-
-                    go [] rootJump remainingAfterRoot
+                    go prefix rootJump remainingAfterRoot
                 pure
                     $ MPFProof
                         { mpfProofSteps = reverse steps
@@ -269,7 +272,7 @@ fetchSiblingDetails
     -> HexKey
     -> HexDigit
     -> Transaction m cf d ops (Map HexDigit (HexIndirect a))
-fetchSiblingDetails sel prefix exclude = do
+fetchSiblingDetails sel pfx exclude = do
     let digits =
             [ HexDigit n
             | n <- [0 .. 15]
@@ -281,7 +284,7 @@ fetchSiblingDetails sel prefix exclude = do
             [(d, hi) | (d, Just hi) <- pairs]
   where
     fetchOne d = do
-        mi <- query sel (prefix <> [d])
+        mi <- query sel (pfx <> [d])
         pure (d, mi)
 
 -- | Compute the merkle root of a branch's children
@@ -453,23 +456,27 @@ foldMPFProof
                                 psfBranchJump
                                 mr
 
--- | Verify a membership proof
+-- | Verify a membership proof.
+-- The prefix scopes the root query to a subtree.
 verifyMPFInclusionProof
     :: (Eq a, Monad m, GCompare d)
-    => FromHexKV k v a
+    => HexKey
+    -- ^ Prefix (use @[]@ for root)
+    -> FromHexKV k v a
     -> Selector d HexKey (HexIndirect a)
     -> MPFHashing a
     -> v
     -> MPFProof a
     -> Transaction m cf d ops Bool
 verifyMPFInclusionProof
+    prefix
     FromHexKV{fromHexV}
     sel
     hashing@MPFHashing{leafHash = lh}
     v
     proof = do
         let valueHash = fromHexV v
-        mv <- query sel []
+        mv <- query sel prefix
         pure $ case mv of
             Just
                 HexIndirect

--- a/lib/mts/MTS/Interface.hs
+++ b/lib/mts/MTS/Interface.hs
@@ -13,6 +13,9 @@ module MTS.Interface
     , MtsProof
     , MtsLeaf
     , MtsCompletenessProof
+    , MtsPrefix
+    , NamespacedMTS (..)
+    , hoistNamespacedMTS
     )
 where
 
@@ -83,4 +86,28 @@ hoistMTS f s =
         , mtsMkCompletenessProof = f (mtsMkCompletenessProof s)
         , mtsVerifyCompletenessProof =
             \ls p -> f (mtsVerifyCompletenessProof s ls p)
+        }
+
+-- | Namespace prefix type for an implementation.
+type family MtsPrefix imp
+
+-- | A namespaced Merkle tree store supporting multiple independent
+-- namespaces within one database.
+data NamespacedMTS imp m = NamespacedMTS
+    { nsStore :: MtsPrefix imp -> MerkleTreeStore imp m
+    -- ^ Get a scoped store for a namespace.
+    --   Creation is implicit on first insert.
+    , nsDelete :: MtsPrefix imp -> m ()
+    -- ^ Delete an entire namespace (all nodes under prefix).
+    }
+
+-- | Transform the monad of a 'NamespacedMTS'.
+hoistNamespacedMTS
+    :: (forall a. m a -> n a)
+    -> NamespacedMTS imp m
+    -> NamespacedMTS imp n
+hoistNamespacedMTS f ns =
+    NamespacedMTS
+        { nsStore = hoistMTS f . nsStore ns
+        , nsDelete = f . nsDelete ns
         }

--- a/mts.cabal
+++ b/mts.cabal
@@ -237,6 +237,7 @@ test-suite unit-tests
     MPF.HashesSpec
     MPF.InsertionSpec
     MPF.InterfaceSpec
+    MPF.NamespaceSpec
     MPF.Proof.InsertionSpec
     MPF.PropertySpec
     MTS.PropertySpec

--- a/test-lib/mpf/MPF/Test/Lib.hs
+++ b/test-lib/mpf/MPF/Test/Lib.hs
@@ -17,6 +17,14 @@ module MPF.Test.Lib
     , fromHexKVIdentity
     , fromHexKVByteString
 
+      -- * Prefix-aware Utilities
+    , insertMPFMAt
+    , deleteMPFMAt
+    , getRootHashMAt
+    , proofMPFMAt
+    , verifyMPFMAt
+    , deleteSubtreeMAt
+
       -- * Pure Backend (for benchmarking)
     , MPFInMemoryDB
     , MPFPure
@@ -57,7 +65,7 @@ import MPF.Backend.Standalone
     ( MPFStandalone (..)
     , MPFStandaloneCodecs (..)
     )
-import MPF.Deletion (deleting)
+import MPF.Deletion (deleteSubtree, deleting)
 import MPF.Hashes
     ( MPFHash
     , MPFHashing (..)
@@ -136,9 +144,18 @@ deleteMPF db k =
 
 -- | Insert in the Pure monad
 insertMPFM :: HexKey -> MPFHash -> MPFPure ()
-insertMPFM k v =
+insertMPFM = insertMPFMAt []
+
+-- | Delete in the Pure monad
+deleteMPFM :: HexKey -> MPFPure ()
+deleteMPFM = deleteMPFMAt []
+
+-- | Insert at a prefix in the Pure monad
+insertMPFMAt :: HexKey -> HexKey -> MPFHash -> MPFPure ()
+insertMPFMAt prefix k v =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
         $ inserting
+            prefix
             fromHexKVIdentity
             mpfHashing
             MPFStandaloneKVCol
@@ -146,11 +163,12 @@ insertMPFM k v =
             k
             v
 
--- | Delete in the Pure monad
-deleteMPFM :: HexKey -> MPFPure ()
-deleteMPFM k =
+-- | Delete at a prefix in the Pure monad
+deleteMPFMAt :: HexKey -> HexKey -> MPFPure ()
+deleteMPFMAt prefix k =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
         $ deleting
+            prefix
             fromHexKVIdentity
             mpfHashing
             MPFStandaloneKVCol
@@ -171,6 +189,7 @@ insertBatchMPFM :: [(HexKey, MPFHash)] -> MPFPure ()
 insertBatchMPFM kvs =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
         $ insertingBatch
+            []
             fromHexKVIdentity
             mpfHashing
             MPFStandaloneKVCol
@@ -183,6 +202,7 @@ insertChunkedMPFM :: Int -> [(HexKey, MPFHash)] -> MPFPure Int
 insertChunkedMPFM chunkSize kvs =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
         $ insertingChunked
+            []
             fromHexKVIdentity
             mpfHashing
             MPFStandaloneKVCol
@@ -196,6 +216,7 @@ insertStreamMPFM :: [(HexKey, MPFHash)] -> MPFPure ()
 insertStreamMPFM kvs =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
         $ insertingStream
+            []
             fromHexKVIdentity
             mpfHashing
             MPFStandaloneKVCol
@@ -204,20 +225,39 @@ insertStreamMPFM kvs =
 
 -- | Generate a membership proof for a key in the Pure monad
 proofMPFM :: HexKey -> MPFPure (Maybe (MPFProof MPFHash))
-proofMPFM k =
+proofMPFM = proofMPFMAt []
+
+-- | Generate a membership proof at a prefix
+proofMPFMAt :: HexKey -> HexKey -> MPFPure (Maybe (MPFProof MPFHash))
+proofMPFMAt prefix k =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
-        $ mkMPFInclusionProof fromHexKVIdentity mpfHashing MPFStandaloneMPFCol k
+        $ mkMPFInclusionProof
+            prefix
+            fromHexKVIdentity
+            mpfHashing
+            MPFStandaloneMPFCol
+            k
 
 -- | Verify a membership proof for a key-value pair in the Pure monad
 verifyMPFM :: HexKey -> MPFHash -> MPFPure Bool
-verifyMPFM k v =
+verifyMPFM = verifyMPFMAt []
+
+-- | Verify a membership proof at a prefix
+verifyMPFMAt :: HexKey -> HexKey -> MPFHash -> MPFPure Bool
+verifyMPFMAt prefix k v =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs) $ do
         mProof <-
-            mkMPFInclusionProof fromHexKVIdentity mpfHashing MPFStandaloneMPFCol k
+            mkMPFInclusionProof
+                prefix
+                fromHexKVIdentity
+                mpfHashing
+                MPFStandaloneMPFCol
+                k
         case mProof of
             Nothing -> pure False
             Just proof ->
                 verifyMPFInclusionProof
+                    prefix
                     fromHexKVIdentity
                     MPFStandaloneMPFCol
                     mpfHashing
@@ -226,16 +266,26 @@ verifyMPFM k v =
 
 -- | Get the root hash from the MPF trie
 getRootHashM :: MPFPure (Maybe MPFHash)
-getRootHashM =
+getRootHashM = getRootHashMAt []
+
+-- | Get the root hash at a prefix
+getRootHashMAt :: HexKey -> MPFPure (Maybe MPFHash)
+getRootHashMAt prefix =
     runTransactionUnguarded (mpfPureDatabase mpfHashCodecs) $ do
-        mi <- query MPFStandaloneMPFCol []
+        mi <- query MPFStandaloneMPFCol prefix
         pure $ case mi of
             Nothing -> Nothing
             Just i ->
                 Just
                     $ if hexIsLeaf i
-                        then leafHash mpfHashing (hexJump i) (hexValue i) -- Leaf: compute from value hash
-                        else hexValue i -- Branch: already has branch hash
+                        then leafHash mpfHashing (hexJump i) (hexValue i)
+                        else hexValue i
+
+-- | Delete an entire subtree at a prefix
+deleteSubtreeMAt :: HexKey -> MPFPure ()
+deleteSubtreeMAt prefix =
+    runTransactionUnguarded (mpfPureDatabase mpfHashCodecs)
+        $ deleteSubtree MPFStandaloneMPFCol prefix
 
 -- | Evaluate a pure MPF computation from empty database
 evalMPFPure' :: MPFPure a -> a
@@ -249,36 +299,36 @@ runMPFPure' = runMPFPure emptyMPFInMemoryDB
 -- 30 fruit key-value pairs (must match exactly for compatible root hash)
 fruitsTestData :: [(ByteString, ByteString)]
 fruitsTestData =
-    [ ("apple[uid: 58]", encodeUtf8 "🍎")
-    , ("apricot[uid: 0]", encodeUtf8 "🤷")
-    , ("banana[uid: 218]", encodeUtf8 "🍌")
-    , ("blueberry[uid: 0]", encodeUtf8 "🫐")
-    , ("cherry[uid: 0]", encodeUtf8 "🍒")
-    , ("coconut[uid: 0]", encodeUtf8 "🥥")
-    , ("cranberry[uid: 0]", encodeUtf8 "🤷")
-    , ("fig[uid: 68267]", encodeUtf8 "🤷")
-    , ("grapefruit[uid: 0]", encodeUtf8 "🤷")
-    , ("grapes[uid: 0]", encodeUtf8 "🍇")
-    , ("guava[uid: 344]", encodeUtf8 "🤷")
-    , ("kiwi[uid: 0]", encodeUtf8 "🥝")
-    , ("kumquat[uid: 0]", encodeUtf8 "🤷")
-    , ("lemon[uid: 0]", encodeUtf8 "🍋")
-    , ("lime[uid: 0]", encodeUtf8 "🤷")
-    , ("mango[uid: 0]", encodeUtf8 "🥭")
-    , ("orange[uid: 0]", encodeUtf8 "🍊")
-    , ("papaya[uid: 0]", encodeUtf8 "🤷")
-    , ("passionfruit[uid: 0]", encodeUtf8 "🤷")
-    , ("peach[uid: 0]", encodeUtf8 "🍑")
-    , ("pear[uid: 0]", encodeUtf8 "🍐")
-    , ("pineapple[uid: 12577]", encodeUtf8 "🍍")
-    , ("plum[uid: 15492]", encodeUtf8 "🤷")
-    , ("pomegranate[uid: 0]", encodeUtf8 "🤷")
-    , ("raspberry[uid: 0]", encodeUtf8 "🤷")
-    , ("strawberry[uid: 2532]", encodeUtf8 "🍓")
-    , ("tangerine[uid: 11]", encodeUtf8 "🍊")
-    , ("tomato[uid: 83468]", encodeUtf8 "🍅")
-    , ("watermelon[uid: 0]", encodeUtf8 "🍉")
-    , ("yuzu[uid: 0]", encodeUtf8 "🤷")
+    [ ("apple[uid: 58]", encodeUtf8 "\127822")
+    , ("apricot[uid: 0]", encodeUtf8 "\129335")
+    , ("banana[uid: 218]", encodeUtf8 "\127820")
+    , ("blueberry[uid: 0]", encodeUtf8 "\129744")
+    , ("cherry[uid: 0]", encodeUtf8 "\127826")
+    , ("coconut[uid: 0]", encodeUtf8 "\129381")
+    , ("cranberry[uid: 0]", encodeUtf8 "\129335")
+    , ("fig[uid: 68267]", encodeUtf8 "\129335")
+    , ("grapefruit[uid: 0]", encodeUtf8 "\129335")
+    , ("grapes[uid: 0]", encodeUtf8 "\127815")
+    , ("guava[uid: 344]", encodeUtf8 "\129335")
+    , ("kiwi[uid: 0]", encodeUtf8 "\129373")
+    , ("kumquat[uid: 0]", encodeUtf8 "\129335")
+    , ("lemon[uid: 0]", encodeUtf8 "\127819")
+    , ("lime[uid: 0]", encodeUtf8 "\129335")
+    , ("mango[uid: 0]", encodeUtf8 "\129389")
+    , ("orange[uid: 0]", encodeUtf8 "\127818")
+    , ("papaya[uid: 0]", encodeUtf8 "\129335")
+    , ("passionfruit[uid: 0]", encodeUtf8 "\129335")
+    , ("peach[uid: 0]", encodeUtf8 "\127825")
+    , ("pear[uid: 0]", encodeUtf8 "\127824")
+    , ("pineapple[uid: 12577]", encodeUtf8 "\127821")
+    , ("plum[uid: 15492]", encodeUtf8 "\129335")
+    , ("pomegranate[uid: 0]", encodeUtf8 "\129335")
+    , ("raspberry[uid: 0]", encodeUtf8 "\129335")
+    , ("strawberry[uid: 2532]", encodeUtf8 "\127827")
+    , ("tangerine[uid: 11]", encodeUtf8 "\127818")
+    , ("tomato[uid: 83468]", encodeUtf8 "\127813")
+    , ("watermelon[uid: 0]", encodeUtf8 "\127817")
+    , ("yuzu[uid: 0]", encodeUtf8 "\129335")
     ]
 
 -- | Expected root hash after inserting all fruits

--- a/test/MPF/NamespaceSpec.hs
+++ b/test/MPF/NamespaceSpec.hs
@@ -1,0 +1,84 @@
+module MPF.NamespaceSpec (spec) where
+
+import MPF.Hashes (mkMPFHash)
+import MPF.Interface (HexDigit (..), byteStringToHexKey)
+import MPF.Test.Lib
+    ( deleteMPFMAt
+    , deleteSubtreeMAt
+    , evalMPFPure'
+    , getRootHashM
+    , getRootHashMAt
+    , insertMPFM
+    , insertMPFMAt
+    , verifyMPFMAt
+    )
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
+
+spec :: Spec
+spec = describe "MPF.Namespace" $ do
+    let pfxA = [HexDigit 0, HexDigit 1]
+        pfxB = [HexDigit 0, HexDigit 2]
+        key1 = byteStringToHexKey "hello"
+        val1 = mkMPFHash "world"
+        key2 = byteStringToHexKey "foo"
+        val2 = mkMPFHash "bar"
+        key3 = byteStringToHexKey "baz"
+        val3 = mkMPFHash "qux"
+
+    it "namespaces are independent" $ do
+        let (rootA, rootB) = evalMPFPure' $ do
+                insertMPFMAt pfxA key1 val1
+                insertMPFMAt pfxB key2 val2
+                (,)
+                    <$> getRootHashMAt pfxA
+                    <*> getRootHashMAt pfxB
+        rootA `shouldNotBe` rootB
+
+    it "prefix root matches non-prefixed root" $ do
+        let rootPrefixed = evalMPFPure' $ do
+                insertMPFMAt pfxA key1 val1
+                getRootHashMAt pfxA
+            rootPlain = evalMPFPure' $ do
+                insertMPFM key1 val1
+                getRootHashM
+        rootPrefixed `shouldBe` rootPlain
+
+    it "delete under one prefix doesn't affect another" $ do
+        let rootB = evalMPFPure' $ do
+                insertMPFMAt pfxA key1 val1
+                insertMPFMAt pfxB key2 val2
+                deleteMPFMAt pfxA key1
+                getRootHashMAt pfxB
+            rootBAlone = evalMPFPure' $ do
+                insertMPFMAt pfxB key2 val2
+                getRootHashMAt pfxB
+        rootB `shouldBe` rootBAlone
+
+    it "nsDelete wipes entire namespace" $ do
+        let (rootA, rootB) = evalMPFPure' $ do
+                insertMPFMAt pfxA key1 val1
+                insertMPFMAt pfxA key2 val2
+                insertMPFMAt pfxB key3 val3
+                deleteSubtreeMAt pfxA
+                (,)
+                    <$> getRootHashMAt pfxA
+                    <*> getRootHashMAt pfxB
+        rootA `shouldBe` Nothing
+        rootB `shouldNotBe` Nothing
+
+    it "proofs work within a namespace" $ do
+        let verified = evalMPFPure' $ do
+                insertMPFMAt pfxA key1 val1
+                verifyMPFMAt pfxA key1 val1
+        verified `shouldBe` True
+
+    it "multiple inserts in same namespace" $ do
+        let rootPrefixed = evalMPFPure' $ do
+                insertMPFMAt pfxA key1 val1
+                insertMPFMAt pfxA key2 val2
+                getRootHashMAt pfxA
+            rootPlain = evalMPFPure' $ do
+                insertMPFM key1 val1
+                insertMPFM key2 val2
+                getRootHashM
+        rootPrefixed `shouldBe` rootPlain

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -82,6 +82,7 @@ mkMpfStore = do
             pure a
     pure
         $ mpfMerkleTreeStore
+            []
             run
             (mpfPureDatabase mpfCodecs)
             fromHexKVBS


### PR DESCRIPTION
## Summary

- Add `HexKey` prefix parameter to all core MPF traversal functions (insertion, deletion, proofs, completeness) enabling multiple independent namespaces within a single database
- New `MtsPrefix` type family + `NamespacedMTS` record in `MTS.Interface`, with `mpfNamespacedMTST`/`mpfNamespacedMTS` constructors in `MPF.MTS`
- New `deleteSubtree` function for wiping entire namespaces

## Test plan

- [x] All 189 existing tests pass (existing callers use `[]` prefix)
- [x] 6 new namespace isolation tests verify independence, hash equivalence, and subtree deletion

Closes #69