### PR TITLE
fix: add pop to CSMT test vectors import

### DIFF
--- a/app/test-vectors/Main.hs
+++ b/app/test-vectors/Main.hs
@@ -193,7 +193,7 @@ main = do
     putStrLn
         "use aiken/csmt.{Proof, ProofStep, empty, from_root,"
     putStrLn
-        "  has, insert, delete, update, root, is_empty}"
+        "  has, insert, delete, update, pop, root, is_empty}"
     putStrLn "use aiken/csmt/hashing.{Indirect}"
     putStrLn ""
 


### PR DESCRIPTION
## Summary
- Add missing `pop` import to generated CSMT test vectors Aiken code

## Test plan
- [x] 230 tests pass locally
- [ ] CI passes