### PR TITLE
feat: prefix-scoped CSMT operations

### DIFF
--- a/lib/csmt/CSMT.hs
+++ b/lib/csmt/CSMT.hs
@@ -19,12 +19,14 @@
 module CSMT
     ( module CSMT.Interface
     , module CSMT.Insertion
+    , module CSMT.Deletion
     , module CSMT.Proof.Insertion
     , module CSMT.Backend.Standalone
     )
 where
 
 import CSMT.Backend.Standalone
+import CSMT.Deletion
 import CSMT.Insertion
 import CSMT.Interface
 import CSMT.Proof.Insertion

--- a/lib/csmt/CSMT/Deletion.hs
+++ b/lib/csmt/CSMT/Deletion.hs
@@ -19,6 +19,7 @@ module CSMT.Deletion
     , newDeletionPath
     , DeletionPath (..)
     , deletionPathToOps
+    , deleteSubtree
     )
 where
 
@@ -71,24 +72,27 @@ data DeletionPath a where
 -- 3. Updates the tree structure and recomputes affected hashes
 deleting
     :: (Monad m, Ord k, GCompare d)
-    => FromKV k v a
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV k v a
     -> Hashing a
     -> Selector d k v
     -> Selector d Key (Indirect a)
     -> k
     -> Transaction m cf d ops ()
-deleting FromKV{isoK, treePrefix} hashing kvSel csmtSel key = do
+deleting pfx FromKV{isoK, treePrefix} hashing kvSel csmtSel key = do
     mv <- query kvSel key
     case mv of
         Nothing -> pure ()
         Just v -> do
             let treeKey = treePrefix v <> view isoK key
-            mpath <- newDeletionPath csmtSel treeKey
+            mpath <- newDeletionPath pfx csmtSel treeKey
             case mpath of
                 Nothing -> pure ()
                 Just path -> do
                     delete kvSel key
-                    mapM_ (applyOp csmtSel) $ deletionPathToOps hashing path
+                    mapM_ (applyOp csmtSel)
+                        $ deletionPathToOps pfx hashing path
 
 -- | Apply a single database operation (insert or delete).
 applyOp
@@ -107,10 +111,12 @@ applyOp csmtSel (k, Just i) = insert csmtSel k i
 -- jump path is extended to maintain the compact representation.
 deletionPathToOps
     :: forall a
-     . Hashing a
+     . Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Hashing a
     -> DeletionPath a
     -> [(Key, Maybe (Indirect a))]
-deletionPathToOps hashing = snd . go []
+deletionPathToOps pfx hashing = snd . go pfx
   where
     go
         :: Key
@@ -149,10 +155,12 @@ deletionPathToOps hashing = snd . go []
 newDeletionPath
     :: forall a d ops cf m
      . (Monad m, GCompare d)
-    => Selector d Key (Indirect a)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Selector d Key (Indirect a)
     -> Key
     -> Transaction m cf d ops (Maybe (DeletionPath a))
-newDeletionPath csmtSel = runMaybeT . go []
+newDeletionPath pfx csmtSel = runMaybeT . go pfx
   where
     go
         :: Key
@@ -170,3 +178,22 @@ newDeletionPath csmtSel = runMaybeT . go []
                     MaybeT $ query csmtSel (current' <> [oppositeDirection r])
                 p <- go (current' <> [r]) remaining''
                 pure $ Branch j r p sibling
+
+-- | Delete all nodes under a prefix (entire namespace).
+-- Walks the binary trie from @prefix@, deleting every node encountered.
+deleteSubtree
+    :: (Monad m, GCompare d)
+    => Selector d Key (Indirect a)
+    -> Key
+    -> Transaction m cf d ops ()
+deleteSubtree csmtSel = go
+  where
+    go current = do
+        mi <- query csmtSel current
+        case mi of
+            Nothing -> pure ()
+            Just Indirect{jump} -> do
+                delete csmtSel current
+                let base = current <> jump
+                go (base <> [L])
+                go (base <> [R])

--- a/lib/csmt/CSMT/Hashes.hs
+++ b/lib/csmt/CSMT/Hashes.hs
@@ -98,7 +98,7 @@ insert
     -> k
     -> v
     -> Transaction m cf d ops ()
-insert csmt = inserting csmt hashHashing
+insert csmt = inserting [] csmt hashHashing
 
 -- | Delete a key-value pair using Blake2b-256 hashing.
 delete
@@ -108,7 +108,7 @@ delete
     -> Selector d Key (Indirect Hash)
     -> k
     -> Transaction m cf d ops ()
-delete csmt = deleting csmt hashHashing
+delete csmt = deleting [] csmt hashHashing
 
 -- | Convert a ByteString to a Key by expanding each byte to 8 directions.
 byteStringToKey :: ByteString -> Key
@@ -139,7 +139,7 @@ root
     => Selector d Key (Indirect Hash)
     -> Transaction m cf d ops (Maybe ByteString)
 root csmt = do
-    mi <- Interface.root hashHashing csmt
+    mi <- Interface.root hashHashing csmt []
     case mi of
         Nothing -> return Nothing
         Just v -> return (Just $ renderHash v)
@@ -157,7 +157,7 @@ generateInclusionProof
     -> k
     -> Transaction m cf d ops (Maybe (v, ByteString))
 generateInclusionProof csmt kvSel csmtSel k = do
-    mp <- Proof.buildInclusionProof csmt kvSel csmtSel hashHashing k
+    mp <- Proof.buildInclusionProof [] csmt kvSel csmtSel hashHashing k
     pure $ fmap (second renderProof) mp
 
 -- | Verify an inclusion proof from a serialized ByteString.

--- a/lib/csmt/CSMT/Insertion.hs
+++ b/lib/csmt/CSMT/Insertion.hs
@@ -73,18 +73,20 @@ compose R j left right = Compose j right left
 -- 3. Computes hashes and applies all CSMT updates atomically
 inserting
     :: (Monad m, Ord k, GCompare d)
-    => FromKV k v a
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV k v a
     -> Hashing a
     -> Selector d k v
     -> Selector d Key (Indirect a)
     -> k
     -> v
     -> Transaction m cf d ops ()
-inserting FromKV{isoK, fromV, treePrefix} hashing kVCol csmtCol k v = do
+inserting pfx FromKV{isoK, fromV, treePrefix} hashing kVCol csmtCol k v = do
     insert kVCol k v
     let treeKey = treePrefix v <> view isoK k
-    c <- buildComposeTree csmtCol treeKey (fromV v)
-    mapM_ (uncurry $ insert csmtCol) $ snd $ scanCompose hashing c
+    c <- buildComposeTree csmtCol pfx treeKey (fromV v)
+    mapM_ (uncurry $ insert csmtCol) $ snd $ scanCompose pfx hashing c
 
 -- |
 -- Scan a Compose tree bottom-up, computing hashes and collecting database operations.
@@ -92,8 +94,12 @@ inserting FromKV{isoK, fromV, treePrefix} hashing kVCol csmtCol k v = do
 -- Returns the root indirect value and a list of (key, value) pairs to insert.
 -- Hashes are computed by combining child hashes at each internal node.
 scanCompose
-    :: Hashing a -> Compose a -> (Indirect a, [(Key, Indirect a)])
-scanCompose Hashing{combineHash} = go []
+    :: Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Hashing a
+    -> Compose a
+    -> (Indirect a, [(Key, Indirect a)])
+scanCompose pfx Hashing{combineHash} = go pfx
   where
     go k (Leaf i) = (i, [(k, i)])
     go k (Compose jump left right) =
@@ -118,9 +124,11 @@ buildComposeTree
      . (Monad m, GCompare d)
     => Selector d Key (Indirect a)
     -> Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Key
     -> a
     -> Transaction m cf d ops (Compose a)
-buildComposeTree csmtCol key h = go key [] pure
+buildComposeTree csmtCol pfx key h = go key pfx pure
   where
     go [] _ cont = cont $ Leaf $ Indirect [] h
     go target current cont = do

--- a/lib/csmt/CSMT/Interface.hs
+++ b/lib/csmt/CSMT/Interface.hs
@@ -145,9 +145,11 @@ root
     :: (Monad m, GCompare d)
     => Hashing a
     -> Selector d Key (Indirect a)
+    -> Key
+    -- ^ Prefix (use @[]@ for root)
     -> Transaction m cf d ops (Maybe a)
-root hsh sel = do
-    mi <- query sel []
+root hsh sel pfx = do
+    mi <- query sel pfx
     pure $ case mi of
         Nothing -> Nothing
         Just i -> Just $ rootHash hsh i

--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -4,18 +4,20 @@
 -- and constructors that wrap CSMT operations into
 -- 'MerkleTreeStore'.
 --
--- Two constructors are provided:
+-- Four constructors are provided:
 --
--- * 'csmtMerkleTreeStoreT' — operations live in the
---   'Transaction' monad, composable within a single atomic
---   transaction.
+-- * 'csmtMerkleTreeStoreT' — prefix-scoped transactional store,
+--   composable within a single atomic transaction.
 -- * 'csmtMerkleTreeStore' — convenience wrapper that commits
---   each operation in its own transaction (suitable for simple
---   use cases and tests).
+--   each operation in its own transaction.
+-- * 'csmtNamespacedMTST' — transactional namespaced store.
+-- * 'csmtNamespacedMTS' — IO namespaced store.
 module CSMT.MTS
     ( CsmtImpl
     , csmtMerkleTreeStoreT
     , csmtMerkleTreeStore
+    , csmtNamespacedMTST
+    , csmtNamespacedMTS
     )
 where
 
@@ -24,13 +26,14 @@ import CSMT.Backend.Standalone
     , StandaloneCF
     , StandaloneOp
     )
-import CSMT.Deletion (deleting)
+import CSMT.Deletion (deleteSubtree, deleting)
 import CSMT.Hashes (Hash)
 import CSMT.Insertion (inserting)
 import CSMT.Interface
     ( FromKV (..)
     , Hashing (..)
     , Indirect (..)
+    , Key
     , root
     )
 import CSMT.Proof.Completeness
@@ -57,9 +60,12 @@ import MTS.Interface
     , MtsHash
     , MtsKey
     , MtsLeaf
+    , MtsPrefix
     , MtsProof
     , MtsValue
+    , NamespacedMTS (..)
     , hoistMTS
+    , hoistNamespacedMTS
     )
 
 -- | Phantom type tag for the CSMT implementation.
@@ -71,8 +77,10 @@ type instance MtsHash CsmtImpl = Hash
 type instance MtsProof CsmtImpl = InclusionProof Hash
 type instance MtsLeaf CsmtImpl = Indirect Hash
 type instance MtsCompletenessProof CsmtImpl = CompletenessProof Hash
+type instance MtsPrefix CsmtImpl = Key
 
--- | Build a transactional 'MerkleTreeStore' for CSMT.
+-- | Build a transactional 'MerkleTreeStore' for CSMT scoped to a
+-- prefix.
 --
 -- Operations live in the 'Transaction' monad so multiple
 -- calls can be composed into a single atomic transaction:
@@ -85,7 +93,9 @@ type instance MtsCompletenessProof CsmtImpl = CompletenessProof Hash
 -- @
 csmtMerkleTreeStoreT
     :: (Monad m)
-    => FromKV ByteString ByteString Hash
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV ByteString ByteString Hash
     -> Hashing Hash
     -> MerkleTreeStore
         CsmtImpl
@@ -95,17 +105,28 @@ csmtMerkleTreeStoreT
             (Standalone ByteString ByteString Hash)
             StandaloneOp
         )
-csmtMerkleTreeStoreT fromKV hashing =
+csmtMerkleTreeStoreT prefix fromKV hashing =
     MerkleTreeStore
         { mtsInsert =
-            inserting fromKV hashing StandaloneKVCol StandaloneCSMTCol
+            inserting
+                prefix
+                fromKV
+                hashing
+                StandaloneKVCol
+                StandaloneCSMTCol
         , mtsDelete =
-            deleting fromKV hashing StandaloneKVCol StandaloneCSMTCol
+            deleting
+                prefix
+                fromKV
+                hashing
+                StandaloneKVCol
+                StandaloneCSMTCol
         , mtsRootHash =
-            root hashing StandaloneCSMTCol
+            root hashing StandaloneCSMTCol prefix
         , mtsMkProof = \k -> do
             mp <-
                 buildInclusionProof
+                    prefix
                     fromKV
                     StandaloneKVCol
                     StandaloneCSMTCol
@@ -114,7 +135,7 @@ csmtMerkleTreeStoreT fromKV hashing =
             case mp of
                 Nothing -> pure Nothing
                 Just (_, proof) -> do
-                    mr <- root hashing StandaloneCSMTCol
+                    mr <- root hashing StandaloneCSMTCol prefix
                     pure $ case mr of
                         Nothing -> Nothing
                         Just r -> Just (r, proof)
@@ -128,6 +149,7 @@ csmtMerkleTreeStoreT fromKV hashing =
             mapM_
                 ( uncurry
                     ( inserting
+                        prefix
                         fromKV
                         hashing
                         StandaloneKVCol
@@ -135,11 +157,12 @@ csmtMerkleTreeStoreT fromKV hashing =
                     )
                 )
         , mtsCollectLeaves =
-            collectValues StandaloneCSMTCol []
+            collectValues StandaloneCSMTCol prefix []
         , mtsMkCompletenessProof =
-            generateProof StandaloneCSMTCol []
+            generateProof StandaloneCSMTCol prefix []
         , mtsVerifyCompletenessProof = \leaves proof -> do
-            currentRoot <- root hashing StandaloneCSMTCol
+            currentRoot <-
+                root hashing StandaloneCSMTCol prefix
             let computed =
                     foldCompletenessProof hashing [] leaves proof
             pure $ case (currentRoot, computed) of
@@ -148,11 +171,56 @@ csmtMerkleTreeStoreT fromKV hashing =
                 _ -> False
         }
 
--- | Build an IO 'MerkleTreeStore' for CSMT.
+-- | Build an IO 'MerkleTreeStore' for CSMT scoped to a prefix.
 --
 -- Each operation commits in its own transaction. For atomic
 -- multi-operation sequences, use 'csmtMerkleTreeStoreT' instead.
 csmtMerkleTreeStore
+    :: (MonadFail m)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> (forall b. m b -> IO b)
+    -> Database
+        m
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+    -> FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> MerkleTreeStore CsmtImpl IO
+csmtMerkleTreeStore prefix run db fromKV hashing =
+    hoistMTS
+        (run . runTransactionUnguarded db)
+        (csmtMerkleTreeStoreT prefix fromKV hashing)
+
+-- | Build a transactional 'NamespacedMTS' for CSMT.
+--
+-- Each namespace is a prefix-scoped 'MerkleTreeStore'.
+csmtNamespacedMTST
+    :: (Monad m)
+    => FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> NamespacedMTS
+        CsmtImpl
+        ( Transaction
+            m
+            StandaloneCF
+            (Standalone ByteString ByteString Hash)
+            StandaloneOp
+        )
+csmtNamespacedMTST fromKV hashing =
+    NamespacedMTS
+        { nsStore = \prefix ->
+            csmtMerkleTreeStoreT prefix fromKV hashing
+        , nsDelete =
+            deleteSubtree StandaloneCSMTCol
+        }
+
+-- | Build an IO 'NamespacedMTS' for CSMT.
+--
+-- Each namespace is a prefix-scoped 'MerkleTreeStore' that
+-- commits each operation in its own transaction.
+csmtNamespacedMTS
     :: (MonadFail m)
     => (forall b. m b -> IO b)
     -> Database
@@ -162,8 +230,8 @@ csmtMerkleTreeStore
         StandaloneOp
     -> FromKV ByteString ByteString Hash
     -> Hashing Hash
-    -> MerkleTreeStore CsmtImpl IO
-csmtMerkleTreeStore run db fromKV hashing =
-    hoistMTS
+    -> NamespacedMTS CsmtImpl IO
+csmtNamespacedMTS run db fromKV hashing =
+    hoistNamespacedMTS
         (run . runTransactionUnguarded db)
-        (csmtMerkleTreeStoreT fromKV hashing)
+        (csmtNamespacedMTST fromKV hashing)

--- a/lib/csmt/CSMT/Proof/Completeness.hs
+++ b/lib/csmt/CSMT/Proof/Completeness.hs
@@ -184,8 +184,10 @@ collectValues
     :: (Monad m, GCompare d)
     => Selector d Key (Indirect a)
     -> Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Key
     -> Transaction m cf d op [Indirect a]
-collectValues sel = navigate []
+collectValues sel = navigate
   where
     navigate currentKey remainingPrefix = do
         mi <- query sel currentKey
@@ -228,9 +230,11 @@ generateProof
      . (Monad m, GCompare d)
     => Selector d Key (Indirect a)
     -> Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Key
     -> Transaction m cf d op (Maybe (CompletenessProof a))
-generateProof sel targetPrefix = do
-    result <- navigate 0 [] targetPrefix []
+generateProof sel pfx targetPrefix = do
+    result <- navigate 0 pfx targetPrefix []
     pure $ case result of
         Nothing -> Nothing
         Just (mergeOps, _, inclusionSteps) ->
@@ -361,8 +365,10 @@ queryPrefix
     :: (Monad m, GCompare d)
     => Selector d Key (Indirect a)
     -> Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Key
     -> Transaction m cf d op (Maybe (Indirect a))
-queryPrefix sel = navigate []
+queryPrefix sel = navigate
   where
     navigate currentKey remainingPrefix = do
         mi <- query sel currentKey

--- a/lib/csmt/CSMT/Proof/Insertion.hs
+++ b/lib/csmt/CSMT/Proof/Insertion.hs
@@ -89,7 +89,9 @@ data InclusionProof a = InclusionProof
 -- the current state of the tree.
 buildInclusionProof
     :: (Monad m, Ord k, GCompare d)
-    => FromKV k v a
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV k v a
     -> Selector d k v
     -- ^ KV column to look up the value
     -> Selector d Key (Indirect a)
@@ -97,12 +99,12 @@ buildInclusionProof
     -> Hashing a
     -> k
     -> Transaction m cf d ops (Maybe (v, InclusionProof a))
-buildInclusionProof FromKV{isoK, fromV, treePrefix} kvSel csmtSel hashing k =
+buildInclusionProof pfx FromKV{isoK, fromV, treePrefix} kvSel csmtSel hashing k =
     runMaybeT $ do
         v <- MaybeT $ query kvSel k
         let key = treePrefix v <> view isoK k
             value = fromV v
-        rootIndirect@(Indirect rootJump _) <- MaybeT $ query csmtSel []
+        rootIndirect@(Indirect rootJump _) <- MaybeT $ query csmtSel pfx
         guard $ isPrefixOf rootJump key
         steps <- go rootJump $ drop (length rootJump) key
         let proofData =

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -218,8 +218,8 @@ mpfNamespacedMTST fromKV hashing =
     NamespacedMTS
         { nsStore = \prefix ->
             mpfMerkleTreeStoreT prefix fromKV hashing
-        , nsDelete = \prefix ->
-            deleteSubtree MPFStandaloneMPFCol prefix
+        , nsDelete =
+            deleteSubtree MPFStandaloneMPFCol
         }
 
 -- | Build an IO 'NamespacedMTS' for MPF.

--- a/lib/mpf/MPF/Proof/Completeness.hs
+++ b/lib/mpf/MPF/Proof/Completeness.hs
@@ -52,7 +52,7 @@ collectMPFLeaves
     -> HexKey
     -- ^ Prefix (use @[]@ for root)
     -> Transaction m cf d op [HexIndirect a]
-collectMPFLeaves sel prefix = navigate prefix
+collectMPFLeaves sel = navigate
   where
     navigate currentKey = do
         mi <- query sel currentKey

--- a/mts.cabal
+++ b/mts.cabal
@@ -231,6 +231,7 @@ test-suite unit-tests
     CSMT.HashesSpec
     CSMT.InsertionSpec
     CSMT.InterfaceSpec
+    CSMT.NamespaceSpec
     CSMT.Proof.CompletenessSpec
     CSMT.Proof.InsertionSpec
     CSMT.TreePrefixSpec

--- a/test-lib/csmt/CSMT/Test/Lib.hs
+++ b/test-lib/csmt/CSMT/Test/Lib.hs
@@ -43,6 +43,13 @@ module CSMT.Test.Lib
     , word64Codecs
     , hashCodecs
     , listOfWord64Codecs
+    , insertHashMAt
+    , deleteHashMAt
+    , deleteSubtreeHashMAt
+    , getRootHashMAt
+    , verifyHashMAt
+    , insertHashM
+    , getRootHashM
     )
 where
 
@@ -55,6 +62,7 @@ import CSMT
     , Standalone (..)
     , StandaloneCodecs (..)
     , buildInclusionProof
+    , deleteSubtree
     , inserting
     , keyPrism
     , verifyInclusionProof
@@ -72,7 +80,7 @@ import CSMT.Deletion
     , newDeletionPath
     )
 import CSMT.Hashes (Hash, hashHashing, isoHash, mkHash)
-import CSMT.Interface (FromKV (..), Hashing (..))
+import CSMT.Interface (FromKV (..), Hashing (..), root)
 import Control.Lens (Prism', prism', simple)
 import Control.Monad (replicateM)
 import Control.Monad.Free (Free (..), liftF)
@@ -157,7 +165,7 @@ insertM
     -> Pure ()
 insertM codecs fromKV hashing k v =
     runTransactionUnguarded (pureDatabase codecs)
-        $ inserting fromKV hashing StandaloneKVCol StandaloneCSMTCol k v
+        $ inserting [] fromKV hashing StandaloneKVCol StandaloneCSMTCol k v
 
 word64Prism :: Prism' ByteString Word64
 word64Prism = prism' encode decode
@@ -176,7 +184,7 @@ deleteM
     -> Pure ()
 deleteM codecs fromKV hashing k =
     runTransactionUnguarded (pureDatabase codecs)
-        $ deleting fromKV hashing StandaloneKVCol StandaloneCSMTCol k
+        $ deleting [] fromKV hashing StandaloneKVCol StandaloneCSMTCol k
 
 insertMWord64 :: Key -> Word64 -> Pure ()
 insertMWord64 = insertM word64Codecs identityFromKV word64Hashing
@@ -235,6 +243,7 @@ proofM
 proofM codecs fromKV hashing k =
     runTransactionUnguarded (pureDatabase codecs)
         $ buildInclusionProof
+            []
             fromKV
             StandaloneKVCol
             StandaloneCSMTCol
@@ -324,7 +333,7 @@ mkDeletionPath codecs s k =
     fst
         . runPure s
         $ runTransactionUnguarded (pureDatabase codecs)
-        $ newDeletionPath StandaloneCSMTCol k
+        $ newDeletionPath [] StandaloneCSMTCol k
 
 data List e a
     = Cons e a
@@ -371,3 +380,66 @@ insertHashes = mapM_ $ insertIndirectM hashCodecs hashHashing
 
 manyRandomPaths :: Gen [Key]
 manyRandomPaths = scale (* 10) $ genSomePaths 256
+
+-- | Insert a hash at a prefix in the Pure monad.
+insertHashMAt :: Key -> Key -> Hash -> Pure ()
+insertHashMAt prefix k v =
+    runTransactionUnguarded (pureDatabase hashCodecs)
+        $ inserting
+            prefix
+            identityFromKV
+            hashHashing
+            StandaloneKVCol
+            StandaloneCSMTCol
+            k
+            v
+
+-- | Insert a hash at root in the Pure monad.
+insertHashM :: Key -> Hash -> Pure ()
+insertHashM = insertHashMAt []
+
+-- | Delete a hash at a prefix in the Pure monad.
+deleteHashMAt :: Key -> Key -> Pure ()
+deleteHashMAt prefix k =
+    runTransactionUnguarded (pureDatabase hashCodecs)
+        $ deleting
+            prefix
+            identityFromKV
+            hashHashing
+            StandaloneKVCol
+            StandaloneCSMTCol
+            k
+
+-- | Delete an entire subtree at a prefix.
+deleteSubtreeHashMAt :: Key -> Pure ()
+deleteSubtreeHashMAt prefix =
+    runTransactionUnguarded (pureDatabase hashCodecs)
+        $ deleteSubtree StandaloneCSMTCol prefix
+
+-- | Get the root hash at a prefix.
+getRootHashMAt :: Key -> Pure (Maybe Hash)
+getRootHashMAt prefix =
+    runTransactionUnguarded (pureDatabase hashCodecs)
+        $ root hashHashing StandaloneCSMTCol prefix
+
+-- | Get the root hash at root.
+getRootHashM :: Pure (Maybe Hash)
+getRootHashM = getRootHashMAt []
+
+-- | Verify a membership proof at a prefix.
+verifyHashMAt :: Key -> Key -> Hash -> Pure Bool
+verifyHashMAt prefix k v =
+    runTransactionUnguarded (pureDatabase hashCodecs) $ do
+        mProof <-
+            buildInclusionProof
+                prefix
+                identityFromKV
+                StandaloneKVCol
+                StandaloneCSMTCol
+                hashHashing
+                k
+        pure $ case mProof of
+            Nothing -> False
+            Just (val, proof) ->
+                val == v
+                    && verifyInclusionProof hashHashing proof

--- a/test/CSMT/Backend/RocksDBSpec.hs
+++ b/test/CSMT/Backend/RocksDBSpec.hs
@@ -84,6 +84,7 @@ rocksDBCodecs =
 iM :: ByteString -> ByteString -> T ()
 iM =
     inserting
+        []
         fromKVHashes
         hashHashing
         StandaloneKVCol
@@ -92,6 +93,7 @@ iM =
 dM :: ByteString -> T ()
 dM =
     deleting
+        []
         fromKVHashes
         hashHashing
         StandaloneKVCol
@@ -100,6 +102,7 @@ dM =
 pfM :: ByteString -> T (Maybe (ByteString, InclusionProof Hash))
 pfM =
     buildInclusionProof
+        []
         fromKVHashes
         StandaloneKVCol
         StandaloneCSMTCol

--- a/test/CSMT/DeletionSpec.hs
+++ b/test/CSMT/DeletionSpec.hs
@@ -50,7 +50,7 @@ spec = do
                 (mp, _) = do
                     runPure rs0
                         $ runPureTransaction word64Codecs
-                        $ newDeletionPath StandaloneCSMTCol []
+                        $ newDeletionPath [] StandaloneCSMTCol []
               in
                 mp `shouldBe` Just (Value [] 1)
         it "constructs a deletion path for a tree with siblings"
@@ -269,7 +269,7 @@ spec = do
                 rs1 = insertWord64 rs0 [L, R] (2 :: Word64)
                 rs2 = insertWord64 rs1 [R, L] (3 :: Word64)
                 Just mp = mkDeletionPath word64Codecs rs2 [L, R]
-                ops = deletionPathToOps word64Hashing mp
+                ops = deletionPathToOps [] word64Hashing mp
               in
                 ops
                     `shouldBe` [ ([], Just $ node [R, L] 3)

--- a/test/CSMT/NamespaceSpec.hs
+++ b/test/CSMT/NamespaceSpec.hs
@@ -1,0 +1,85 @@
+module CSMT.NamespaceSpec (spec) where
+
+import CSMT.Hashes (mkHash)
+import CSMT.Interface (Direction (..))
+import CSMT.Test.Lib
+    ( deleteHashMAt
+    , deleteSubtreeHashMAt
+    , evalPureFromEmptyDB
+    , getRootHashM
+    , getRootHashMAt
+    , insertHashM
+    , insertHashMAt
+    , verifyHashMAt
+    )
+import Data.String (fromString)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
+
+spec :: Spec
+spec = describe "CSMT.Namespace" $ do
+    let pfxA = [L, L]
+        pfxB = [L, R]
+        key1 = [R, L, R]
+        val1 = mkHash $ fromString "world"
+        key2 = [R, R, L]
+        val2 = mkHash $ fromString "bar"
+        key3 = [L, R, L]
+        val3 = mkHash $ fromString "qux"
+
+    it "namespaces are independent" $ do
+        let (rootA, rootB) = evalPureFromEmptyDB $ do
+                insertHashMAt pfxA key1 val1
+                insertHashMAt pfxB key2 val2
+                (,)
+                    <$> getRootHashMAt pfxA
+                    <*> getRootHashMAt pfxB
+        rootA `shouldNotBe` rootB
+
+    it "prefix root matches non-prefixed root" $ do
+        let rootPrefixed = evalPureFromEmptyDB $ do
+                insertHashMAt pfxA key1 val1
+                getRootHashMAt pfxA
+            rootPlain = evalPureFromEmptyDB $ do
+                insertHashM key1 val1
+                getRootHashM
+        rootPrefixed `shouldBe` rootPlain
+
+    it "delete under one prefix doesn't affect another" $ do
+        let rootB = evalPureFromEmptyDB $ do
+                insertHashMAt pfxA key1 val1
+                insertHashMAt pfxB key2 val2
+                deleteHashMAt pfxA key1
+                getRootHashMAt pfxB
+            rootBAlone = evalPureFromEmptyDB $ do
+                insertHashMAt pfxB key2 val2
+                getRootHashMAt pfxB
+        rootB `shouldBe` rootBAlone
+
+    it "nsDelete wipes entire namespace" $ do
+        let (rootA, rootB) = evalPureFromEmptyDB $ do
+                insertHashMAt pfxA key1 val1
+                insertHashMAt pfxA key2 val2
+                insertHashMAt pfxB key3 val3
+                deleteSubtreeHashMAt pfxA
+                (,)
+                    <$> getRootHashMAt pfxA
+                    <*> getRootHashMAt pfxB
+        rootA `shouldBe` Nothing
+        rootB `shouldNotBe` Nothing
+
+    it "proofs work within a namespace" $ do
+        let verified = evalPureFromEmptyDB $ do
+                insertHashMAt pfxA key1 val1
+                verifyHashMAt pfxA key1 val1
+        verified `shouldBe` True
+
+    it "multiple inserts in same namespace" $ do
+        let rootPrefixed = evalPureFromEmptyDB $ do
+                insertHashMAt pfxA key1 val1
+                insertHashMAt pfxA key2 val2
+                getRootHashMAt pfxA
+            rootPlain = evalPureFromEmptyDB $ do
+                insertHashM key1 val1
+                insertHashM key2 val2
+                getRootHashM
+        rootPrefixed `shouldBe` rootPlain

--- a/test/CSMT/Proof/CompletenessSpec.hs
+++ b/test/CSMT/Proof/CompletenessSpec.hs
@@ -45,7 +45,7 @@ spec = do
                     collected = evalPureFromEmptyDB $ do
                         insertWord64s values
                         runPureTransaction word64Codecs
-                            $ collectValues StandaloneCSMTCol []
+                            $ collectValues StandaloneCSMTCol [] []
                 collected
                     `shouldBe` sort values
         it "collects all values for a simple tree of hashes"
@@ -56,7 +56,7 @@ spec = do
                     collected = evalPureFromEmptyDB $ do
                         insertHashes values
                         runPureTransaction hashCodecs
-                            $ collectValues StandaloneCSMTCol []
+                            $ collectValues StandaloneCSMTCol [] []
                 collected
                     `shouldBe` sort values
     describe "generateProof" $ do
@@ -64,14 +64,14 @@ spec = do
             $ let mp =
                     evalPureFromEmptyDB
                         $ runPureTransaction hashCodecs
-                        $ generateProof StandaloneCSMTCol []
+                        $ generateProof StandaloneCSMTCol [] []
               in  mp `shouldBe` Nothing
         it "can generate proof for simple tree"
             $ let
                 mp = evalPureFromEmptyDB $ do
                     insertWord64s [indirect [L] 1]
                     runPureTransaction word64Codecs
-                        $ generateProof StandaloneCSMTCol []
+                        $ generateProof StandaloneCSMTCol [] []
               in
                 fmap cpMergeOps mp `shouldBe` Just []
         it "can generate proof for larger tree"
@@ -82,7 +82,7 @@ spec = do
                         , indirect [R] 2
                         ]
                     runPureTransaction word64Codecs
-                        $ generateProof StandaloneCSMTCol []
+                        $ generateProof StandaloneCSMTCol [] []
               in
                 fmap cpMergeOps mp `shouldBe` Just [(0, 1)]
         it "can generate proof for even larger tree"
@@ -95,7 +95,7 @@ spec = do
                         , indirect [R, R, R, R] 16
                         ]
                     runPureTransaction word64Codecs
-                        $ generateProof StandaloneCSMTCol []
+                        $ generateProof StandaloneCSMTCol [] []
               in
                 fmap cpMergeOps mp
                     `shouldBe` Just [(1, 2), (0, 1), (0, 3)]
@@ -112,7 +112,7 @@ spec = do
                     insertWord64s values
                     mp' <-
                         runPureTransaction word64Codecs
-                            $ generateProof StandaloneCSMTCol []
+                            $ generateProof StandaloneCSMTCol [] []
                     r' <-
                         runPureTransaction word64Codecs
                             $ query StandaloneCSMTCol []
@@ -138,7 +138,7 @@ spec = do
                         insertWord64s values
                         mp' <-
                             runPureTransaction word64Codecs
-                                $ generateProof StandaloneCSMTCol []
+                                $ generateProof StandaloneCSMTCol [] []
                         r' <-
                             runPureTransaction word64Codecs
                                 $ query StandaloneCSMTCol []
@@ -163,7 +163,7 @@ spec = do
                         insertHashes values
                         mp' <-
                             runPureTransaction hashCodecs
-                                $ generateProof StandaloneCSMTCol []
+                                $ generateProof StandaloneCSMTCol [] []
                         r' <-
                             runPureTransaction hashCodecs
                                 $ query StandaloneCSMTCol []

--- a/test/CSMT/TreePrefixSpec.hs
+++ b/test/CSMT/TreePrefixSpec.hs
@@ -121,12 +121,12 @@ spec = do
                     fst
                         $ runPure db
                         $ runPureTransaction word64Codecs
-                        $ collectValues StandaloneCSMTCol [L]
+                        $ collectValues StandaloneCSMTCol [] [L]
                 collectedR =
                     fst
                         $ runPure db
                         $ runPureTransaction word64Codecs
-                        $ collectValues StandaloneCSMTCol [R]
+                        $ collectValues StandaloneCSMTCol [] [R]
             length collectedL `shouldBe` 2
             length collectedR `shouldBe` 1
 
@@ -139,7 +139,7 @@ spec = do
                     fst
                         $ runPure db
                         $ runPureTransaction word64Codecs
-                        $ collectValues StandaloneCSMTCol [L]
+                        $ collectValues StandaloneCSMTCol [] [L]
             length collected `shouldBe` 1
             map value collected `shouldBe` [2]
 
@@ -196,12 +196,12 @@ spec = do
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
-                                $ collectValues StandaloneCSMTCol [L]
+                                $ collectValues StandaloneCSMTCol [] [L]
                         collectedR =
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
-                                $ collectValues StandaloneCSMTCol [R]
+                                $ collectValues StandaloneCSMTCol [] [R]
                         actualEven = sort $ map value collectedL
                         actualOdd = sort $ map value collectedR
                     actualEven `shouldBe` expectedEven
@@ -218,7 +218,7 @@ spec = do
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
-                                $ collectValues StandaloneCSMTCol p
+                                $ collectValues StandaloneCSMTCol [] p
                         allValues = sort $ map value $ collect []
                         partitioned =
                             sort
@@ -239,7 +239,7 @@ spec = do
                                 $ fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
-                                $ collectValues StandaloneCSMTCol []
+                                $ collectValues StandaloneCSMTCol [] []
                         expected = sort $ map snd kvs
                     collected `shouldBe` expected
 
@@ -255,7 +255,7 @@ spec = do
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
-                                $ collectValues StandaloneCSMTCol [R]
+                                $ collectValues StandaloneCSMTCol [] [R]
                     collected `shouldBe` []
 
         it "completeness proof for both prefix subtrees verifies"
@@ -269,14 +269,14 @@ spec = do
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
-                                $ queryPrefix StandaloneCSMTCol []
+                                $ queryPrefix StandaloneCSMTCol [] []
                         verifyP p =
                             fst
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
                                 $ do
-                                    c <- collectValues StandaloneCSMTCol p
-                                    pr <- generateProof StandaloneCSMTCol p
+                                    c <- collectValues StandaloneCSMTCol [] p
+                                    pr <- generateProof StandaloneCSMTCol [] p
                                     pure (c, pr)
                     -- Verify both [L] and [R] subtrees
                     mapM_
@@ -310,9 +310,9 @@ spec = do
                                 $ runPure db
                                 $ runPureTransaction word64Codecs
                                 $ do
-                                    c <- collectValues StandaloneCSMTCol []
-                                    p <- generateProof StandaloneCSMTCol []
-                                    r <- queryPrefix StandaloneCSMTCol []
+                                    c <- collectValues StandaloneCSMTCol [] []
+                                    p <- generateProof StandaloneCSMTCol [] []
+                                    r <- queryPrefix StandaloneCSMTCol [] []
                                     pure (c, p, r)
                     case proof of
                         Nothing -> collected `shouldBe` []
@@ -339,8 +339,8 @@ spec = do
                                         $ runPure db
                                         $ runPureTransaction word64Codecs
                                         $ do
-                                            c <- collectValues StandaloneCSMTCol p
-                                            pr <- generateProof StandaloneCSMTCol p
+                                            c <- collectValues StandaloneCSMTCol [] p
+                                            pr <- generateProof StandaloneCSMTCol [] p
                                             pure (null c, isJust pr)
                             in  isEmpty /= hasProof
                     all consistent ([[], [L], [R]] :: [Key])

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -54,6 +54,7 @@ mkCsmtStore = do
             pure a
     pure
         $ csmtMerkleTreeStore
+            []
             run
             (pureDatabase csmtCodecs)
             fromKVHashes


### PR DESCRIPTION
Closes #71

## Summary

- Add `Key` prefix parameter to all CSMT core functions (`inserting`, `deleting`, `buildInclusionProof`, `root`, `collectValues`, `generateProof`, `queryPrefix`, etc.) replacing hardcoded `[]` root entry points
- Add `deleteSubtree` for CSMT binary trie (walks L/R branches)
- Add `csmtNamespacedMTST` and `csmtNamespacedMTS` constructors with `MtsPrefix CsmtImpl = Key`
- Add `CSMT.NamespaceSpec` with 6 tests mirroring `MPF.NamespaceSpec`
- Fix pre-existing hlint hints in MPF code

## Test plan

- [x] All 195 tests pass (6 new namespace tests)
- [x] hlint clean
- [x] fourmolu + cabal-fmt format checks pass
- [x] CI green locally