### PR TITLE
feat: add replay tracing callback to patchParallel

### DIFF
--- a/bench/populate.hs
+++ b/bench/populate.hs
@@ -107,7 +107,7 @@ benchPopulate tmpDir bucketBits batchSize kvs = do
                         StandaloneCSMTCol
                         StandaloneKVCol
                         chunk
-            mapConcurrently_ runTx txns
+            mapConcurrently_ (runTx . snd) txns
         runTx
             $ mergeSubtreeRoots [] hashHashing StandaloneCSMTCol bucketBits
         end <- getCurrentTime

--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -55,6 +55,9 @@ module CSMT.MTS
         )
     , mkKVOnlyOps
     , mkFullOps
+
+      -- * Replay tracing
+    , ReplayEvent (..)
     )
 where
 
@@ -668,6 +671,24 @@ data Ops (mode :: Mode) m cf d ops k v a where
            }
         -> Ops 'Full m cf d ops k v a
 
+-- | Replay trace events. Emitted in pairs: 'ReplayStart'
+-- before the concurrent batch, 'ReplayStop' after.
+data ReplayEvent
+    = -- | About to run bucket transactions concurrently.
+      ReplayStart
+        { rsChunkSize :: Int
+        -- ^ Journal entries in this chunk
+        , rsBuckets :: Int
+        -- ^ Active buckets (with ops)
+        , rsTotalBuckets :: Int
+        -- ^ Total bucket count (2^bucketBits)
+        , rsOpsPerBucket :: [Int]
+        -- ^ Ops per active bucket
+        }
+    | -- | Concurrent batch completed.
+      ReplayStop
+    deriving stock (Show)
+
 -- | Build 'KVOnly' ops for generic column types.
 --
 -- Insert/delete write KV + journal atomically. Query reads
@@ -692,6 +713,8 @@ mkKVOnlyOps
     -> Hashing a
     -> (forall b. Transaction m cf d ops b -> IO b)
     -- ^ Transaction runner (must be thread-safe)
+    -> (ReplayEvent -> IO ())
+    -- ^ Trace callback (called per replay chunk)
     -> Ops 'KVOnly m cf d ops k v a
 mkKVOnlyOps
     prefix
@@ -703,7 +726,8 @@ mkKVOnlyOps
     journalIso
     fromKV
     hashing
-    runTx =
+    runTx
+    trace =
         OpsKVOnly
             { kvCommon =
                 CommonOps
@@ -755,8 +779,10 @@ mkKVOnlyOps
                         fromKV
                         hashing
                         runTx
+                        trace
             }
       where
+        totalBuckets = 2 ^ bucketBits :: Int
         replayLoop = do
             entries <-
                 runTx
@@ -771,7 +797,7 @@ mkKVOnlyOps
                                 journalIso
                                 fromKV
                                 entries
-                        txns =
+                        bucketTxns =
                             patchParallel
                                 bucketBits
                                 prefix
@@ -779,7 +805,18 @@ mkKVOnlyOps
                                 csmtCol
                                 journalCol
                                 ops
-                    mapConcurrently_ runTx txns
+                    trace
+                        ReplayStart
+                            { rsChunkSize = length entries
+                            , rsBuckets = length bucketTxns
+                            , rsTotalBuckets = totalBuckets
+                            , rsOpsPerBucket =
+                                map fst bucketTxns
+                            }
+                    mapConcurrently_
+                        (runTx . snd)
+                        bucketTxns
+                    trace ReplayStop
                     replayLoop
 
 -- | Build 'Full' ops for generic column types.
@@ -807,6 +844,8 @@ mkFullOps
     -> Hashing a
     -> (forall b. Transaction m cf d ops b -> IO b)
     -- ^ Transaction runner
+    -> (ReplayEvent -> IO ())
+    -- ^ Trace callback (passed through to 'mkKVOnlyOps')
     -> Ops 'Full m cf d ops k v a
 mkFullOps
     prefix
@@ -818,7 +857,8 @@ mkFullOps
     journalIso
     fromKV
     hashing
-    runTx =
+    runTx
+    trace =
         OpsFull
             { fullCommon =
                 CommonOps
@@ -857,6 +897,7 @@ mkFullOps
                                 fromKV
                                 hashing
                                 runTx
+                                trace
                     else pure Nothing
             }
 

--- a/lib/csmt/CSMT/Populate.hs
+++ b/lib/csmt/CSMT/Populate.hs
@@ -79,8 +79,8 @@ patchParallel
     -- ^ Journal column (for deleting replayed entries)
     -> [(jk, PatchOp Key a)]
     -- ^ (journal key, tree operation) pairs
-    -> [Transaction m cf d ops ()]
-    -- ^ Independent bucket transactions
+    -> [(Int, Transaction m cf d ops ())]
+    -- ^ (op count, transaction) per active bucket
 patchParallel bucketBits pfx hashing csmtCol journalCol entries =
     map mkBucketTx (Map.toList buckets)
   where
@@ -104,9 +104,11 @@ patchParallel bucketBits pfx hashing csmtCol journalCol entries =
     -- Build a transaction for one bucket
     mkBucketTx (idx, ops) =
         let bpfx = pfx <> (prefixes !! idx)
-        in  do
+        in  ( length ops
+            , do
                 mapM_ (applyOp bpfx . snd) ops
                 mapM_ (delete journalCol . fst) ops
+            )
 
     applyOp bpfx (PatchInsert k v) =
         insertingDirect bpfx hashing csmtCol k v

--- a/test/CSMT/Backend/RocksDBSpec.hs
+++ b/test/CSMT/Backend/RocksDBSpec.hs
@@ -214,7 +214,7 @@ spec = around tempDB $ do
                                                     StandaloneCSMTCol
                                                     StandaloneKVCol
                                                     ops
-                                        mapConcurrently_ (runTransactionUnguarded database) txns
+                                        mapConcurrently_ (runTransactionUnguarded database . snd) txns
                                         runTransactionUnguarded database
                                             $ mergeSubtreeRoots [] hashHashing StandaloneCSMTCol bucketBits
                                         runTransactionUnguarded database
@@ -269,7 +269,7 @@ spec = around tempDB $ do
                                                         StandaloneCSMTCol
                                                         StandaloneKVCol
                                                         ops
-                                            mapConcurrently_ (runTransactionUnguarded database) txns
+                                            mapConcurrently_ (runTransactionUnguarded database . snd) txns
                                             runTransactionUnguarded database
                                                 $ mergeSubtreeRoots [] hashHashing StandaloneCSMTCol bucketBits
                                             runTransactionUnguarded database

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -336,6 +336,7 @@ mkCsmtKVOnlyOps = do
             fromKVHashes
             hashHashing
             runTx
+            (const $ pure ())
         , RunTxPure runTx
         )
 
@@ -587,6 +588,7 @@ spec = do
                         fromKVHashes
                         hashHashing
                         runTx
+                        (const $ pure ())
             runTx (opsInsert (fullCommon fullOps) "k" "v")
             mKV <- toKVOnly fullOps
             case mKV of
@@ -606,6 +608,7 @@ spec = do
                                 fromKVHashes
                                 hashHashing
                                 runTx
+                                (const $ pure ())
                     mKV2 <- toKVOnly fullOps2
                     case mKV2 of
                         Nothing -> pure ()


### PR DESCRIPTION
## Summary
- `patchParallel` returns `[(Int, Transaction)]` (op count per bucket)
- `mkKVOnlyOps` / `mkFullOps` accept a `ReplayEvent -> IO ()` callback
- `ReplayStart` / `ReplayStop` events bracket each concurrent batch

Closes #100