### PR TITLE
fix: use format-check in CI and add hlint job

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -92,4 +92,14 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check Formatting
-        run: nix --quiet develop -c just format
+        run: nix --quiet develop -c just format-check
+  hlint:
+    name: HLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Run HLint
+        run: nix --quiet develop -c just hlint

--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -507,7 +507,7 @@ replayEntries
 replayEntries prefix fromKV hashing entries = do
     mapM_ applyEntry entries
     mapM_
-        (\e -> delete StandaloneJournalCol (entryKey e))
+        (delete StandaloneJournalCol . entryKey)
         entries
   where
     applyEntry e =

--- a/lib/mpf/MPF/Backend/RocksDB.hs
+++ b/lib/mpf/MPF/Backend/RocksDB.hs
@@ -64,7 +64,8 @@ mpfStandaloneRocksDBCols
                     }
             ]
 mpfStandaloneRocksDBCols _ _ =
-    error "mpfStandaloneRocksDBCols: expected exactly three column families"
+    error
+        "mpfStandaloneRocksDBCols: expected exactly three column families"
 
 -- | Create a RocksDB database for MPF
 mpfStandaloneRocksDBDatabase

--- a/lib/mpf/MPF/Backend/Standalone.hs
+++ b/lib/mpf/MPF/Backend/Standalone.hs
@@ -20,7 +20,10 @@ import Database.KV.Transaction
 import MPF.Interface (HexIndirect (..), HexKey)
 
 -- | Column family identifiers for MPF standalone backend
-data MPFStandaloneCF = MPFStandaloneKV | MPFStandaloneMPF | MPFStandaloneJournal
+data MPFStandaloneCF
+    = MPFStandaloneKV
+    | MPFStandaloneMPF
+    | MPFStandaloneJournal
     deriving (Show, Eq, Ord)
 
 -- | Operation type for standalone backend
@@ -35,7 +38,8 @@ mkMPFStandaloneOp = (,,)
 data MPFStandalone k v a x where
     MPFStandaloneKVCol :: MPFStandalone k v a (KV k v)
     MPFStandaloneMPFCol :: MPFStandalone k v a (KV HexKey (HexIndirect a))
-    MPFStandaloneJournalCol :: MPFStandalone k v a (KV ByteString ByteString)
+    MPFStandaloneJournalCol
+        :: MPFStandalone k v a (KV ByteString ByteString)
 
 instance GEq (MPFStandalone k v a) where
     geq MPFStandaloneKVCol MPFStandaloneKVCol = Just Refl

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -35,9 +35,9 @@ module MPF.MTS
 where
 
 import Control.Monad (unless, when)
-import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Database.KV.Cursor
     ( Cursor
     , Entry (..)
@@ -492,7 +492,7 @@ mpfReplayEntries
         ()
 mpfReplayEntries prefix fromKV hashing entries = do
     mapM_ applyEntry entries
-    mapM_ (\e -> delete MPFStandaloneJournalCol (entryKey e)) entries
+    mapM_ (delete MPFStandaloneJournalCol . entryKey) entries
   where
     applyEntry e =
         let (tag, v) = parseJournalEntry (entryValue e)

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -403,7 +403,7 @@ spec = do
     describe "CSMT mode exclusivity" $ do
         it "Full rejects non-empty journal"
             $ mkCsmtStoreWithJournal
-                `shouldThrow` (\(_ :: SomeException) -> True)
+            `shouldThrow` (\(_ :: SomeException) -> True)
         it "KVOnly throws after transition" $ do
             t <- mkCsmtTransition
             mtsInsert (mtsKV (transitionKVStore t)) "k" "v"
@@ -419,7 +419,7 @@ spec = do
     describe "MPF mode exclusivity" $ do
         it "Full rejects non-empty journal"
             $ mkMpfStoreWithJournal
-                `shouldThrow` (\(_ :: SomeException) -> True)
+            `shouldThrow` (\(_ :: SomeException) -> True)
         it "KVOnly throws after transition" $ do
             t <- mkMpfTransition
             mtsInsert (mtsKV (transitionKVStore t)) "k" "v"


### PR DESCRIPTION
## Summary
- CI formatting job ran `just format` (silently fixes) instead of `just format-check` (fails on violations), letting unformatted code through
- Adds missing hlint CI job
- Fixes existing fourmolu and hlint violations on main