### PR TITLE
feat!: add split-mode MTS with KVOnly bootstrap and journal replay

### DIFF
--- a/lib/csmt/CSMT/Backend/Pure.hs
+++ b/lib/csmt/CSMT/Backend/Pure.hs
@@ -36,7 +36,7 @@ import CSMT.Interface
     , Key
     , csmtCodecs
     )
-import Control.Lens (preview)
+import Control.Lens (iso, preview)
 import Control.Monad.Catch.Pure (Catch, runCatch)
 import Control.Monad.Trans.State.Strict
     ( StateT (runStateT)
@@ -119,15 +119,17 @@ prevCursor c@Cursor{position = Just k, snapshot} =
             Nothing -> c{position = Nothing}
 
 -- |
--- In-memory database storing CSMT nodes and key-value pairs.
+-- In-memory database storing CSMT nodes, key-value pairs, and journal.
 --
--- Contains three maps:
+-- Contains four maps:
 -- * 'inMemoryCSMT' - The CSMT node storage
 -- * 'inMemoryKV' - The key-value pair storage
+-- * 'inMemoryJournal' - The journal for KVOnly replay
 -- * 'inMemoryIterators' - Active iterator cursors
 data InMemoryDB = InMemoryDB
     { inMemoryCSMT :: Map ByteString ByteString
     , inMemoryKV :: Map ByteString ByteString
+    , inMemoryJournal :: Map ByteString ByteString
     , inMemoryIterators :: Map Int Cursor
     }
     deriving (Show, Eq)
@@ -148,7 +150,7 @@ inMemoryCSMTParsed StandaloneCodecs{nodeCodec = pa} m =
 
 -- | An empty in-memory database with no data.
 emptyInMemoryDB :: InMemoryDB
-emptyInMemoryDB = InMemoryDB Map.empty Map.empty Map.empty
+emptyInMemoryDB = InMemoryDB Map.empty Map.empty Map.empty Map.empty
 
 onCSMT
     :: (Map ByteString ByteString -> Map ByteString ByteString)
@@ -161,6 +163,12 @@ onKV
     -> InMemoryDB
     -> InMemoryDB
 onKV f m = m{inMemoryKV = f (inMemoryKV m)}
+
+onJournal
+    :: (Map ByteString ByteString -> Map ByteString ByteString)
+    -> InMemoryDB
+    -> InMemoryDB
+onJournal f m = m{inMemoryJournal = f (inMemoryJournal m)}
 
 -- | Pure monad for CSMT operations
 type Pure = StateT InMemoryDB Catch
@@ -182,6 +190,9 @@ pureValueAt StandaloneKV k = do
 pureValueAt StandaloneCSMT k = do
     csmt <- gets inMemoryCSMT
     pure $ Map.lookup k csmt
+pureValueAt StandaloneJournal k = do
+    journal <- gets inMemoryJournal
+    pure $ Map.lookup k journal
 
 pureApplyOps :: [StandaloneOp] -> Pure ()
 pureApplyOps ops = forM_ ops $ \(cf, k, mv) -> case (cf, mv) of
@@ -189,6 +200,8 @@ pureApplyOps ops = forM_ ops $ \(cf, k, mv) -> case (cf, mv) of
     (StandaloneKV, Just v) -> modify' $ onKV $ Map.insert k v
     (StandaloneCSMT, Nothing) -> modify' $ onCSMT $ Map.delete k
     (StandaloneCSMT, Just v) -> modify' $ onCSMT $ Map.insert k v
+    (StandaloneJournal, Nothing) -> modify' $ onJournal $ Map.delete k
+    (StandaloneJournal, Just v) -> modify' $ onJournal $ Map.insert k v
 
 -- | Build column definitions for the pure in-memory backend.
 standalonePureCols
@@ -206,6 +219,11 @@ standalonePureCols StandaloneCodecs{keyCodec = pk, valueCodec = pv, nodeCodec = 
                 { family = StandaloneCSMT
                 , codecs = csmtCodecs pa
                 }
+        , StandaloneJournalCol
+            :=> Column
+                { family = StandaloneJournal
+                , codecs = Codecs (iso id id) (iso id id)
+                }
         ]
 
 pureIterator :: StandaloneCF -> Pure (QueryIterator Pure)
@@ -213,6 +231,7 @@ pureIterator cf = do
     db <- gets $ case cf of
         StandaloneKV -> inMemoryKV
         StandaloneCSMT -> inMemoryCSMT
+        StandaloneJournal -> inMemoryJournal
     nextId <- gets $ \m -> case Map.lookupMax (inMemoryIterators m) of
         Just (i, _) -> i + 1
         Nothing -> 0

--- a/lib/csmt/CSMT/Backend/RocksDB.hs
+++ b/lib/csmt/CSMT/Backend/RocksDB.hs
@@ -7,9 +7,10 @@
 -- A persistent storage backend for CSMT using RocksDB. This backend stores
 -- all data on disk, making it suitable for production use with large datasets.
 --
--- The database uses two column families:
+-- The database uses three column families:
 -- * \"kv\" - For key-value pair storage
 -- * \"csmt\" - For CSMT node storage
+-- * \"journal\" - For KVOnly mode journal entries
 module CSMT.Backend.RocksDB
     ( withRocksDB
     , RocksDB
@@ -26,6 +27,7 @@ import CSMT.Backend.Standalone
 import CSMT.Interface (csmtCodecs)
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
 import Control.Concurrent.Async (async, link)
+import Control.Lens (iso)
 import Control.Monad ((<=<))
 import Control.Monad.Trans.Reader (ReaderT (..), ask)
 import Database.KV.Database
@@ -58,7 +60,7 @@ standaloneRocksDBCols
     -> DMap (Standalone k v a) (Column ColumnFamily)
 standaloneRocksDBCols
     StandaloneCodecs{keyCodec, valueCodec, nodeCodec = pa}
-    [kvcf, csmtcf] =
+    [kvcf, csmtcf, journalcf] =
         fromPairList
             [ StandaloneKVCol
                 :=> Column
@@ -70,8 +72,14 @@ standaloneRocksDBCols
                     { family = csmtcf
                     , codecs = csmtCodecs pa
                     }
+            , StandaloneJournalCol
+                :=> Column
+                    { family = journalcf
+                    , codecs = Codecs (iso id id) (iso id id)
+                    }
             ]
-standaloneRocksDBCols _ _ = error "pureCols: expected exactly two column families"
+standaloneRocksDBCols _ _ =
+    error "standaloneRocksDBCols: expected exactly three column families"
 
 -- | Create a RocksDB-backed database instance.
 standaloneRocksDBDatabase
@@ -104,7 +112,10 @@ withRocksDB path csmtMaxFiles kvMaxFiles action = do
     withDBCF
         path
         def
-        [("kv", configKV kvMaxFiles), ("csmt", configCSMT csmtMaxFiles)]
+        [ ("kv", configKV kvMaxFiles)
+        , ("csmt", configCSMT csmtMaxFiles)
+        , ("journal", configJournal)
+        ]
         $ \db -> do
             action $ RunRocksDB $ flip runReaderT db
 
@@ -122,7 +133,10 @@ unsafeWithRocksDB path csmtMaxFiles kvMaxFiles = do
         withDBCF
             path
             def
-            [("kv", configKV kvMaxFiles), ("csmt", configCSMT csmtMaxFiles)]
+            [ ("kv", configKV kvMaxFiles)
+            , ("csmt", configCSMT csmtMaxFiles)
+            , ("journal", configJournal)
+            ]
             $ \db -> do
                 putMVar dbv (RunRocksDB $ flip runReaderT db)
                 readMVar wait
@@ -163,6 +177,18 @@ configKV n =
         , errorIfExists = False
         , paranoidChecks = False
         , maxFiles = Just n
+        , prefixLength = Nothing
+        , bloomFilter = False
+        }
+
+-- | Configuration for the journal column family.
+configJournal :: Config
+configJournal =
+    Config
+        { createIfMissing = True
+        , errorIfExists = False
+        , paranoidChecks = False
+        , maxFiles = Nothing
         , prefixLength = Nothing
         , bloomFilter = False
         }

--- a/lib/csmt/CSMT/Backend/Standalone.hs
+++ b/lib/csmt/CSMT/Backend/Standalone.hs
@@ -32,7 +32,7 @@ import Database.KV.Transaction
     )
 
 -- | Column family identifiers for the standalone backend.
-data StandaloneCF = StandaloneKV | StandaloneCSMT
+data StandaloneCF = StandaloneKV | StandaloneCSMT | StandaloneJournal
 
 -- | A database operation: column family, key, and optional value (Nothing = delete).
 type StandaloneOp = (StandaloneCF, ByteString, Maybe ByteString)
@@ -43,26 +43,33 @@ mkStandaloneOp
 mkStandaloneOp = (,,)
 
 -- |
--- GADT defining the two column types in the standalone backend:
+-- GADT defining the column types in the standalone backend:
 --
 -- * 'StandaloneKVCol' - The key-value storage column
 -- * 'StandaloneCSMTCol' - The CSMT node storage column
+-- * 'StandaloneJournalCol' - The journal column for KVOnly replay
 data Standalone k v a x where
     -- | Column for user key-value pairs
     StandaloneKVCol :: Standalone k v a (KV k v)
     -- | Column for CSMT tree nodes
     StandaloneCSMTCol :: Standalone k v a (KV Key (Indirect a))
+    -- | Column for journal entries (raw ByteString key-value)
+    StandaloneJournalCol :: Standalone k v a (KV ByteString ByteString)
 
 instance GEq (Standalone k v a) where
     geq StandaloneKVCol StandaloneKVCol = Just Refl
     geq StandaloneCSMTCol StandaloneCSMTCol = Just Refl
+    geq StandaloneJournalCol StandaloneJournalCol = Just Refl
     geq _ _ = Nothing
 
 instance GCompare (Standalone k v a) where
     gcompare StandaloneKVCol StandaloneKVCol = GEQ
-    gcompare StandaloneKVCol StandaloneCSMTCol = GLT
+    gcompare StandaloneKVCol _ = GLT
     gcompare StandaloneCSMTCol StandaloneKVCol = GGT
     gcompare StandaloneCSMTCol StandaloneCSMTCol = GEQ
+    gcompare StandaloneCSMTCol StandaloneJournalCol = GLT
+    gcompare StandaloneJournalCol StandaloneJournalCol = GEQ
+    gcompare StandaloneJournalCol _ = GGT
 
 -- |
 -- Codecs for serializing keys, values, and hash nodes to ByteStrings.

--- a/lib/csmt/CSMT/Deletion.hs
+++ b/lib/csmt/CSMT/Deletion.hs
@@ -16,6 +16,7 @@
 -- by extending jump paths where branches become unnecessary.
 module CSMT.Deletion
     ( deleting
+    , deletingTreeOnly
     , newDeletionPath
     , DeletionPath (..)
     , deletionPathToOps
@@ -93,6 +94,27 @@ deleting pfx FromKV{isoK, treePrefix} hashing kvSel csmtSel key = do
                     delete kvSel key
                     mapM_ (applyOp csmtSel)
                         $ deletionPathToOps pfx hashing path
+
+-- | Delete from the tree column only (no KV write).
+-- Takes the old value as parameter (needed for tree key computation).
+-- Used during journal replay when KV is already up to date.
+deletingTreeOnly
+    :: (Monad m, GCompare d)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV k v a
+    -> Hashing a
+    -> Selector d Key (Indirect a)
+    -> k
+    -> v
+    -> Transaction m cf d ops ()
+deletingTreeOnly pfx FromKV{isoK, treePrefix} hashing csmtSel key v = do
+    let treeKey = treePrefix v <> view isoK key
+    mpath <- newDeletionPath pfx csmtSel treeKey
+    case mpath of
+        Nothing -> pure ()
+        Just path ->
+            mapM_ (applyOp csmtSel) $ deletionPathToOps pfx hashing path
 
 -- | Apply a single database operation (insert or delete).
 applyOp

--- a/lib/csmt/CSMT/Insertion.hs
+++ b/lib/csmt/CSMT/Insertion.hs
@@ -18,6 +18,7 @@
 -- are computed, allowing for efficient batch processing of changes.
 module CSMT.Insertion
     ( inserting
+    , insertingTreeOnly
     , buildComposeTree
     , scanCompose
     , Compose (..)
@@ -84,6 +85,23 @@ inserting
     -> Transaction m cf d ops ()
 inserting pfx FromKV{isoK, fromV, treePrefix} hashing kVCol csmtCol k v = do
     insert kVCol k v
+    let treeKey = treePrefix v <> view isoK k
+    c <- buildComposeTree csmtCol pfx treeKey (fromV v)
+    mapM_ (uncurry $ insert csmtCol) $ snd $ scanCompose pfx hashing c
+
+-- | Insert into the tree column only (no KV write).
+-- Used during journal replay when KV is already up to date.
+insertingTreeOnly
+    :: (Monad m, GCompare d)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV k v a
+    -> Hashing a
+    -> Selector d Key (Indirect a)
+    -> k
+    -> v
+    -> Transaction m cf d ops ()
+insertingTreeOnly pfx FromKV{isoK, fromV, treePrefix} hashing csmtCol k v = do
     let treeKey = treePrefix v <> view isoK k
     c <- buildComposeTree csmtCol pfx treeKey (fromV v)
     mapM_ (uncurry $ insert csmtCol) $ snd $ scanCompose pfx hashing c

--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -4,20 +4,33 @@
 -- and constructors that wrap CSMT operations into
 -- 'MerkleTreeStore'.
 --
--- Four constructors are provided:
+-- Full-mode constructors:
 --
--- * 'csmtMerkleTreeStoreT' — prefix-scoped transactional store,
---   composable within a single atomic transaction.
--- * 'csmtMerkleTreeStore' — convenience wrapper that commits
---   each operation in its own transaction.
--- * 'csmtNamespacedMTST' — transactional namespaced store.
--- * 'csmtNamespacedMTS' — IO namespaced store.
+-- * 'csmtMerkleTreeStoreT' — prefix-scoped transactional store
+-- * 'csmtMerkleTreeStore' — IO convenience wrapper
+-- * 'csmtNamespacedMTST' — transactional namespaced store
+-- * 'csmtNamespacedMTS' — IO namespaced store
+--
+-- KVOnly-mode constructors:
+--
+-- * 'csmtKVOnlyStoreT' — transactional, writes KV + journal
+-- * 'csmtKVOnlyStore' — IO convenience wrapper
+--
+-- Journal operations:
+--
+-- * 'csmtReplayJournal' — replay journal against tree
+-- * 'csmtJournalEmpty' — check if journal has entries
 module CSMT.MTS
     ( CsmtImpl
     , csmtMerkleTreeStoreT
     , csmtMerkleTreeStore
     , csmtNamespacedMTST
     , csmtNamespacedMTS
+    , csmtKVOnlyStoreT
+    , csmtKVOnlyStore
+    , csmtManagedTransition
+    , csmtReplayJournal
+    , csmtJournalEmpty
     )
 where
 
@@ -26,9 +39,9 @@ import CSMT.Backend.Standalone
     , StandaloneCF
     , StandaloneOp
     )
-import CSMT.Deletion (deleteSubtree, deleting)
+import CSMT.Deletion (deleteSubtree, deleting, deletingTreeOnly)
 import CSMT.Hashes (Hash)
-import CSMT.Insertion (inserting)
+import CSMT.Insertion (inserting, insertingTreeOnly)
 import CSMT.Interface
     ( FromKV (..)
     , Hashing (..)
@@ -48,20 +61,37 @@ import CSMT.Proof.Insertion
     , computeRootHash
     , verifyInclusionProof
     )
+import Control.Monad (unless, when)
 import Data.ByteString (ByteString)
-import Database.KV.Database (Database)
+import Data.ByteString qualified as B
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Database.KV.Cursor
+    ( Cursor
+    , Entry (..)
+    , firstEntry
+    , nextEntry
+    )
+import Database.KV.Database (Database, KV)
 import Database.KV.Transaction
     ( Transaction
+    , delete
+    , insert
+    , iterating
+    , query
     , runTransactionUnguarded
     )
 import MTS.Interface
     ( MerkleTreeStore (..)
+    , Mode (..)
     , MtsCompletenessProof
     , MtsHash
+    , MtsKV (..)
     , MtsKey
     , MtsLeaf
     , MtsPrefix
     , MtsProof
+    , MtsTransition (..)
+    , MtsTree (..)
     , MtsValue
     , NamespacedMTS (..)
     , hoistMTS
@@ -79,18 +109,35 @@ type instance MtsLeaf CsmtImpl = Indirect Hash
 type instance MtsCompletenessProof CsmtImpl = CompletenessProof Hash
 type instance MtsPrefix CsmtImpl = Key
 
--- | Build a transactional 'MerkleTreeStore' for CSMT scoped to a
--- prefix.
---
--- Operations live in the 'Transaction' monad so multiple
--- calls can be composed into a single atomic transaction:
---
--- @
--- runTransactionUnguarded db $ do
---     mtsInsert store k1 v1
---     mtsDelete store k2
---     mtsRootHash store
--- @
+-- | Journal entry tag bytes.
+journalInsertTag, journalDeleteTag :: ByteString
+journalInsertTag = B.singleton 0x01
+journalDeleteTag = B.singleton 0x00
+
+-- | Encode a journal insert entry: @0x01 ++ value@.
+encodeJournalInsert :: ByteString -> ByteString
+encodeJournalInsert v = journalInsertTag <> v
+
+-- | Encode a journal delete entry: @0x00 ++ oldValue@.
+encodeJournalDelete :: ByteString -> ByteString
+encodeJournalDelete v = journalDeleteTag <> v
+
+-- | Tag for journal entry.
+data JournalTag = JInsert | JDelete
+
+-- | Parse a journal entry into tag + value payload.
+parseJournalEntry :: ByteString -> (JournalTag, ByteString)
+parseJournalEntry bs = case B.uncons bs of
+    Just (0x01, rest) -> (JInsert, rest)
+    Just (0x00, rest) -> (JDelete, rest)
+    _ -> error "parseJournalEntry: invalid tag byte"
+
+-- ------------------------------------------------------------------
+-- Full mode
+-- ------------------------------------------------------------------
+
+-- | Build a transactional 'Full' 'MerkleTreeStore' for CSMT
+-- scoped to a prefix.
 csmtMerkleTreeStoreT
     :: (Monad m)
     => Key
@@ -98,6 +145,7 @@ csmtMerkleTreeStoreT
     -> FromKV ByteString ByteString Hash
     -> Hashing Hash
     -> MerkleTreeStore
+        'Full
         CsmtImpl
         ( Transaction
             m
@@ -106,75 +154,87 @@ csmtMerkleTreeStoreT
             StandaloneOp
         )
 csmtMerkleTreeStoreT prefix fromKV hashing =
-    MerkleTreeStore
-        { mtsInsert =
-            inserting
-                prefix
-                fromKV
-                hashing
-                StandaloneKVCol
-                StandaloneCSMTCol
-        , mtsDelete =
-            deleting
-                prefix
-                fromKV
-                hashing
-                StandaloneKVCol
-                StandaloneCSMTCol
-        , mtsRootHash =
-            root hashing StandaloneCSMTCol prefix
-        , mtsMkProof = \k -> do
-            mp <-
-                buildInclusionProof
+    MkFull kv tree
+  where
+    kv =
+        MtsKV
+            { mtsInsert =
+                inserting
                     prefix
                     fromKV
+                    hashing
                     StandaloneKVCol
                     StandaloneCSMTCol
+            , mtsDelete =
+                deleting
+                    prefix
+                    fromKV
                     hashing
-                    k
-            case mp of
-                Nothing -> pure Nothing
-                Just (_, proof) -> do
-                    mr <- root hashing StandaloneCSMTCol prefix
-                    pure $ case mr of
-                        Nothing -> Nothing
-                        Just r -> Just (r, proof)
-        , mtsVerifyProof = \v proof ->
-            pure
-                $ proofValue proof == fromV fromKV v
-                    && verifyInclusionProof hashing proof
-        , mtsFoldProof =
-            computeRootHash hashing
-        , mtsBatchInsert =
-            mapM_
-                ( uncurry
-                    ( inserting
+                    StandaloneKVCol
+                    StandaloneCSMTCol
+            }
+    tree =
+        MtsTree
+            { mtsRootHash =
+                root hashing StandaloneCSMTCol prefix
+            , mtsMkProof = \k -> do
+                mp <-
+                    buildInclusionProof
                         prefix
                         fromKV
-                        hashing
                         StandaloneKVCol
                         StandaloneCSMTCol
+                        hashing
+                        k
+                case mp of
+                    Nothing -> pure Nothing
+                    Just (_, proof) -> do
+                        mr <-
+                            root hashing StandaloneCSMTCol prefix
+                        pure $ case mr of
+                            Nothing -> Nothing
+                            Just r -> Just (r, proof)
+            , mtsVerifyProof = \v proof ->
+                pure
+                    $ proofValue proof == fromV fromKV v
+                        && verifyInclusionProof hashing proof
+            , mtsFoldProof =
+                computeRootHash hashing
+            , mtsBatchInsert =
+                mapM_
+                    ( uncurry
+                        ( inserting
+                            prefix
+                            fromKV
+                            hashing
+                            StandaloneKVCol
+                            StandaloneCSMTCol
+                        )
                     )
-                )
-        , mtsCollectLeaves =
-            collectValues StandaloneCSMTCol prefix []
-        , mtsMkCompletenessProof =
-            generateProof StandaloneCSMTCol prefix []
-        , mtsVerifyCompletenessProof = \leaves proof -> do
-            currentRoot <-
-                root hashing StandaloneCSMTCol prefix
-            let computed =
-                    foldCompletenessProof hashing [] leaves proof
-            pure $ case (currentRoot, computed) of
-                (Just r, Just computedRoot) ->
-                    computedRoot == r
-                _ -> False
-        }
+            , mtsCollectLeaves =
+                collectValues StandaloneCSMTCol prefix []
+            , mtsMkCompletenessProof =
+                generateProof StandaloneCSMTCol prefix []
+            , mtsVerifyCompletenessProof = \leaves proof -> do
+                currentRoot <-
+                    root hashing StandaloneCSMTCol prefix
+                let computed =
+                        foldCompletenessProof
+                            hashing
+                            []
+                            leaves
+                            proof
+                pure $ case (currentRoot, computed) of
+                    (Just r, Just computedRoot) ->
+                        computedRoot == r
+                    _ -> False
+            }
 
--- | Build an IO 'MerkleTreeStore' for CSMT scoped to a prefix.
+-- | Build an IO 'Full' 'MerkleTreeStore' for CSMT scoped to a
+-- prefix.
 --
--- Each operation commits in its own transaction. For atomic
--- multi-operation sequences, use 'csmtMerkleTreeStoreT' instead.
+-- Checks that the journal is empty before constructing the
+-- store. Fails if there are unplayed journal entries.
 csmtMerkleTreeStore
     :: (MonadFail m)
     => Key
@@ -187,15 +247,18 @@ csmtMerkleTreeStore
         StandaloneOp
     -> FromKV ByteString ByteString Hash
     -> Hashing Hash
-    -> MerkleTreeStore CsmtImpl IO
-csmtMerkleTreeStore prefix run db fromKV hashing =
-    hoistMTS
-        (run . runTransactionUnguarded db)
-        (csmtMerkleTreeStoreT prefix fromKV hashing)
+    -> IO (MerkleTreeStore 'Full CsmtImpl IO)
+csmtMerkleTreeStore prefix run db fromKV hashing = do
+    empty <- csmtJournalEmpty run db
+    unless empty
+        $ fail
+            "csmtMerkleTreeStore: journal is not empty, replay first"
+    pure
+        $ hoistMTS
+            (run . runTransactionUnguarded db)
+            (csmtMerkleTreeStoreT prefix fromKV hashing)
 
 -- | Build a transactional 'NamespacedMTS' for CSMT.
---
--- Each namespace is a prefix-scoped 'MerkleTreeStore'.
 csmtNamespacedMTST
     :: (Monad m)
     => FromKV ByteString ByteString Hash
@@ -217,9 +280,6 @@ csmtNamespacedMTST fromKV hashing =
         }
 
 -- | Build an IO 'NamespacedMTS' for CSMT.
---
--- Each namespace is a prefix-scoped 'MerkleTreeStore' that
--- commits each operation in its own transaction.
 csmtNamespacedMTS
     :: (MonadFail m)
     => (forall b. m b -> IO b)
@@ -235,3 +295,238 @@ csmtNamespacedMTS run db fromKV hashing =
     hoistNamespacedMTS
         (run . runTransactionUnguarded db)
         (csmtNamespacedMTST fromKV hashing)
+
+-- ------------------------------------------------------------------
+-- KVOnly mode
+-- ------------------------------------------------------------------
+
+-- | Build a transactional 'KVOnly' 'MerkleTreeStore' for CSMT.
+--
+-- Each insert/delete writes KV + journal atomically.
+-- No tree operations are available.
+csmtKVOnlyStoreT
+    :: (Monad m)
+    => FromKV ByteString ByteString Hash
+    -> MerkleTreeStore
+        'KVOnly
+        CsmtImpl
+        ( Transaction
+            m
+            StandaloneCF
+            (Standalone ByteString ByteString Hash)
+            StandaloneOp
+        )
+csmtKVOnlyStoreT _fromKV =
+    MkKVOnly
+        MtsKV
+            { mtsInsert = \k v -> do
+                insert StandaloneKVCol k v
+                insert
+                    StandaloneJournalCol
+                    k
+                    (encodeJournalInsert v)
+            , mtsDelete = \k -> do
+                mv <- query StandaloneKVCol k
+                case mv of
+                    Nothing -> pure ()
+                    Just v -> do
+                        delete StandaloneKVCol k
+                        insert
+                            StandaloneJournalCol
+                            k
+                            (encodeJournalDelete v)
+            }
+
+-- | Build an IO 'KVOnly' 'MerkleTreeStore' for CSMT.
+csmtKVOnlyStore
+    :: (MonadFail m)
+    => (forall b. m b -> IO b)
+    -> Database
+        m
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+    -> FromKV ByteString ByteString Hash
+    -> MerkleTreeStore 'KVOnly CsmtImpl IO
+csmtKVOnlyStore run db fromKV =
+    hoistMTS
+        (run . runTransactionUnguarded db)
+        (csmtKVOnlyStoreT fromKV)
+
+-- ------------------------------------------------------------------
+-- Managed transition
+-- ------------------------------------------------------------------
+
+-- | Create a managed lifecycle handle for CSMT.
+--
+-- Returns a 'MtsTransition' that bundles a 'KVOnly' store with
+-- a one-shot transition action. After 'transitionToFull' is
+-- called, any operation on 'transitionKVStore' throws.
+csmtManagedTransition
+    :: forall m
+     . (MonadFail m)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Int
+    -- ^ Chunk size for journal replay
+    -> (forall b. m b -> IO b)
+    -> Database
+        m
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+    -> FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> IO (MtsTransition CsmtImpl IO)
+csmtManagedTransition prefix chunkSize run db fromKV hashing = do
+    locked <- newIORef False
+    let guardedRun
+            :: forall b
+             . Transaction
+                m
+                StandaloneCF
+                (Standalone ByteString ByteString Hash)
+                StandaloneOp
+                b
+            -> IO b
+        guardedRun txn = do
+            isLocked <- readIORef locked
+            when isLocked
+                $ fail
+                    "KVOnly store disabled after transition"
+            run (runTransactionUnguarded db txn)
+    pure
+        MtsTransition
+            { transitionKVStore =
+                hoistMTS
+                    guardedRun
+                    (csmtKVOnlyStoreT fromKV)
+            , transitionToFull = do
+                writeIORef locked True
+                csmtReplayJournal
+                    prefix
+                    chunkSize
+                    run
+                    db
+                    fromKV
+                    hashing
+                pure
+                    $ hoistMTS
+                        (run . runTransactionUnguarded db)
+                        ( csmtMerkleTreeStoreT
+                            prefix
+                            fromKV
+                            hashing
+                        )
+            }
+
+-- ------------------------------------------------------------------
+-- Journal replay
+-- ------------------------------------------------------------------
+
+-- | Check if the journal column is empty.
+csmtJournalEmpty
+    :: (MonadFail m)
+    => (forall b. m b -> IO b)
+    -> Database
+        m
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+    -> IO Bool
+csmtJournalEmpty run db =
+    run $ runTransactionUnguarded db $ do
+        me <- iterating StandaloneJournalCol firstEntry
+        pure $ case me of
+            Nothing -> True
+            Just _ -> False
+
+-- | Replay journal entries against the tree, then clear them.
+--
+-- Processes entries in chunks. Each chunk reads up to
+-- @chunkSize@ entries, applies tree-only operations, and
+-- deletes the replayed journal entries, all in one transaction.
+-- Repeats until the journal is empty.
+csmtReplayJournal
+    :: (MonadFail m)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> Int
+    -- ^ Chunk size
+    -> (forall b. m b -> IO b)
+    -> Database
+        m
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+    -> FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> IO ()
+csmtReplayJournal prefix chunkSize run db fromKV hashing = loop
+  where
+    loop = do
+        done <- run $ runTransactionUnguarded db $ do
+            entries <- iterating StandaloneJournalCol $ do
+                me <- firstEntry
+                case me of
+                    Nothing -> pure []
+                    Just e -> collectN (chunkSize - 1) [e]
+            if null entries
+                then pure True
+                else do
+                    replayEntries prefix fromKV hashing entries
+                    pure False
+        unless done loop
+
+-- | Collect up to @n@ more entries after the first.
+collectN
+    :: (Monad m)
+    => Int
+    -> [Entry c]
+    -> Cursor m c [Entry c]
+collectN 0 acc = pure (reverse acc)
+collectN n acc = do
+    me <- nextEntry
+    case me of
+        Nothing -> pure (reverse acc)
+        Just e -> collectN (n - 1) (e : acc)
+
+-- | Apply journal entries to the tree and clear them.
+replayEntries
+    :: (Monad m)
+    => Key
+    -> FromKV ByteString ByteString Hash
+    -> Hashing Hash
+    -> [Entry (KV ByteString ByteString)]
+    -> Transaction
+        m
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+        ()
+replayEntries prefix fromKV hashing entries = do
+    mapM_ applyEntry entries
+    mapM_
+        (\e -> delete StandaloneJournalCol (entryKey e))
+        entries
+  where
+    applyEntry e =
+        let (tag, v) = parseJournalEntry (entryValue e)
+            k = entryKey e
+        in  case tag of
+                JInsert ->
+                    insertingTreeOnly
+                        prefix
+                        fromKV
+                        hashing
+                        StandaloneCSMTCol
+                        k
+                        v
+                JDelete ->
+                    deletingTreeOnly
+                        prefix
+                        fromKV
+                        hashing
+                        StandaloneCSMTCol
+                        k
+                        v

--- a/lib/mpf/MPF/Backend/Pure.hs
+++ b/lib/mpf/MPF/Backend/Pure.hs
@@ -11,6 +11,7 @@ module MPF.Backend.Pure
     )
 where
 
+import Control.Lens (iso)
 import Control.Monad.Catch.Pure (Catch, runCatch)
 import Control.Monad.Trans.State.Strict
     ( StateT (runStateT)
@@ -105,13 +106,15 @@ prevCursor c@Cursor{position = Just k, snapshot} =
 data MPFInMemoryDB = MPFInMemoryDB
     { mpfInMemoryMPF :: Map ByteString ByteString
     , mpfInMemoryKV :: Map ByteString ByteString
+    , mpfInMemoryJournal :: Map ByteString ByteString
     , mpfInMemoryIterators :: Map Int Cursor
     }
     deriving (Show, Eq)
 
 -- | Empty in-memory database
 emptyMPFInMemoryDB :: MPFInMemoryDB
-emptyMPFInMemoryDB = MPFInMemoryDB Map.empty Map.empty Map.empty
+emptyMPFInMemoryDB =
+    MPFInMemoryDB Map.empty Map.empty Map.empty Map.empty
 
 onMPF
     :: (Map ByteString ByteString -> Map ByteString ByteString)
@@ -124,6 +127,12 @@ onKV
     -> MPFInMemoryDB
     -> MPFInMemoryDB
 onKV f m = m{mpfInMemoryKV = f (mpfInMemoryKV m)}
+
+onJournal
+    :: (Map ByteString ByteString -> Map ByteString ByteString)
+    -> MPFInMemoryDB
+    -> MPFInMemoryDB
+onJournal f m = m{mpfInMemoryJournal = f (mpfInMemoryJournal m)}
 
 -- | Pure monad for MPF operations
 type MPFPure = StateT MPFInMemoryDB Catch
@@ -145,6 +154,9 @@ pureValueAt MPFStandaloneKV k = do
 pureValueAt MPFStandaloneMPF k = do
     mpf <- gets mpfInMemoryMPF
     pure $ Map.lookup k mpf
+pureValueAt MPFStandaloneJournal k = do
+    journal <- gets mpfInMemoryJournal
+    pure $ Map.lookup k journal
 
 pureApplyOps :: [MPFStandaloneOp] -> MPFPure ()
 pureApplyOps ops = forM_ ops $ \(cf, k, mv) -> case (cf, mv) of
@@ -152,6 +164,10 @@ pureApplyOps ops = forM_ ops $ \(cf, k, mv) -> case (cf, mv) of
     (MPFStandaloneKV, Just v) -> modify' $ onKV $ Map.insert k v
     (MPFStandaloneMPF, Nothing) -> modify' $ onMPF $ Map.delete k
     (MPFStandaloneMPF, Just v) -> modify' $ onMPF $ Map.insert k v
+    (MPFStandaloneJournal, Nothing) ->
+        modify' $ onJournal $ Map.delete k
+    (MPFStandaloneJournal, Just v) ->
+        modify' $ onJournal $ Map.insert k v
 
 standaloneMPFPureCols
     :: MPFStandaloneCodecs k v a
@@ -173,6 +189,11 @@ standaloneMPFPureCols
                     { family = MPFStandaloneMPF
                     , codecs = mpfCodecs pa
                     }
+            , MPFStandaloneJournalCol
+                :=> Column
+                    { family = MPFStandaloneJournal
+                    , codecs = Codecs (iso id id) (iso id id)
+                    }
             ]
 
 pureIterator :: MPFStandaloneCF -> MPFPure (QueryIterator MPFPure)
@@ -180,6 +201,7 @@ pureIterator cf = do
     db <- gets $ case cf of
         MPFStandaloneKV -> mpfInMemoryKV
         MPFStandaloneMPF -> mpfInMemoryMPF
+        MPFStandaloneJournal -> mpfInMemoryJournal
     nextId <- gets $ \m -> case Map.lookupMax (mpfInMemoryIterators m) of
         Just (i, _) -> i + 1
         Nothing -> 0

--- a/lib/mpf/MPF/Backend/RocksDB.hs
+++ b/lib/mpf/MPF/Backend/RocksDB.hs
@@ -9,6 +9,7 @@ where
 
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
 import Control.Concurrent.Async (async, link)
+import Control.Lens (iso)
 import Control.Monad ((<=<))
 import Control.Monad.Trans.Reader (ReaderT (..), ask)
 import Database.KV.Database (Database (..))
@@ -44,7 +45,7 @@ mpfStandaloneRocksDBCols
     -> DMap (MPFStandalone k v a) (Column ColumnFamily)
 mpfStandaloneRocksDBCols
     MPFStandaloneCodecs{mpfKeyCodec, mpfValueCodec, mpfNodeCodec}
-    [kvcf, mpfcf] =
+    [kvcf, mpfcf, journalcf] =
         fromPairList
             [ MPFStandaloneKVCol
                 :=> Column
@@ -56,9 +57,14 @@ mpfStandaloneRocksDBCols
                     { family = mpfcf
                     , codecs = mpfCodecs mpfNodeCodec
                     }
+            , MPFStandaloneJournalCol
+                :=> Column
+                    { family = journalcf
+                    , codecs = Codecs (iso id id) (iso id id)
+                    }
             ]
 mpfStandaloneRocksDBCols _ _ =
-    error "mpfStandaloneRocksDBCols: expected exactly two column families"
+    error "mpfStandaloneRocksDBCols: expected exactly three column families"
 
 -- | Create a RocksDB database for MPF
 mpfStandaloneRocksDBDatabase
@@ -86,7 +92,10 @@ withMPFRocksDB path mpfMaxFiles kvMaxFiles action = do
     withDBCF
         path
         def
-        [("kv", configKV kvMaxFiles), ("mpf", configMPF mpfMaxFiles)]
+        [ ("kv", configKV kvMaxFiles)
+        , ("mpf", configMPF mpfMaxFiles)
+        , ("journal", configJournal)
+        ]
         $ \db -> do
             action $ RunMPFRocksDB $ flip runReaderT db
 
@@ -101,7 +110,10 @@ unsafeWithMPFRocksDB path mpfMaxFiles kvMaxFiles = do
         withDBCF
             path
             def
-            [("kv", configKV kvMaxFiles), ("mpf", configMPF mpfMaxFiles)]
+            [ ("kv", configKV kvMaxFiles)
+            , ("mpf", configMPF mpfMaxFiles)
+            , ("journal", configJournal)
+            ]
             $ \db -> do
                 putMVar dbv (RunMPFRocksDB $ flip runReaderT db)
                 readMVar wait
@@ -142,6 +154,18 @@ configKV n =
         , errorIfExists = False
         , paranoidChecks = False
         , maxFiles = Just n
+        , prefixLength = Nothing
+        , bloomFilter = False
+        }
+
+-- | Configuration for the journal column family
+configJournal :: Config
+configJournal =
+    Config
+        { createIfMissing = True
+        , errorIfExists = False
+        , paranoidChecks = False
+        , maxFiles = Nothing
         , prefixLength = Nothing
         , bloomFilter = False
         }

--- a/lib/mpf/MPF/Backend/Standalone.hs
+++ b/lib/mpf/MPF/Backend/Standalone.hs
@@ -20,7 +20,7 @@ import Database.KV.Transaction
 import MPF.Interface (HexIndirect (..), HexKey)
 
 -- | Column family identifiers for MPF standalone backend
-data MPFStandaloneCF = MPFStandaloneKV | MPFStandaloneMPF
+data MPFStandaloneCF = MPFStandaloneKV | MPFStandaloneMPF | MPFStandaloneJournal
     deriving (Show, Eq, Ord)
 
 -- | Operation type for standalone backend
@@ -35,17 +35,22 @@ mkMPFStandaloneOp = (,,)
 data MPFStandalone k v a x where
     MPFStandaloneKVCol :: MPFStandalone k v a (KV k v)
     MPFStandaloneMPFCol :: MPFStandalone k v a (KV HexKey (HexIndirect a))
+    MPFStandaloneJournalCol :: MPFStandalone k v a (KV ByteString ByteString)
 
 instance GEq (MPFStandalone k v a) where
     geq MPFStandaloneKVCol MPFStandaloneKVCol = Just Refl
     geq MPFStandaloneMPFCol MPFStandaloneMPFCol = Just Refl
+    geq MPFStandaloneJournalCol MPFStandaloneJournalCol = Just Refl
     geq _ _ = Nothing
 
 instance GCompare (MPFStandalone k v a) where
     gcompare MPFStandaloneKVCol MPFStandaloneKVCol = GEQ
-    gcompare MPFStandaloneKVCol MPFStandaloneMPFCol = GLT
+    gcompare MPFStandaloneKVCol _ = GLT
     gcompare MPFStandaloneMPFCol MPFStandaloneKVCol = GGT
     gcompare MPFStandaloneMPFCol MPFStandaloneMPFCol = GEQ
+    gcompare MPFStandaloneMPFCol MPFStandaloneJournalCol = GLT
+    gcompare MPFStandaloneJournalCol MPFStandaloneJournalCol = GEQ
+    gcompare MPFStandaloneJournalCol _ = GGT
 
 -- | Serialization codecs for the MPF standalone backend
 data MPFStandaloneCodecs k v a = MPFStandaloneCodecs

--- a/lib/mpf/MPF/Deletion.hs
+++ b/lib/mpf/MPF/Deletion.hs
@@ -2,6 +2,7 @@
 
 module MPF.Deletion
     ( deleting
+    , deletingTreeOnly
     , newMPFDeletionPath
     , MPFDeletionPath (..)
     , deletionPathToOps
@@ -68,6 +69,26 @@ deleting prefix FromHexKV{fromHexK, hexTreePrefix} hashing kvSel mpfSel key = do
                 Just path -> do
                     delete kvSel key
                     mapM_ (applyOp mpfSel) $ deletionPathToOps prefix hashing path
+
+-- | Delete from the tree column only (no KV write).
+-- Takes the old value as parameter (needed for tree key computation).
+-- Used during journal replay when KV is already up to date.
+deletingTreeOnly
+    :: (Monad m, GCompare d)
+    => HexKey
+    -> FromHexKV k v a
+    -> MPFHashing a
+    -> Selector d HexKey (HexIndirect a)
+    -> k
+    -> v
+    -> Transaction m cf d ops ()
+deletingTreeOnly prefix FromHexKV{fromHexK, hexTreePrefix} hashing mpfSel key v = do
+    let treeKey = hexTreePrefix v <> fromHexK key
+    mpath <- newMPFDeletionPath prefix mpfSel treeKey
+    case mpath of
+        Nothing -> pure ()
+        Just path ->
+            mapM_ (applyOp mpfSel) $ deletionPathToOps prefix hashing path
 
 -- | Apply a single deletion operation
 applyOp

--- a/lib/mpf/MPF/Insertion.hs
+++ b/lib/mpf/MPF/Insertion.hs
@@ -4,6 +4,7 @@
 
 module MPF.Insertion
     ( inserting
+    , insertingTreeOnly
     , insertingBatch
     , insertingChunked
     , insertingStream
@@ -59,6 +60,24 @@ inserting
     -> Transaction m cf d ops ()
 inserting prefix FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing kvCol mpfCol k v = do
     insert kvCol k v
+    let treeKey = hexTreePrefix v <> fromHexK k
+    c <- mkMPFCompose mpfCol prefix treeKey (fromHexV v)
+    mapM_ (uncurry $ insert mpfCol)
+        $ snd
+        $ scanMPFCompose prefix hashing c
+
+-- | Insert into the tree column only (no KV write).
+-- Used during journal replay when KV is already up to date.
+insertingTreeOnly
+    :: (Monad m, GCompare d)
+    => HexKey
+    -> FromHexKV k v a
+    -> MPFHashing a
+    -> Selector d HexKey (HexIndirect a)
+    -> k
+    -> v
+    -> Transaction m cf d ops ()
+insertingTreeOnly prefix FromHexKV{fromHexK, fromHexV, hexTreePrefix} hashing mpfCol k v = do
     let treeKey = hexTreePrefix v <> fromHexK k
     c <- mkMPFCompose mpfCol prefix treeKey (fromHexV v)
     mapM_ (uncurry $ insert mpfCol)

--- a/lib/mpf/MPF/MTS.hs
+++ b/lib/mpf/MPF/MTS.hs
@@ -4,27 +4,52 @@
 -- and constructors that wrap MPF operations into
 -- 'MerkleTreeStore'.
 --
--- Four constructors are provided:
+-- Full-mode constructors:
 --
--- * 'mpfMerkleTreeStoreT' — prefix-scoped transactional store,
---   composable within a single atomic transaction.
--- * 'mpfMerkleTreeStore' — convenience wrapper that commits
---   each operation in its own transaction.
--- * 'mpfNamespacedMTST' — transactional namespaced store.
--- * 'mpfNamespacedMTS' — IO namespaced store.
+-- * 'mpfMerkleTreeStoreT' — prefix-scoped transactional store
+-- * 'mpfMerkleTreeStore' — IO convenience wrapper
+-- * 'mpfNamespacedMTST' — transactional namespaced store
+-- * 'mpfNamespacedMTS' — IO namespaced store
+--
+-- KVOnly-mode constructors:
+--
+-- * 'mpfKVOnlyStoreT' — transactional, writes KV + journal
+-- * 'mpfKVOnlyStore' — IO convenience wrapper
+--
+-- Journal operations:
+--
+-- * 'mpfReplayJournal' — replay journal against tree
+-- * 'mpfJournalEmpty' — check if journal has entries
 module MPF.MTS
     ( MpfImpl
     , mpfMerkleTreeStoreT
     , mpfMerkleTreeStore
     , mpfNamespacedMTST
     , mpfNamespacedMTS
+    , mpfKVOnlyStoreT
+    , mpfKVOnlyStore
+    , mpfManagedTransition
+    , mpfReplayJournal
+    , mpfJournalEmpty
     )
 where
 
+import Control.Monad (unless, when)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.ByteString (ByteString)
-import Database.KV.Database (Database)
+import Data.ByteString qualified as B
+import Database.KV.Cursor
+    ( Cursor
+    , Entry (..)
+    , firstEntry
+    , nextEntry
+    )
+import Database.KV.Database (Database, KV)
 import Database.KV.Transaction
     ( Transaction
+    , delete
+    , insert
+    , iterating
     , query
     , runTransactionUnguarded
     )
@@ -33,9 +58,14 @@ import MPF.Backend.Standalone
     , MPFStandaloneCF
     , MPFStandaloneOp
     )
-import MPF.Deletion (deleteSubtree, deleting)
+import MPF.Deletion (deleteSubtree, deleting, deletingTreeOnly)
 import MPF.Hashes (MPFHash, MPFHashing (..))
-import MPF.Insertion (MPFCompose, inserting, insertingBatch)
+import MPF.Insertion
+    ( MPFCompose
+    , inserting
+    , insertingBatch
+    , insertingTreeOnly
+    )
 import MPF.Interface
     ( FromHexKV (..)
     , HexIndirect (..)
@@ -54,12 +84,16 @@ import MPF.Proof.Insertion
     )
 import MTS.Interface
     ( MerkleTreeStore (..)
+    , Mode (..)
     , MtsCompletenessProof
     , MtsHash
+    , MtsKV (..)
     , MtsKey
     , MtsLeaf
     , MtsPrefix
     , MtsProof
+    , MtsTransition (..)
+    , MtsTree (..)
     , MtsValue
     , NamespacedMTS (..)
     , hoistMTS
@@ -77,6 +111,29 @@ type instance MtsLeaf MpfImpl = HexIndirect MPFHash
 type instance MtsCompletenessProof MpfImpl = MPFCompose MPFHash
 type instance MtsPrefix MpfImpl = HexKey
 
+-- | Journal entry tag bytes.
+journalInsertTag, journalDeleteTag :: ByteString
+journalInsertTag = B.singleton 0x01
+journalDeleteTag = B.singleton 0x00
+
+-- | Encode a journal insert entry.
+encodeJournalInsert :: ByteString -> ByteString
+encodeJournalInsert v = journalInsertTag <> v
+
+-- | Encode a journal delete entry.
+encodeJournalDelete :: ByteString -> ByteString
+encodeJournalDelete v = journalDeleteTag <> v
+
+-- | Tag for journal entry.
+data JournalTag = JInsert | JDelete
+
+-- | Parse a journal entry into tag + value payload.
+parseJournalEntry :: ByteString -> (JournalTag, ByteString)
+parseJournalEntry bs = case B.uncons bs of
+    Just (0x01, rest) -> (JInsert, rest)
+    Just (0x00, rest) -> (JDelete, rest)
+    _ -> error "parseJournalEntry: invalid tag byte"
+
 -- | Compute the MPF root hash from the root node.
 mpfRootFromNode
     :: MPFHashing MPFHash -> HexIndirect MPFHash -> MPFHash
@@ -85,25 +142,18 @@ mpfRootFromNode hashing i =
         then leafHash hashing (hexJump i) (hexValue i)
         else hexValue i
 
--- | Build a transactional 'MerkleTreeStore' for MPF scoped to a
--- prefix.
---
--- Operations live in the 'Transaction' monad so multiple
--- calls can be composed into a single atomic transaction:
---
--- @
--- runTransactionUnguarded db $ do
---     mtsInsert store k1 v1
---     mtsDelete store k2
---     mtsRootHash store
--- @
+-- ------------------------------------------------------------------
+-- Full mode
+-- ------------------------------------------------------------------
+
+-- | Build a transactional 'Full' 'MerkleTreeStore' for MPF.
 mpfMerkleTreeStoreT
     :: (MonadFail m)
     => HexKey
-    -- ^ Prefix (use @[]@ for root)
     -> FromHexKV ByteString ByteString MPFHash
     -> MPFHashing MPFHash
     -> MerkleTreeStore
+        'Full
         MpfImpl
         ( Transaction
             m
@@ -112,79 +162,84 @@ mpfMerkleTreeStoreT
             MPFStandaloneOp
         )
 mpfMerkleTreeStoreT prefix fromKV hashing =
-    MerkleTreeStore
-        { mtsInsert =
-            inserting
-                prefix
-                fromKV
-                hashing
-                MPFStandaloneKVCol
-                MPFStandaloneMPFCol
-        , mtsDelete =
-            deleting
-                prefix
-                fromKV
-                hashing
-                MPFStandaloneKVCol
-                MPFStandaloneMPFCol
-        , mtsRootHash = do
-            mi <- query MPFStandaloneMPFCol prefix
-            pure $ fmap (mpfRootFromNode hashing) mi
-        , mtsMkProof = \k -> do
-            mp <-
-                mkMPFInclusionProof
+    MkFull kv tree
+  where
+    kv =
+        MtsKV
+            { mtsInsert =
+                inserting
                     prefix
                     fromKV
                     hashing
+                    MPFStandaloneKVCol
                     MPFStandaloneMPFCol
-                    k
-            case mp of
-                Nothing -> pure Nothing
-                Just proof -> do
-                    mi <-
-                        query MPFStandaloneMPFCol prefix
-                    pure $ case mi of
-                        Nothing -> Nothing
-                        Just i ->
-                            Just (mpfRootFromNode hashing i, proof)
-        , mtsVerifyProof =
-            verifyMPFInclusionProof
-                prefix
-                fromKV
-                MPFStandaloneMPFCol
-                hashing
-        , mtsFoldProof =
-            foldMPFProof hashing
-        , mtsBatchInsert =
-            insertingBatch
-                prefix
-                fromKV
-                hashing
-                MPFStandaloneKVCol
-                MPFStandaloneMPFCol
-        , mtsCollectLeaves =
-            collectMPFLeaves MPFStandaloneMPFCol prefix
-        , mtsMkCompletenessProof =
-            generateMPFCompletenessProof MPFStandaloneMPFCol prefix
-        , mtsVerifyCompletenessProof = \leaves proof -> do
-            mi <- query MPFStandaloneMPFCol prefix
-            let currentRoot = fmap (mpfRootFromNode hashing) mi
-                computed =
-                    foldMPFCompletenessProof hashing leaves proof
-            pure $ case (currentRoot, computed) of
-                (Just r, Just computedRoot) ->
-                    computedRoot == r
-                _ -> False
-        }
+            , mtsDelete =
+                deleting
+                    prefix
+                    fromKV
+                    hashing
+                    MPFStandaloneKVCol
+                    MPFStandaloneMPFCol
+            }
+    tree =
+        MtsTree
+            { mtsRootHash = do
+                mi <- query MPFStandaloneMPFCol prefix
+                pure $ fmap (mpfRootFromNode hashing) mi
+            , mtsMkProof = \k -> do
+                mp <-
+                    mkMPFInclusionProof
+                        prefix
+                        fromKV
+                        hashing
+                        MPFStandaloneMPFCol
+                        k
+                case mp of
+                    Nothing -> pure Nothing
+                    Just proof -> do
+                        mi <-
+                            query MPFStandaloneMPFCol prefix
+                        pure $ case mi of
+                            Nothing -> Nothing
+                            Just i ->
+                                Just (mpfRootFromNode hashing i, proof)
+            , mtsVerifyProof =
+                verifyMPFInclusionProof
+                    prefix
+                    fromKV
+                    MPFStandaloneMPFCol
+                    hashing
+            , mtsFoldProof =
+                foldMPFProof hashing
+            , mtsBatchInsert =
+                insertingBatch
+                    prefix
+                    fromKV
+                    hashing
+                    MPFStandaloneKVCol
+                    MPFStandaloneMPFCol
+            , mtsCollectLeaves =
+                collectMPFLeaves MPFStandaloneMPFCol prefix
+            , mtsMkCompletenessProof =
+                generateMPFCompletenessProof MPFStandaloneMPFCol prefix
+            , mtsVerifyCompletenessProof = \leaves proof -> do
+                mi <- query MPFStandaloneMPFCol prefix
+                let currentRoot = fmap (mpfRootFromNode hashing) mi
+                    computed =
+                        foldMPFCompletenessProof hashing leaves proof
+                pure $ case (currentRoot, computed) of
+                    (Just r, Just computedRoot) ->
+                        computedRoot == r
+                    _ -> False
+            }
 
--- | Build an IO 'MerkleTreeStore' for MPF scoped to a prefix.
+-- | Build an IO 'Full' 'MerkleTreeStore' for MPF.
 --
--- Each operation commits in its own transaction. For atomic
--- multi-operation sequences, use 'mpfMerkleTreeStoreT' instead.
+-- Checks that the journal is empty before constructing the
+-- store. Fails if there are unplayed journal entries.
 mpfMerkleTreeStore
     :: (MonadFail m)
     => HexKey
-    -- ^ Prefix (use @[]@ for root)
     -> (forall b. m b -> IO b)
     -> Database
         m
@@ -193,15 +248,18 @@ mpfMerkleTreeStore
         MPFStandaloneOp
     -> FromHexKV ByteString ByteString MPFHash
     -> MPFHashing MPFHash
-    -> MerkleTreeStore MpfImpl IO
-mpfMerkleTreeStore prefix run db fromKV hashing =
-    hoistMTS
-        (run . runTransactionUnguarded db)
-        (mpfMerkleTreeStoreT prefix fromKV hashing)
+    -> IO (MerkleTreeStore 'Full MpfImpl IO)
+mpfMerkleTreeStore prefix run db fromKV hashing = do
+    empty <- mpfJournalEmpty run db
+    unless empty
+        $ fail
+            "mpfMerkleTreeStore: journal is not empty, replay first"
+    pure
+        $ hoistMTS
+            (run . runTransactionUnguarded db)
+            (mpfMerkleTreeStoreT prefix fromKV hashing)
 
 -- | Build a transactional 'NamespacedMTS' for MPF.
---
--- Each namespace is a prefix-scoped 'MerkleTreeStore'.
 mpfNamespacedMTST
     :: (MonadFail m)
     => FromHexKV ByteString ByteString MPFHash
@@ -223,9 +281,6 @@ mpfNamespacedMTST fromKV hashing =
         }
 
 -- | Build an IO 'NamespacedMTS' for MPF.
---
--- Each namespace is a prefix-scoped 'MerkleTreeStore' that
--- commits each operation in its own transaction.
 mpfNamespacedMTS
     :: (MonadFail m)
     => (forall b. m b -> IO b)
@@ -241,3 +296,221 @@ mpfNamespacedMTS run db fromKV hashing =
     hoistNamespacedMTS
         (run . runTransactionUnguarded db)
         (mpfNamespacedMTST fromKV hashing)
+
+-- ------------------------------------------------------------------
+-- KVOnly mode
+-- ------------------------------------------------------------------
+
+-- | Build a transactional 'KVOnly' 'MerkleTreeStore' for MPF.
+mpfKVOnlyStoreT
+    :: (Monad m)
+    => FromHexKV ByteString ByteString MPFHash
+    -> MerkleTreeStore
+        'KVOnly
+        MpfImpl
+        ( Transaction
+            m
+            MPFStandaloneCF
+            (MPFStandalone ByteString ByteString MPFHash)
+            MPFStandaloneOp
+        )
+mpfKVOnlyStoreT _fromKV =
+    MkKVOnly
+        MtsKV
+            { mtsInsert = \k v -> do
+                insert MPFStandaloneKVCol k v
+                insert
+                    MPFStandaloneJournalCol
+                    k
+                    (encodeJournalInsert v)
+            , mtsDelete = \k -> do
+                mv <- query MPFStandaloneKVCol k
+                case mv of
+                    Nothing -> pure ()
+                    Just v -> do
+                        delete MPFStandaloneKVCol k
+                        insert
+                            MPFStandaloneJournalCol
+                            k
+                            (encodeJournalDelete v)
+            }
+
+-- | Build an IO 'KVOnly' 'MerkleTreeStore' for MPF.
+mpfKVOnlyStore
+    :: (MonadFail m)
+    => (forall b. m b -> IO b)
+    -> Database
+        m
+        MPFStandaloneCF
+        (MPFStandalone ByteString ByteString MPFHash)
+        MPFStandaloneOp
+    -> FromHexKV ByteString ByteString MPFHash
+    -> MerkleTreeStore 'KVOnly MpfImpl IO
+mpfKVOnlyStore run db fromKV =
+    hoistMTS
+        (run . runTransactionUnguarded db)
+        (mpfKVOnlyStoreT fromKV)
+
+-- ------------------------------------------------------------------
+-- Managed transition
+-- ------------------------------------------------------------------
+
+-- | Create a managed lifecycle handle for MPF.
+--
+-- Returns a 'MtsTransition' that bundles a 'KVOnly' store with
+-- a one-shot transition action. After 'transitionToFull' is
+-- called, any operation on 'transitionKVStore' throws.
+mpfManagedTransition
+    :: forall m
+     . (MonadFail m)
+    => HexKey
+    -> Int
+    -- ^ Chunk size for journal replay
+    -> (forall b. m b -> IO b)
+    -> Database
+        m
+        MPFStandaloneCF
+        (MPFStandalone ByteString ByteString MPFHash)
+        MPFStandaloneOp
+    -> FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> IO (MtsTransition MpfImpl IO)
+mpfManagedTransition prefix chunkSize run db fromKV hashing = do
+    locked <- newIORef False
+    let guardedRun
+            :: forall b
+             . Transaction
+                m
+                MPFStandaloneCF
+                (MPFStandalone ByteString ByteString MPFHash)
+                MPFStandaloneOp
+                b
+            -> IO b
+        guardedRun txn = do
+            isLocked <- readIORef locked
+            when isLocked
+                $ fail
+                    "KVOnly store disabled after transition"
+            run (runTransactionUnguarded db txn)
+    pure
+        MtsTransition
+            { transitionKVStore =
+                hoistMTS
+                    guardedRun
+                    (mpfKVOnlyStoreT fromKV)
+            , transitionToFull = do
+                writeIORef locked True
+                mpfReplayJournal
+                    prefix
+                    chunkSize
+                    run
+                    db
+                    fromKV
+                    hashing
+                pure
+                    $ hoistMTS
+                        (run . runTransactionUnguarded db)
+                        (mpfMerkleTreeStoreT prefix fromKV hashing)
+            }
+
+-- ------------------------------------------------------------------
+-- Journal replay
+-- ------------------------------------------------------------------
+
+-- | Check if the journal column is empty.
+mpfJournalEmpty
+    :: (MonadFail m)
+    => (forall b. m b -> IO b)
+    -> Database
+        m
+        MPFStandaloneCF
+        (MPFStandalone ByteString ByteString MPFHash)
+        MPFStandaloneOp
+    -> IO Bool
+mpfJournalEmpty run db =
+    run $ runTransactionUnguarded db $ do
+        me <- iterating MPFStandaloneJournalCol firstEntry
+        pure $ case me of
+            Nothing -> True
+            Just _ -> False
+
+-- | Replay journal entries against the tree, then clear them.
+mpfReplayJournal
+    :: (MonadFail m)
+    => HexKey
+    -> Int
+    -> (forall b. m b -> IO b)
+    -> Database
+        m
+        MPFStandaloneCF
+        (MPFStandalone ByteString ByteString MPFHash)
+        MPFStandaloneOp
+    -> FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> IO ()
+mpfReplayJournal prefix chunkSize run db fromKV hashing = loop
+  where
+    loop = do
+        done <- run $ runTransactionUnguarded db $ do
+            entries <- iterating MPFStandaloneJournalCol $ do
+                me <- firstEntry
+                case me of
+                    Nothing -> pure []
+                    Just e -> collectN (chunkSize - 1) [e]
+            if null entries
+                then pure True
+                else do
+                    mpfReplayEntries prefix fromKV hashing entries
+                    pure False
+        unless done loop
+
+-- | Collect up to @n@ more entries after the first.
+collectN
+    :: (Monad m)
+    => Int
+    -> [Entry c]
+    -> Cursor m c [Entry c]
+collectN 0 acc = pure (reverse acc)
+collectN n acc = do
+    me <- nextEntry
+    case me of
+        Nothing -> pure (reverse acc)
+        Just e -> collectN (n - 1) (e : acc)
+
+-- | Apply journal entries to the MPF tree and clear them.
+mpfReplayEntries
+    :: (Monad m)
+    => HexKey
+    -> FromHexKV ByteString ByteString MPFHash
+    -> MPFHashing MPFHash
+    -> [Entry (KV ByteString ByteString)]
+    -> Transaction
+        m
+        MPFStandaloneCF
+        (MPFStandalone ByteString ByteString MPFHash)
+        MPFStandaloneOp
+        ()
+mpfReplayEntries prefix fromKV hashing entries = do
+    mapM_ applyEntry entries
+    mapM_ (\e -> delete MPFStandaloneJournalCol (entryKey e)) entries
+  where
+    applyEntry e =
+        let (tag, v) = parseJournalEntry (entryValue e)
+            k = entryKey e
+        in  case tag of
+                JInsert ->
+                    insertingTreeOnly
+                        prefix
+                        fromKV
+                        hashing
+                        MPFStandaloneMPFCol
+                        k
+                        v
+                JDelete ->
+                    deletingTreeOnly
+                        prefix
+                        fromKV
+                        hashing
+                        MPFStandaloneMPFCol
+                        k
+                        v

--- a/lib/mts/MTS/Interface.hs
+++ b/lib/mts/MTS/Interface.hs
@@ -2,11 +2,33 @@
 --
 -- Uses type families so each implementation phantom type
 -- (@CsmtImpl@, @MpfImpl@) determines key, value, hash, and
--- proof types. The 'MerkleTreeStore' record is parameterised
--- by just the implementation tag and the monad.
+-- proof types.
+--
+-- The store is parameterised by a @mode@ ('KVOnly' or 'Full')
+-- that determines which operations are available at the type
+-- level.
 module MTS.Interface
-    ( MerkleTreeStore (..)
+    ( -- * Mode
+      Mode (..)
+
+      -- * Operation records
+    , MtsKV (..)
+    , MtsTree (..)
+
+      -- * Store GADT
+    , MerkleTreeStore (..)
+    , mtsKV
+    , mtsTree
+
+      -- * Lifecycle transition
+    , MtsTransition (..)
+
+      -- * Natural transformations
+    , hoistMtsKV
+    , hoistMtsTree
     , hoistMTS
+
+      -- * Type families
     , MtsKey
     , MtsValue
     , MtsHash
@@ -14,6 +36,8 @@ module MTS.Interface
     , MtsLeaf
     , MtsCompletenessProof
     , MtsPrefix
+
+      -- * Namespaced store
     , NamespacedMTS (..)
     , hoistNamespacedMTS
     )
@@ -37,19 +61,28 @@ type family MtsLeaf imp
 -- | Completeness proof type for an implementation.
 type family MtsCompletenessProof imp
 
--- | A generic Merkle tree store providing insert, delete,
--- proof generation and verification.
-data MerkleTreeStore imp m = MerkleTreeStore
+-- | Store mode: 'KVOnly' during bootstrap (no tree ops),
+-- 'Full' after replay (all operations).
+data Mode = KVOnly | Full
+
+-- | KV operations -- available in both modes.
+data MtsKV imp m = MtsKV
     { mtsInsert :: MtsKey imp -> MtsValue imp -> m ()
     -- ^ Insert a key-value pair
     , mtsDelete :: MtsKey imp -> m ()
     -- ^ Delete a key
-    , mtsRootHash :: m (Maybe (MtsHash imp))
+    }
+
+-- | Tree operations -- only available in 'Full' mode.
+data MtsTree imp m = MtsTree
+    { mtsRootHash :: m (Maybe (MtsHash imp))
     -- ^ Query the current root hash
-    , mtsMkProof :: MtsKey imp -> m (Maybe (MtsHash imp, MtsProof imp))
-    -- ^ Generate a membership proof anchored to the current root hash
+    , mtsMkProof
+        :: MtsKey imp
+        -> m (Maybe (MtsHash imp, MtsProof imp))
+    -- ^ Generate a membership proof
     , mtsVerifyProof :: MtsValue imp -> MtsProof imp -> m Bool
-    -- ^ Verify a membership proof for a value
+    -- ^ Verify a membership proof
     , mtsFoldProof :: MtsProof imp -> MtsHash imp
     -- ^ Compute root hash from a proof
     , mtsBatchInsert :: [(MtsKey imp, MtsValue imp)] -> m ()
@@ -66,18 +99,57 @@ data MerkleTreeStore imp m = MerkleTreeStore
     -- ^ Verify a completeness proof against leaves
     }
 
--- | Transform the monad of a 'MerkleTreeStore' via a natural
--- transformation. Use this to run a transactional store in 'IO'
--- by supplying @run . runTransactionUnguarded db@.
-hoistMTS
+-- | Mode-indexed Merkle tree store.
+--
+-- In 'KVOnly' mode only KV operations are available (insert,
+-- delete). In 'Full' mode both KV and tree operations
+-- (root hash, proofs, batch insert) are available.
+data MerkleTreeStore (mode :: Mode) imp m where
+    MkKVOnly :: MtsKV imp m -> MerkleTreeStore 'KVOnly imp m
+    MkFull :: MtsKV imp m -> MtsTree imp m -> MerkleTreeStore 'Full imp m
+
+-- | Extract KV operations from any mode.
+mtsKV :: MerkleTreeStore mode imp m -> MtsKV imp m
+mtsKV (MkKVOnly kv) = kv
+mtsKV (MkFull kv _) = kv
+
+-- | Extract tree operations (only from 'Full').
+mtsTree :: MerkleTreeStore 'Full imp m -> MtsTree imp m
+mtsTree (MkFull _ tree) = tree
+
+-- | Lifecycle handle for managed mode transitions.
+--
+-- Bundles a 'KVOnly' store with a one-shot transition action
+-- that replays the journal and returns a 'Full' store. After
+-- 'transitionToFull' is called, operations on
+-- 'transitionKVStore' throw to prevent concurrent usage.
+data MtsTransition imp m = MtsTransition
+    { transitionKVStore :: MerkleTreeStore 'KVOnly imp m
+    -- ^ KVOnly store (disabled after transition)
+    , transitionToFull :: m (MerkleTreeStore 'Full imp m)
+    -- ^ Replay journal and return Full store.
+    --   Permanently disables 'transitionKVStore'.
+    }
+
+-- | Transform the monad of 'MtsKV'.
+hoistMtsKV
     :: (forall a. m a -> n a)
-    -> MerkleTreeStore imp m
-    -> MerkleTreeStore imp n
-hoistMTS f s =
-    MerkleTreeStore
+    -> MtsKV imp m
+    -> MtsKV imp n
+hoistMtsKV f s =
+    MtsKV
         { mtsInsert = \k v -> f (mtsInsert s k v)
         , mtsDelete = f . mtsDelete s
-        , mtsRootHash = f (mtsRootHash s)
+        }
+
+-- | Transform the monad of 'MtsTree'.
+hoistMtsTree
+    :: (forall a. m a -> n a)
+    -> MtsTree imp m
+    -> MtsTree imp n
+hoistMtsTree f s =
+    MtsTree
+        { mtsRootHash = f (mtsRootHash s)
         , mtsMkProof = f . mtsMkProof s
         , mtsVerifyProof = \v p -> f (mtsVerifyProof s v p)
         , mtsFoldProof = mtsFoldProof s
@@ -88,13 +160,23 @@ hoistMTS f s =
             \ls p -> f (mtsVerifyCompletenessProof s ls p)
         }
 
+-- | Transform the monad of a 'MerkleTreeStore' via a natural
+-- transformation.
+hoistMTS
+    :: (forall a. m a -> n a)
+    -> MerkleTreeStore mode imp m
+    -> MerkleTreeStore mode imp n
+hoistMTS f (MkKVOnly kv) = MkKVOnly (hoistMtsKV f kv)
+hoistMTS f (MkFull kv tree) =
+    MkFull (hoistMtsKV f kv) (hoistMtsTree f tree)
+
 -- | Namespace prefix type for an implementation.
 type family MtsPrefix imp
 
 -- | A namespaced Merkle tree store supporting multiple independent
--- namespaces within one database.
+-- namespaces within one database. Always 'Full' mode.
 data NamespacedMTS imp m = NamespacedMTS
-    { nsStore :: MtsPrefix imp -> MerkleTreeStore imp m
+    { nsStore :: MtsPrefix imp -> MerkleTreeStore 'Full imp m
     -- ^ Get a scoped store for a namespace.
     --   Creation is implicit on first insert.
     , nsDelete :: MtsPrefix imp -> m ()

--- a/lib/mts/MTS/Properties.hs
+++ b/lib/mts/MTS/Properties.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE DataKinds #-}
+
 -- | Shared QuickCheck properties for Merkle tree store
 -- implementations. Each property takes a store constructor
 -- and generators as arguments, returning a 'Property'.
+--
+-- Existing properties operate on @'Full@-mode stores.
+-- Replay properties test the @'KVOnly@ to @'Full@ transition.
 module MTS.Properties
-    ( propInsertVerify
+    ( -- * Full-mode properties
+      propInsertVerify
     , propMultipleInsertAllVerify
     , propInsertionOrderIndependence
     , propDeleteRemovesKey
@@ -16,6 +22,13 @@ module MTS.Properties
     , propCompletenessRoundTrip
     , propCompletenessEmpty
     , propCompletenessAfterDelete
+
+      -- * Replay properties
+    , propKVOnlyThenReplayMatchesFull
+    , propKVOnlyThenReplayProofsWork
+    , propKVOnlyDeleteThenReplay
+    , propReplayIdempotent
+    , propJournalCompression
     )
 where
 
@@ -24,9 +37,14 @@ import Data.Maybe (isJust, isNothing)
 import Data.Ord (comparing)
 import MTS.Interface
     ( MerkleTreeStore (..)
+    , Mode (..)
     , MtsHash
+    , MtsKV (..)
     , MtsKey
+    , MtsTree (..)
     , MtsValue
+    , mtsKV
+    , mtsTree
     )
 import Test.QuickCheck
     ( Gen
@@ -37,43 +55,48 @@ import Test.QuickCheck
     , (==>)
     )
 
+-- ------------------------------------------------------------------
+-- Full-mode properties
+-- ------------------------------------------------------------------
+
 -- | After inserting k v, verify k v returns True.
 propInsertVerify
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen (MtsKey imp, MtsValue imp)
     -> Property
 propInsertVerify mkStore gen =
     property $ forAll gen $ \(k, v) -> ioProperty $ do
         store <- mkStore
-        mtsInsert store k v
-        mp <- mtsMkProof store k
+        mtsInsert (mtsKV store) k v
+        mp <- mtsMkProof (mtsTree store) k
         case mp of
             Nothing -> pure False
-            Just (_, proof) -> mtsVerifyProof store v proof
+            Just (_, proof) ->
+                mtsVerifyProof (mtsTree store) v proof
 
 -- | Insert N pairs, all verify.
 propMultipleInsertAllVerify
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen [(MtsKey imp, MtsValue imp)]
     -> Property
 propMultipleInsertAllVerify mkStore gen =
     property $ forAll gen $ \kvs -> ioProperty $ do
         store <- mkStore
-        mapM_ (uncurry $ mtsInsert store) kvs
+        mapM_ (uncurry $ mtsInsert (mtsKV store)) kvs
         results <-
             mapM
                 ( \(k, v) -> do
-                    mp <- mtsMkProof store k
+                    mp <- mtsMkProof (mtsTree store) k
                     case mp of
                         Nothing -> pure False
                         Just (_, proof) ->
-                            mtsVerifyProof store v proof
+                            mtsVerifyProof (mtsTree store) v proof
                 )
                 kvs
         pure $ and results
@@ -85,8 +108,8 @@ propInsertionOrderIndependence
        , Eq (MtsHash imp)
        , Ord (MtsKey imp)
        )
-    => IO (MerkleTreeStore imp IO)
-    -> IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
+    -> IO (MerkleTreeStore 'Full imp IO)
     -> Gen [(MtsKey imp, MtsValue imp)]
     -> Property
 propInsertionOrderIndependence mkStore1 mkStore2 gen =
@@ -94,11 +117,11 @@ propInsertionOrderIndependence mkStore1 mkStore2 gen =
         let sorted = sortBy (comparing fst) kvs
             reversed' = reverse sorted
         store1 <- mkStore1
-        mapM_ (uncurry $ mtsInsert store1) sorted
-        h1 <- mtsRootHash store1
+        mapM_ (uncurry $ mtsInsert (mtsKV store1)) sorted
+        h1 <- mtsRootHash (mtsTree store1)
         store2 <- mkStore2
-        mapM_ (uncurry $ mtsInsert store2) reversed'
-        h2 <- mtsRootHash store2
+        mapM_ (uncurry $ mtsInsert (mtsKV store2)) reversed'
+        h2 <- mtsRootHash (mtsTree store2)
         pure $ h1 == h2
 
 -- | Insert k v, delete k, verify k v returns False.
@@ -106,19 +129,19 @@ propDeleteRemovesKey
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen (MtsKey imp, MtsValue imp)
     -> Property
 propDeleteRemovesKey mkStore gen =
     property $ forAll gen $ \(k, v) -> ioProperty $ do
         store <- mkStore
-        mtsInsert store k v
-        mtsDelete store k
-        mp <- mtsMkProof store k
+        mtsInsert (mtsKV store) k v
+        mtsDelete (mtsKV store) k
+        mp <- mtsMkProof (mtsTree store) k
         case mp of
             Nothing -> pure True
             Just (_, proof) ->
-                not <$> mtsVerifyProof store v proof
+                not <$> mtsVerifyProof (mtsTree store) v proof
 
 -- | Insert 3 distinct keys, delete one, other two still verify.
 propDeletePreservesSiblings
@@ -126,7 +149,7 @@ propDeletePreservesSiblings
        , Show (MtsValue imp)
        , Eq (MtsKey imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen (MtsKey imp, MtsValue imp)
     -> Gen (MtsKey imp, MtsValue imp)
     -> Gen (MtsKey imp, MtsValue imp)
@@ -140,22 +163,30 @@ propDeletePreservesSiblings mkStore gen1 gen2 gen3 =
                     k1 /= k2 && k2 /= k3 && k1 /= k3 ==>
                         ioProperty $ do
                             store <- mkStore
-                            mtsInsert store k1 v1
-                            mtsInsert store k2 v2
-                            mtsInsert store k3 v3
-                            mtsDelete store k2
+                            mtsInsert (mtsKV store) k1 v1
+                            mtsInsert (mtsKV store) k2 v2
+                            mtsInsert (mtsKV store) k3 v3
+                            mtsDelete (mtsKV store) k2
                             r1 <- do
-                                mp <- mtsMkProof store k1
+                                mp <-
+                                    mtsMkProof (mtsTree store) k1
                                 case mp of
                                     Nothing -> pure False
                                     Just (_, proof) ->
-                                        mtsVerifyProof store v1 proof
+                                        mtsVerifyProof
+                                            (mtsTree store)
+                                            v1
+                                            proof
                             r3 <- do
-                                mp <- mtsMkProof store k3
+                                mp <-
+                                    mtsMkProof (mtsTree store) k3
                                 case mp of
                                     Nothing -> pure False
                                     Just (_, proof) ->
-                                        mtsVerifyProof store v3 proof
+                                        mtsVerifyProof
+                                            (mtsTree store)
+                                            v3
+                                            proof
                             pure $ r1 && r3
 
 -- | Batch insert produces same root as sequential.
@@ -164,60 +195,58 @@ propBatchEqualsSequential
        , Show (MtsValue imp)
        , Eq (MtsHash imp)
        )
-    => IO (MerkleTreeStore imp IO)
-    -> IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
+    -> IO (MerkleTreeStore 'Full imp IO)
     -> Gen [(MtsKey imp, MtsValue imp)]
     -> Property
 propBatchEqualsSequential mkSeqStore mkBatchStore gen =
     property $ forAll gen $ \kvs -> ioProperty $ do
         seqStore <- mkSeqStore
-        mapM_ (uncurry $ mtsInsert seqStore) kvs
-        h1 <- mtsRootHash seqStore
+        mapM_ (uncurry $ mtsInsert (mtsKV seqStore)) kvs
+        h1 <- mtsRootHash (mtsTree seqStore)
         batchStore <- mkBatchStore
-        mtsBatchInsert batchStore kvs
-        h2 <- mtsRootHash batchStore
+        mtsBatchInsert (mtsTree batchStore) kvs
+        h2 <- mtsRootHash (mtsTree batchStore)
         pure $ h1 == h2
 
 -- | Insert N, delete all N, root is Nothing.
 propInsertDeleteAllEmpty
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
-       , Eq (MtsHash imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen [(MtsKey imp, MtsValue imp)]
     -> Property
 propInsertDeleteAllEmpty mkStore gen =
     property $ forAll gen $ \kvs -> ioProperty $ do
         store <- mkStore
-        mapM_ (uncurry $ mtsInsert store) kvs
-        mapM_ (mtsDelete store . fst) kvs
-        h <- mtsRootHash store
+        mapM_ (uncurry $ mtsInsert (mtsKV store)) kvs
+        mapM_ (mtsDelete (mtsKV store) . fst) kvs
+        h <- mtsRootHash (mtsTree store)
         pure $ isNothing h
 
 -- | Empty tree has no root hash.
 propEmptyTreeNoRoot
-    :: IO (MerkleTreeStore imp IO)
+    :: IO (MerkleTreeStore 'Full imp IO)
     -> Property
 propEmptyTreeNoRoot mkStore = ioProperty $ do
     store <- mkStore
-    h <- mtsRootHash store
+    h <- mtsRootHash (mtsTree store)
     pure $ isNothing h
 
 -- | Single insert produces a root hash.
 propSingleInsertHasRoot
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
-       , Eq (MtsHash imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen (MtsKey imp, MtsValue imp)
     -> Property
 propSingleInsertHasRoot mkStore gen =
     property $ forAll gen $ \(k, v) -> ioProperty $ do
         store <- mkStore
-        mtsInsert store k v
-        h <- mtsRootHash store
+        mtsInsert (mtsKV store) k v
+        h <- mtsRootHash (mtsTree store)
         pure $ isJust h
 
 -- | Insert k v, verify k v' where v /= v' returns False.
@@ -225,18 +254,19 @@ propWrongValueRejects
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen (MtsKey imp, MtsValue imp, MtsValue imp)
     -> Property
 propWrongValueRejects mkStore gen =
     property $ forAll gen $ \(k, v, v') -> ioProperty $ do
         store <- mkStore
-        mtsInsert store k v
-        mp <- mtsMkProof store k
+        mtsInsert (mtsKV store) k v
+        mp <- mtsMkProof (mtsTree store) k
         case mp of
             Nothing -> pure False
             Just (_, proof) ->
-                not <$> mtsVerifyProof store v' proof
+                not
+                    <$> mtsVerifyProof (mtsTree store) v' proof
 
 -- | The root hash returned by mtsMkProof matches mtsFoldProof
 -- and mtsRootHash.
@@ -245,19 +275,20 @@ propProofAnchoredToRoot
        , Show (MtsValue imp)
        , Eq (MtsHash imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen (MtsKey imp, MtsValue imp)
     -> Property
 propProofAnchoredToRoot mkStore gen =
     property $ forAll gen $ \(k, v) -> ioProperty $ do
         store <- mkStore
-        mtsInsert store k v
-        mp <- mtsMkProof store k
+        mtsInsert (mtsKV store) k v
+        mp <- mtsMkProof (mtsTree store) k
         case mp of
             Nothing -> pure False
             Just (anchoredRoot, proof) -> do
-                currentRoot <- mtsRootHash store
-                let foldedRoot = mtsFoldProof store proof
+                currentRoot <- mtsRootHash (mtsTree store)
+                let foldedRoot =
+                        mtsFoldProof (mtsTree store) proof
                 pure
                     $ currentRoot == Just anchoredRoot
                         && foldedRoot == anchoredRoot
@@ -268,27 +299,30 @@ propCompletenessRoundTrip
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen [(MtsKey imp, MtsValue imp)]
     -> Property
 propCompletenessRoundTrip mkStore gen =
     property $ forAll gen $ \kvs -> ioProperty $ do
         store <- mkStore
-        mapM_ (uncurry $ mtsInsert store) kvs
-        leaves <- mtsCollectLeaves store
-        mp <- mtsMkCompletenessProof store
+        mapM_ (uncurry $ mtsInsert (mtsKV store)) kvs
+        leaves <- mtsCollectLeaves (mtsTree store)
+        mp <- mtsMkCompletenessProof (mtsTree store)
         case mp of
             Nothing -> pure False
             Just proof ->
-                mtsVerifyCompletenessProof store leaves proof
+                mtsVerifyCompletenessProof
+                    (mtsTree store)
+                    leaves
+                    proof
 
 -- | Empty tree has no completeness proof.
 propCompletenessEmpty
-    :: IO (MerkleTreeStore imp IO)
+    :: IO (MerkleTreeStore 'Full imp IO)
     -> Property
 propCompletenessEmpty mkStore = ioProperty $ do
     store <- mkStore
-    mp <- mtsMkCompletenessProof store
+    mp <- mtsMkCompletenessProof (mtsTree store)
     pure $ case mp of
         Nothing -> True
         Just _ -> False
@@ -299,25 +333,200 @@ propCompletenessAfterDelete
     :: ( Show (MtsKey imp)
        , Show (MtsValue imp)
        )
-    => IO (MerkleTreeStore imp IO)
+    => IO (MerkleTreeStore 'Full imp IO)
     -> Gen [(MtsKey imp, MtsValue imp)]
     -> Property
 propCompletenessAfterDelete mkStore gen =
     property $ forAll gen $ \kvs -> ioProperty $ do
         store <- mkStore
-        mapM_ (uncurry $ mtsInsert store) kvs
+        mapM_ (uncurry $ mtsInsert (mtsKV store)) kvs
         let toDelete = take (length kvs `div` 2) kvs
-        mapM_ (mtsDelete store . fst) toDelete
-        root' <- mtsRootHash store
+        mapM_ (mtsDelete (mtsKV store) . fst) toDelete
+        root' <- mtsRootHash (mtsTree store)
         case root' of
             Nothing -> pure True
             Just _ -> do
-                leaves <- mtsCollectLeaves store
-                mp <- mtsMkCompletenessProof store
+                leaves <- mtsCollectLeaves (mtsTree store)
+                mp <- mtsMkCompletenessProof (mtsTree store)
                 case mp of
                     Nothing -> pure False
                     Just proof ->
                         mtsVerifyCompletenessProof
-                            store
+                            (mtsTree store)
                             leaves
                             proof
+
+-- ------------------------------------------------------------------
+-- Replay properties
+-- ------------------------------------------------------------------
+
+-- | Insert N pairs via KVOnly, replay journal, root hash
+-- matches Full-mode store with same inserts.
+propKVOnlyThenReplayMatchesFull
+    :: ( Show (MtsKey imp)
+       , Show (MtsValue imp)
+       , Eq (MtsHash imp)
+       )
+    => IO
+        ( MerkleTreeStore 'KVOnly imp IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full imp IO)
+        )
+    -> IO (MerkleTreeStore 'Full imp IO)
+    -> Gen [(MtsKey imp, MtsValue imp)]
+    -> Property
+propKVOnlyThenReplayMatchesFull mkReplayEnv mkRefStore gen =
+    property $ forAll gen $ \kvs -> ioProperty $ do
+        (kvStore, replay, mkFull) <- mkReplayEnv
+        mapM_
+            (uncurry $ mtsInsert (mtsKV kvStore))
+            kvs
+        replay
+        fullStore <- mkFull
+        h1 <- mtsRootHash (mtsTree fullStore)
+        refStore <- mkRefStore
+        mapM_
+            (uncurry $ mtsInsert (mtsKV refStore))
+            kvs
+        h2 <- mtsRootHash (mtsTree refStore)
+        pure $ h1 == h2
+
+-- | After KVOnly inserts and replay, all keys have valid
+-- proofs.
+propKVOnlyThenReplayProofsWork
+    :: ( Show (MtsKey imp)
+       , Show (MtsValue imp)
+       )
+    => IO
+        ( MerkleTreeStore 'KVOnly imp IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full imp IO)
+        )
+    -> Gen [(MtsKey imp, MtsValue imp)]
+    -> Property
+propKVOnlyThenReplayProofsWork mkReplayEnv gen =
+    property $ forAll gen $ \kvs -> ioProperty $ do
+        (kvStore, replay, mkFull) <- mkReplayEnv
+        mapM_
+            (uncurry $ mtsInsert (mtsKV kvStore))
+            kvs
+        replay
+        fullStore <- mkFull
+        results <-
+            mapM
+                ( \(k, v) -> do
+                    mp <- mtsMkProof (mtsTree fullStore) k
+                    case mp of
+                        Nothing -> pure False
+                        Just (_, proof) ->
+                            mtsVerifyProof
+                                (mtsTree fullStore)
+                                v
+                                proof
+                )
+                kvs
+        pure $ and results
+
+-- | Insert + delete some via KVOnly, replay, surviving keys
+-- have valid proofs and deleted keys do not.
+--
+-- Note: we verify via proofs rather than root hash comparison
+-- because journal compression (last-write-wins) means replay
+-- may build the tree from scratch rather than replaying the
+-- full insert+delete history. For implementations where
+-- deletion does not fully normalize branch structure (e.g.
+-- MPF), this can produce a structurally different but
+-- semantically correct tree.
+propKVOnlyDeleteThenReplay
+    :: ( Show (MtsKey imp)
+       , Show (MtsValue imp)
+       )
+    => IO
+        ( MerkleTreeStore 'KVOnly imp IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full imp IO)
+        )
+    -> Gen [(MtsKey imp, MtsValue imp)]
+    -> Property
+propKVOnlyDeleteThenReplay mkReplayEnv gen =
+    property $ forAll gen $ \kvs -> ioProperty $ do
+        (kvStore, replay, mkFull) <- mkReplayEnv
+        mapM_
+            (uncurry $ mtsInsert (mtsKV kvStore))
+            kvs
+        let toDelete = take (length kvs `div` 2) kvs
+            surviving = drop (length kvs `div` 2) kvs
+        mapM_
+            (mtsDelete (mtsKV kvStore) . fst)
+            toDelete
+        replay
+        fullStore <- mkFull
+        -- Surviving keys must have valid proofs
+        okSurviving <-
+            mapM
+                ( \(k, v) -> do
+                    mp <- mtsMkProof (mtsTree fullStore) k
+                    case mp of
+                        Nothing -> pure False
+                        Just (_, proof) ->
+                            mtsVerifyProof
+                                (mtsTree fullStore)
+                                v
+                                proof
+                )
+                surviving
+        -- Deleted keys must not verify
+        okDeleted <-
+            mapM
+                ( \(k, v) -> do
+                    mp <- mtsMkProof (mtsTree fullStore) k
+                    case mp of
+                        Nothing -> pure True
+                        Just (_, proof) ->
+                            not
+                                <$> mtsVerifyProof
+                                    (mtsTree fullStore)
+                                    v
+                                    proof
+                )
+                toDelete
+        pure $ and okSurviving && and okDeleted
+
+-- | Replaying an empty journal is a no-op.
+propReplayIdempotent
+    :: IO
+        ( MerkleTreeStore 'KVOnly imp IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full imp IO)
+        )
+    -> Property
+propReplayIdempotent mkReplayEnv = ioProperty $ do
+    (_, replay, mkFull) <- mkReplayEnv
+    replay
+    fullStore <- mkFull
+    h <- mtsRootHash (mtsTree fullStore)
+    pure $ isNothing h
+
+-- | Insert k v then delete k via KVOnly; after replay the
+-- tree is empty. Verifies that conflicting operations on
+-- the same key are handled correctly by the journal.
+propJournalCompression
+    :: ( Show (MtsKey imp)
+       , Show (MtsValue imp)
+       )
+    => IO
+        ( MerkleTreeStore 'KVOnly imp IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full imp IO)
+        )
+    -> Gen (MtsKey imp, MtsValue imp)
+    -> Property
+propJournalCompression mkReplayEnv gen =
+    property $ forAll gen $ \(k, v) -> ioProperty $ do
+        (kvStore, replay, mkFull) <- mkReplayEnv
+        mtsInsert (mtsKV kvStore) k v
+        mtsDelete (mtsKV kvStore) k
+        replay
+        fullStore <- mkFull
+        h <- mtsRootHash (mtsTree fullStore)
+        pure $ isNothing h

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module MTS.PropertySpec (spec) where
 
 import CSMT.Backend.Pure
@@ -8,10 +10,18 @@ import CSMT.Backend.Pure
     )
 import CSMT.Backend.Standalone (StandaloneCodecs (..))
 import CSMT.Hashes (Hash, fromKVHashes, hashHashing, isoHash)
-import CSMT.MTS (CsmtImpl, csmtMerkleTreeStore)
+import CSMT.MTS
+    ( CsmtImpl
+    , csmtKVOnlyStore
+    , csmtManagedTransition
+    , csmtMerkleTreeStore
+    , csmtReplayJournal
+    )
+import Control.Exception (SomeException, try)
 import Control.Lens (Iso', iso)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
+import Data.Either (isLeft)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import MPF.Backend.Pure
     ( MPFPure
@@ -28,10 +38,28 @@ import MPF.Hashes
     , renderMPFHash
     )
 import MPF.Interface (FromHexKV (..), byteStringToHexKey)
-import MPF.MTS (MpfImpl, mpfMerkleTreeStore)
-import MTS.Interface (MerkleTreeStore)
+import MPF.MTS
+    ( MpfImpl
+    , mpfKVOnlyStore
+    , mpfManagedTransition
+    , mpfMerkleTreeStore
+    , mpfReplayJournal
+    )
+import MTS.Interface
+    ( MerkleTreeStore
+    , Mode (..)
+    , MtsKV (..)
+    , MtsTransition (..)
+    , mtsKV
+    )
 import MTS.Properties
-import Test.Hspec (Spec, describe, it)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldReturn
+    , shouldThrow
+    )
 import Test.QuickCheck
     ( Gen
     , arbitrary
@@ -40,10 +68,22 @@ import Test.QuickCheck
     )
 
 -- ------------------------------------------------------------------
+-- CSMT codecs (shared)
+-- ------------------------------------------------------------------
+
+csmtCodecs :: StandaloneCodecs ByteString ByteString Hash
+csmtCodecs =
+    StandaloneCodecs
+        { keyCodec = iso id id
+        , valueCodec = iso id id
+        , nodeCodec = isoHash
+        }
+
+-- ------------------------------------------------------------------
 -- CSMT store factory
 -- ------------------------------------------------------------------
 
-mkCsmtStore :: IO (MerkleTreeStore CsmtImpl IO)
+mkCsmtStore :: IO (MerkleTreeStore 'Full CsmtImpl IO)
 mkCsmtStore = do
     ref <- newIORef emptyInMemoryDB
     let run :: forall b. Pure b -> IO b
@@ -52,27 +92,71 @@ mkCsmtStore = do
             let (a, db') = runPure db action
             writeIORef ref db'
             pure a
+    csmtMerkleTreeStore
+        []
+        run
+        (pureDatabase csmtCodecs)
+        fromKVHashes
+        hashHashing
+
+-- ------------------------------------------------------------------
+-- CSMT replay factory
+-- ------------------------------------------------------------------
+
+mkCsmtReplayEnv
+    :: IO
+        ( MerkleTreeStore 'KVOnly CsmtImpl IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full CsmtImpl IO)
+        )
+mkCsmtReplayEnv = do
+    ref <- newIORef emptyInMemoryDB
+    let run :: forall b. Pure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runPure s action
+            writeIORef ref s'
+            pure a
+        db = pureDatabase csmtCodecs
     pure
-        $ csmtMerkleTreeStore
-            []
-            run
-            (pureDatabase csmtCodecs)
-            fromKVHashes
-            hashHashing
-  where
-    csmtCodecs :: StandaloneCodecs ByteString ByteString Hash
-    csmtCodecs =
-        StandaloneCodecs
-            { keyCodec = iso id id
-            , valueCodec = iso id id
-            , nodeCodec = isoHash
-            }
+        ( csmtKVOnlyStore run db fromKVHashes
+        , csmtReplayJournal [] 100 run db fromKVHashes hashHashing
+        , csmtMerkleTreeStore [] run db fromKVHashes hashHashing
+        )
+
+-- ------------------------------------------------------------------
+-- MPF codecs (shared)
+-- ------------------------------------------------------------------
+
+mpfCodecs :: MPFStandaloneCodecs ByteString ByteString MPFHash
+mpfCodecs =
+    MPFStandaloneCodecs
+        { mpfKeyCodec = iso id id
+        , mpfValueCodec = iso id id
+        , mpfNodeCodec = isoMPFHash
+        }
+
+isoMPFHash :: Iso' ByteString MPFHash
+isoMPFHash = iso parseMPFHashUnsafe renderMPFHash
+
+parseMPFHashUnsafe :: ByteString -> MPFHash
+parseMPFHashUnsafe bs = case parseMPFHash bs of
+    Just h -> h
+    Nothing -> mkMPFHash bs
+
+fromHexKVBS :: FromHexKV ByteString ByteString MPFHash
+fromHexKVBS =
+    FromHexKV
+        { fromHexK = byteStringToHexKey
+        , fromHexV = mkMPFHash
+        , hexTreePrefix = const []
+        }
 
 -- ------------------------------------------------------------------
 -- MPF store factory
 -- ------------------------------------------------------------------
 
-mkMpfStore :: IO (MerkleTreeStore MpfImpl IO)
+mkMpfStore :: IO (MerkleTreeStore 'Full MpfImpl IO)
 mkMpfStore = do
     ref <- newIORef emptyMPFInMemoryDB
     let run :: forall b. MPFPure b -> IO b
@@ -81,33 +165,106 @@ mkMpfStore = do
             let (a, db') = runMPFPure db action
             writeIORef ref db'
             pure a
+    mpfMerkleTreeStore
+        []
+        run
+        (mpfPureDatabase mpfCodecs)
+        fromHexKVBS
+        mpfHashing
+
+-- ------------------------------------------------------------------
+-- MPF replay factory
+-- ------------------------------------------------------------------
+
+mkMpfReplayEnv
+    :: IO
+        ( MerkleTreeStore 'KVOnly MpfImpl IO
+        , IO ()
+        , IO (MerkleTreeStore 'Full MpfImpl IO)
+        )
+mkMpfReplayEnv = do
+    ref <- newIORef emptyMPFInMemoryDB
+    let run :: forall b. MPFPure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runMPFPure s action
+            writeIORef ref s'
+            pure a
+        db = mpfPureDatabase mpfCodecs
     pure
-        $ mpfMerkleTreeStore
-            []
-            run
-            (mpfPureDatabase mpfCodecs)
-            fromHexKVBS
-            mpfHashing
-  where
-    mpfCodecs :: MPFStandaloneCodecs ByteString ByteString MPFHash
-    mpfCodecs =
-        MPFStandaloneCodecs
-            { mpfKeyCodec = iso id id
-            , mpfValueCodec = iso id id
-            , mpfNodeCodec = isoMPFHash
-            }
-    isoMPFHash :: Iso' ByteString MPFHash
-    isoMPFHash = iso parseMPFHashUnsafe renderMPFHash
-    parseMPFHashUnsafe bs = case parseMPFHash bs of
-        Just h -> h
-        Nothing -> mkMPFHash bs
-    fromHexKVBS :: FromHexKV ByteString ByteString MPFHash
-    fromHexKVBS =
-        FromHexKV
-            { fromHexK = byteStringToHexKey
-            , fromHexV = mkMPFHash
-            , hexTreePrefix = const []
-            }
+        ( mpfKVOnlyStore run db fromHexKVBS
+        , mpfReplayJournal [] 100 run db fromHexKVBS mpfHashing
+        , mpfMerkleTreeStore [] run db fromHexKVBS mpfHashing
+        )
+
+-- ------------------------------------------------------------------
+-- Transition factories
+-- ------------------------------------------------------------------
+
+mkCsmtTransition :: IO (MtsTransition CsmtImpl IO)
+mkCsmtTransition = do
+    ref <- newIORef emptyInMemoryDB
+    let run :: forall b. Pure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runPure s action
+            writeIORef ref s'
+            pure a
+    csmtManagedTransition
+        []
+        100
+        run
+        (pureDatabase csmtCodecs)
+        fromKVHashes
+        hashHashing
+
+mkMpfTransition :: IO (MtsTransition MpfImpl IO)
+mkMpfTransition = do
+    ref <- newIORef emptyMPFInMemoryDB
+    let run :: forall b. MPFPure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runMPFPure s action
+            writeIORef ref s'
+            pure a
+    mpfManagedTransition
+        []
+        100
+        run
+        (mpfPureDatabase mpfCodecs)
+        fromHexKVBS
+        mpfHashing
+
+-- | Test that Full construction fails when journal is non-empty.
+mkCsmtStoreWithJournal :: IO (MerkleTreeStore 'Full CsmtImpl IO)
+mkCsmtStoreWithJournal = do
+    ref <- newIORef emptyInMemoryDB
+    let run :: forall b. Pure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runPure s action
+            writeIORef ref s'
+            pure a
+        db = pureDatabase csmtCodecs
+    -- Write to journal via KVOnly
+    let kvStore = csmtKVOnlyStore run db fromKVHashes
+    mtsInsert (mtsKV kvStore) "key" "value"
+    -- Now try to construct Full — should fail
+    csmtMerkleTreeStore [] run db fromKVHashes hashHashing
+
+mkMpfStoreWithJournal :: IO (MerkleTreeStore 'Full MpfImpl IO)
+mkMpfStoreWithJournal = do
+    ref <- newIORef emptyMPFInMemoryDB
+    let run :: forall b. MPFPure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runMPFPure s action
+            writeIORef ref s'
+            pure a
+        db = mpfPureDatabase mpfCodecs
+    let kvStore = mpfKVOnlyStore run db fromHexKVBS
+    mtsInsert (mtsKV kvStore) "key" "value"
+    mpfMerkleTreeStore [] run db fromHexKVBS mpfHashing
 
 -- ------------------------------------------------------------------
 -- Generators
@@ -136,17 +293,27 @@ genBSTriple = do
 spec :: Spec
 spec = do
     describe "CSMT shared properties" $ do
-        it "insert-verify" $ propInsertVerify mkCsmtStore genBSPair
+        it "insert-verify"
+            $ propInsertVerify mkCsmtStore genBSPair
         it "multiple insert all verify"
             $ propMultipleInsertAllVerify mkCsmtStore genBSPairs
         it "insertion order independence"
-            $ propInsertionOrderIndependence mkCsmtStore mkCsmtStore genBSPairs
-        it "delete removes key" $ propDeleteRemovesKey mkCsmtStore genBSPair
+            $ propInsertionOrderIndependence
+                mkCsmtStore
+                mkCsmtStore
+                genBSPairs
+        it "delete removes key"
+            $ propDeleteRemovesKey mkCsmtStore genBSPair
         it "delete preserves siblings"
-            $ propDeletePreservesSiblings mkCsmtStore genBSPair genBSPair genBSPair
+            $ propDeletePreservesSiblings
+                mkCsmtStore
+                genBSPair
+                genBSPair
+                genBSPair
         it "insert-delete-all empty"
             $ propInsertDeleteAllEmpty mkCsmtStore genBSPairs
-        it "empty tree no root" $ propEmptyTreeNoRoot mkCsmtStore
+        it "empty tree no root"
+            $ propEmptyTreeNoRoot mkCsmtStore
         it "single insert has root"
             $ propSingleInsertHasRoot mkCsmtStore genBSPair
         it "wrong value rejects"
@@ -160,18 +327,47 @@ spec = do
         it "completeness after delete"
             $ propCompletenessAfterDelete mkCsmtStore genBSPairs
 
+    describe "CSMT replay properties" $ do
+        it "kvonly then replay matches full"
+            $ propKVOnlyThenReplayMatchesFull
+                mkCsmtReplayEnv
+                mkCsmtStore
+                genBSPairs
+        it "kvonly then replay proofs work"
+            $ propKVOnlyThenReplayProofsWork
+                mkCsmtReplayEnv
+                genBSPairs
+        it "kvonly delete then replay"
+            $ propKVOnlyDeleteThenReplay
+                mkCsmtReplayEnv
+                genBSPairs
+        it "replay idempotent"
+            $ propReplayIdempotent mkCsmtReplayEnv
+        it "journal compression"
+            $ propJournalCompression mkCsmtReplayEnv genBSPair
+
     describe "MPF shared properties" $ do
-        it "insert-verify" $ propInsertVerify mkMpfStore genBSPair
+        it "insert-verify"
+            $ propInsertVerify mkMpfStore genBSPair
         it "multiple insert all verify"
             $ propMultipleInsertAllVerify mkMpfStore genBSPairs
         it "insertion order independence"
-            $ propInsertionOrderIndependence mkMpfStore mkMpfStore genBSPairs
-        it "delete removes key" $ propDeleteRemovesKey mkMpfStore genBSPair
+            $ propInsertionOrderIndependence
+                mkMpfStore
+                mkMpfStore
+                genBSPairs
+        it "delete removes key"
+            $ propDeleteRemovesKey mkMpfStore genBSPair
         it "delete preserves siblings"
-            $ propDeletePreservesSiblings mkMpfStore genBSPair genBSPair genBSPair
+            $ propDeletePreservesSiblings
+                mkMpfStore
+                genBSPair
+                genBSPair
+                genBSPair
         it "insert-delete-all empty"
             $ propInsertDeleteAllEmpty mkMpfStore genBSPairs
-        it "empty tree no root" $ propEmptyTreeNoRoot mkMpfStore
+        it "empty tree no root"
+            $ propEmptyTreeNoRoot mkMpfStore
         it "single insert has root"
             $ propSingleInsertHasRoot mkMpfStore genBSPair
         it "wrong value rejects"
@@ -184,3 +380,54 @@ spec = do
             $ propCompletenessEmpty mkMpfStore
         it "completeness after delete"
             $ propCompletenessAfterDelete mkMpfStore genBSPairs
+
+    describe "MPF replay properties" $ do
+        it "kvonly then replay matches full"
+            $ propKVOnlyThenReplayMatchesFull
+                mkMpfReplayEnv
+                mkMpfStore
+                genBSPairs
+        it "kvonly then replay proofs work"
+            $ propKVOnlyThenReplayProofsWork
+                mkMpfReplayEnv
+                genBSPairs
+        it "kvonly delete then replay"
+            $ propKVOnlyDeleteThenReplay
+                mkMpfReplayEnv
+                genBSPairs
+        it "replay idempotent"
+            $ propReplayIdempotent mkMpfReplayEnv
+        it "journal compression"
+            $ propJournalCompression mkMpfReplayEnv genBSPair
+
+    describe "CSMT mode exclusivity" $ do
+        it "Full rejects non-empty journal"
+            $ mkCsmtStoreWithJournal
+                `shouldThrow` (\(_ :: SomeException) -> True)
+        it "KVOnly throws after transition" $ do
+            t <- mkCsmtTransition
+            mtsInsert (mtsKV (transitionKVStore t)) "k" "v"
+            _ <- transitionToFull t
+            result <-
+                try @SomeException
+                    $ mtsInsert
+                        (mtsKV (transitionKVStore t))
+                        "k2"
+                        "v2"
+            pure (isLeft result) `shouldReturn` True
+
+    describe "MPF mode exclusivity" $ do
+        it "Full rejects non-empty journal"
+            $ mkMpfStoreWithJournal
+                `shouldThrow` (\(_ :: SomeException) -> True)
+        it "KVOnly throws after transition" $ do
+            t <- mkMpfTransition
+            mtsInsert (mtsKV (transitionKVStore t)) "k" "v"
+            _ <- transitionToFull t
+            result <-
+                try @SomeException
+                    $ mtsInsert
+                        (mtsKV (transitionKVStore t))
+                        "k2"
+                        "v2"
+            pure (isLeft result) `shouldReturn` True


### PR DESCRIPTION
## Summary
- Add split-mode MTS: KVOnly bootstrap inserts to KV column only (no trie updates), journaling operations for later replay
- Journal replay rebuilds the merkle trie from accumulated operations after bootstrap completes