### PR TITLE
feat: add delete support to patchParallel

### DIFF
--- a/bench/populate.hs
+++ b/bench/populate.hs
@@ -26,7 +26,7 @@ import CSMT.Hashes
     , renderHash
     )
 import CSMT.Interface (FromKV (..), root)
-import CSMT.Populate (patchParallel)
+import CSMT.Populate (PatchOp (..), patchParallel)
 import Control.Lens (view)
 import Control.Monad (forM_)
 import Data.ByteString (ByteString)
@@ -91,7 +91,7 @@ benchPopulate tmpDir bucketBits batchSize kvs = do
             (runTransactionUnguarded database)
             $ \feed ->
                 forM_ kvs $ \(k, val) ->
-                    feed (view (isoK fkv) k) (fromV fkv val)
+                    feed $ PatchInsert (view (isoK fkv) k) (fromV fkv val)
         end <- getCurrentTime
         pure $ realToFrac (diffUTCTime end start)
 

--- a/lib/csmt/CSMT/Deletion.hs
+++ b/lib/csmt/CSMT/Deletion.hs
@@ -17,6 +17,7 @@
 module CSMT.Deletion
     ( deleting
     , deletingTreeOnly
+    , deletingDirect
     , newDeletionPath
     , DeletionPath (..)
     , deletionPathToOps
@@ -110,6 +111,30 @@ deletingTreeOnly
     -> Transaction m cf d ops ()
 deletingTreeOnly pfx FromKV{isoK, treePrefix} hashing csmtSel key v = do
     let treeKey = treePrefix v <> view isoK key
+    mpath <- newDeletionPath pfx csmtSel treeKey
+    case mpath of
+        Nothing -> pure ()
+        Just path ->
+            mapM_ (applyOp csmtSel) $ deletionPathToOps pfx hashing path
+
+-- | Delete a pre-computed tree key from the CSMT.
+--
+-- Like 'deletingTreeOnly' but takes the tree key directly,
+-- without going through 'FromKV'. Used by parallel population
+-- where the producer has already done the conversion.
+--
+-- The @treeKey@ should be relative to @pfx@ (bucket prefix
+-- bits already stripped).
+deletingDirect
+    :: (Monad m, GCompare d)
+    => Key
+    -- ^ Prefix (bucket prefix)
+    -> Hashing a
+    -> Selector d Key (Indirect a)
+    -> Key
+    -- ^ Tree key (relative to prefix)
+    -> Transaction m cf d ops ()
+deletingDirect pfx hashing csmtSel treeKey = do
     mpath <- newDeletionPath pfx csmtSel treeKey
     case mpath of
         Nothing -> pure ()

--- a/lib/csmt/CSMT/Populate.hs
+++ b/lib/csmt/CSMT/Populate.hs
@@ -1,21 +1,23 @@
 -- |
 -- Module      : CSMT.Populate
--- Description : Parallel CSMT population from a stream of entries
+-- Description : Parallel CSMT patching from a stream of operations
 -- Copyright   : (c) Paolo Veronelli, 2024
 -- License     : Apache-2.0
 --
--- Patches a CSMT in parallel by bucketing entries by tree key
--- prefix and building subtrees concurrently. Works on both
--- empty and non-empty trees.
+-- Patches a CSMT in parallel by bucketing operations by tree key
+-- prefix and applying them in subtrees concurrently. Works on both
+-- empty and non-empty trees. Supports both inserts and deletes.
 --
--- The caller provides entries via a callback. The library handles
+-- The caller provides operations via a callback. The library handles
 -- tree preparation, bucketing, parallel consumers with batched
 -- transactions, and final merge of the top levels.
 module CSMT.Populate
     ( patchParallel
+    , PatchOp (..)
     )
 where
 
+import CSMT.Deletion (deletingDirect)
 import CSMT.Insertion
     ( allPrefixes
     , bucketIndex
@@ -43,13 +45,22 @@ import Database.KV.Transaction
     )
 import Numeric.Natural (Natural)
 
+-- | An operation to apply to the tree.
+data PatchOp key value
+    = -- | Insert or update a key-value pair.
+      PatchInsert key value
+    | -- | Delete a key.
+      PatchDelete key
+    deriving stock (Eq, Show)
+
 -- |
--- Populate an empty CSMT in parallel.
+-- Patch a CSMT in parallel.
 --
--- Spawns @2^bucketBits@ consumer threads, each building its
--- subtree in batched transactions. The caller produces entries
--- via the @producer@ callback. When the producer returns, the
--- library drains all consumers and merges the top levels.
+-- Spawns @2^bucketBits@ consumer threads, each applying
+-- operations to its subtree in batched transactions. The
+-- caller produces operations via the @producer@ callback.
+-- When the producer returns, the library drains all consumers
+-- and merges the top levels.
 --
 -- The @runTx@ callback must support concurrent calls from
 -- different threads (e.g. 'runTransactionUnguarded'). Each
@@ -69,10 +80,9 @@ patchParallel
     -> Selector d Key (Indirect a)
     -> (forall b. Transaction IO cf d ops b -> IO b)
     -- ^ Run a transaction (must be thread-safe)
-    -> ((Key -> a -> IO ()) -> IO ())
+    -> ((PatchOp Key a -> IO ()) -> IO ())
     -- ^ Producer: given a feed function, emit all
-    -- @(treeKey, hash)@ pairs. When this returns,
-    -- the stream is over.
+    -- operations. When this returns, the stream is over.
     -> IO ()
 patchParallel bucketBits batchSize queueBound pfx hashing csmtCol runTx producer = do
     let prefixes = allPrefixes bucketBits
@@ -88,11 +98,12 @@ patchParallel bucketBits batchSize queueBound pfx hashing csmtCol runTx producer
         async $ consumeQueue (pfx <> bpfx) q
 
     -- Producer runs in the current thread
-    producer $ \treeKey hash -> do
-        let (bucket, stripped) = splitAt bucketBits treeKey
+    producer $ \op -> do
+        let treeKey = opKey op
+            (bucket, stripped) = splitAt bucketBits treeKey
             idx = bucketIndex bucket
         atomically
-            $ writeTBQueue (queues !! idx) (Just (stripped, hash))
+            $ writeTBQueue (queues !! idx) (Just (setOpKey stripped op))
 
     -- Signal end-of-stream to all queues
     forM_ queues $ \q -> atomically $ writeTBQueue q Nothing
@@ -109,7 +120,6 @@ patchParallel bucketBits batchSize queueBound pfx hashing csmtCol runTx producer
             mEntry <- atomically $ readTBQueue q
             case mEntry of
                 Nothing ->
-                    -- Flush remaining batch
                     flushBatch bpfx batch
                 Just entry -> do
                     let batch' = entry : batch
@@ -121,7 +131,19 @@ patchParallel bucketBits batchSize queueBound pfx hashing csmtCol runTx producer
 
     flushBatch _ [] = pure ()
     flushBatch bpfx batch =
-        runTx
-            $ mapM_
-                (uncurry (insertingDirect bpfx hashing csmtCol))
-                batch
+        runTx $ mapM_ (applyOp bpfx) batch
+
+    applyOp bpfx (PatchInsert k v) =
+        insertingDirect bpfx hashing csmtCol k v
+    applyOp bpfx (PatchDelete k) =
+        deletingDirect bpfx hashing csmtCol k
+
+-- | Extract the tree key from an operation.
+opKey :: PatchOp Key a -> Key
+opKey (PatchInsert k _) = k
+opKey (PatchDelete k) = k
+
+-- | Replace the key in an operation.
+setOpKey :: Key -> PatchOp Key a -> PatchOp Key a
+setOpKey k (PatchInsert _ v) = PatchInsert k v
+setOpKey k (PatchDelete _) = PatchDelete k

--- a/test/CSMT/Backend/RocksDBSpec.hs
+++ b/test/CSMT/Backend/RocksDBSpec.hs
@@ -25,7 +25,7 @@ import CSMT.Hashes
     )
 import CSMT.Hashes qualified as Hashes
 import CSMT.Interface (FromKV (..), root)
-import CSMT.Populate (patchParallel)
+import CSMT.Populate (PatchOp (..), patchParallel)
 import Control.Lens (view)
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -206,12 +206,12 @@ spec = around tempDB $ do
                                                     (runTransactionUnguarded database)
                                                     $ \feed ->
                                                         forM_ kvs $ \(k, v) ->
-                                                            feed (view (isoK fkv) k) (fromV fkv v)
+                                                            feed $ PatchInsert (view (isoK fkv) k) (fromV fkv v)
                                                 runTransactionUnguarded database
                                                     $ root hashHashing StandaloneCSMTCol []
                                     popRoot `shouldBe` seqRoot
 
-        it "patchParallel on non-empty tree (with deletes) matches sequential"
+        it "patchParallel with mixed inserts and deletes matches sequential"
             $ \_run -> property
                 $ forAll (scale (* 10) $ genSomePaths 32)
                 $ \allKeys ->
@@ -219,16 +219,22 @@ spec = around tempDB $ do
                         $ \bucketBits ->
                             forAll (choose (1, 50))
                                 $ \batchSize ->
-                                    length allKeys > 3 ==> do
+                                    length allKeys > 5 ==> do
                                         let fkv = fromKVHashes
-                                            -- Split keys: first third pre-populated, some deleted, rest via populate
                                             n = length allKeys
+                                            -- First third: pre-populate the tree
                                             preKeys = take (n `div` 3) allKeys
-                                            delKeys = take (length preKeys `div` 2) preKeys
-                                            popKeys = drop (n `div` 3) allKeys
                                             preKvs = zip preKeys $ BC.pack . ("pre" <>) . show <$> [1 :: Int ..]
+                                            -- Rest: new inserts via patchParallel
+                                            popKeys = drop (n `div` 3) allKeys
                                             popKvs = zip popKeys $ BC.pack . ("pop" <>) . show <$> [1 :: Int ..]
-                                        -- Sequential: pre-insert, delete, then insert remaining
+                                            -- Delete half of pre-inserted keys via patchParallel
+                                            delKeys = take (length preKeys `div` 2) preKeys
+                                            -- Build the operation stream: inserts then deletes
+                                            ops =
+                                                [PatchInsert (view (isoK fkv) k) (fromV fkv v) | (k, v) <- popKvs]
+                                                    <> [PatchDelete (view (isoK fkv) k) | k <- delKeys]
+                                        -- Sequential: pre-insert, then apply same ops
                                         seqRoot <- withSystemTempDirectory "seq"
                                             $ \dir -> do
                                                 let path = dir </> "seqdb"
@@ -236,19 +242,18 @@ spec = around tempDB $ do
                                                     database <- run $ RocksDB.standaloneRocksDBDatabase rocksDBCodecs
                                                     runTransactionUnguarded database $ do
                                                         traverse_ (uncurry iM) preKvs
-                                                        traverse_ dM delKeys
                                                         traverse_ (uncurry iM) popKvs
+                                                        traverse_ dM delKeys
                                                     runTransactionUnguarded database
                                                         $ root hashHashing StandaloneCSMTCol []
-                                        -- Parallel: pre-insert + delete, then patchParallel the rest
+                                        -- Parallel: pre-insert, then patchParallel with mixed ops
                                         popRoot <- withSystemTempDirectory "pop"
                                             $ \dir -> do
                                                 let path = dir </> "popdb"
                                                 withRocksDB path 1 1 $ \(RunRocksDB run) -> do
                                                     database <- run $ RocksDB.standaloneRocksDBDatabase rocksDBCodecs
-                                                    runTransactionUnguarded database $ do
-                                                        traverse_ (uncurry iM) preKvs
-                                                        traverse_ dM delKeys
+                                                    runTransactionUnguarded database
+                                                        $ traverse_ (uncurry iM) preKvs
                                                     patchParallel
                                                         bucketBits
                                                         batchSize
@@ -257,9 +262,7 @@ spec = around tempDB $ do
                                                         hashHashing
                                                         StandaloneCSMTCol
                                                         (runTransactionUnguarded database)
-                                                        $ \feed ->
-                                                            forM_ popKvs $ \(k, v) ->
-                                                                feed (view (isoK fkv) k) (fromV fkv v)
+                                                        $ \feed -> forM_ ops feed
                                                     runTransactionUnguarded database
                                                         $ root hashHashing StandaloneCSMTCol []
                                         popRoot `shouldBe` seqRoot


### PR DESCRIPTION
## Summary

- Add `deletingDirect` to `CSMT.Deletion`: pre-computed tree key, no `FromKV`
- Add `PatchOp` type (`PatchInsert`/`PatchDelete`) to `CSMT.Populate`
- `patchParallel` now accepts mixed insert/delete streams
- Property test: mixed inserts and deletes via `patchParallel` match sequential

## Test plan

- [x] Empty tree: inserts only via patchParallel matches sequential (100 tests)
- [x] Non-empty tree: mixed PatchInsert + PatchDelete in the parallel stream matches sequential (100 tests, random bucketBits 1-4, random batchSize 1-50)

Closes #95