### PR TITLE
feat: add unguarded replay runner to mkKVOnlyOps

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -80,9 +80,12 @@ data Ops (mode :: Mode) m cf d ops k v a where
 ```
 
 - **`mkKVOnlyOps`** — builds KVOnly ops with journal-based mutations
-  and `toFull` via `patchParallel`
+  and `toFull` via `patchParallel`. Takes two transaction runners:
+  a guarded one for normal ops and an unguarded one for parallel
+  replay (see [Transaction Runners](library.md#transaction-runners)).
 - **`mkFullOps`** — builds Full ops with tree-updating mutations and
-  `toKVOnly` (requires empty journal)
+  `toKVOnly` (requires empty journal). Also takes dual runners,
+  passed through when transitioning back to KVOnly.
 
 ## Constructors
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -145,7 +145,7 @@ import CSMT.MTS (mkKVOnlyOps, Ops(..), CommonOps(..))
 -- Build KVOnly ops
 let ops = mkKVOnlyOps prefix bucketBits chunkSize
             kvCol csmtCol journalCol journalIso
-            fromKV hashing runTx trace
+            fromKV hashing runTx runTxReplay trace
 
 -- Insert (writes KV + journal, no tree)
 runTx $ opsInsert (kvCommon ops) key value
@@ -154,6 +154,73 @@ runTx $ opsInsert (kvCommon ops) key value
 Just fullOps <- toFull ops
 rootHash <- runTx $ opsRootHash fullOps
 ```
+
+### Crash Recovery
+
+`openOps` checks for a sentinel flag left by a crashed `toFull`
+transition and returns a `DbState` value:
+
+```mermaid
+stateDiagram-v2
+    [*] --> openOps
+    openOps --> NeedsRecovery : sentinel present
+    openOps --> Ready : no sentinel
+
+    NeedsRecovery --> Ready : merge subtrees + delete sentinel
+
+    Ready --> ChooseKVOnly
+    Ready --> ChooseFull
+
+    state "Mode transitions" as modes {
+        ChooseKVOnly --> KVOnly
+        ChooseFull --> Full : replays journal
+
+        KVOnly --> Full : toFull (replay)
+        Full --> KVOnly : toKVOnly (journal empty)
+    }
+```
+
+If the process crashes mid-`toFull` (after the sentinel is
+written but before merge completes), the next `openOps` call
+detects the sentinel, runs `mergeSubtreeRoots`, and returns
+a clean `Ready` state.
+
+### Transaction Runners
+
+`mkKVOnlyOps` and `openOps` take two transaction runners:
+
+- **`runTx`** — guarded (e.g. MVar-locked), used for normal
+  insert/delete operations where concurrent block processing
+  requires serialization.
+- **`runTxReplay`** — unguarded, used exclusively during the
+  `toFull` journal replay where `patchParallel` splits work
+  into independent bucket transactions.
+
+```mermaid
+flowchart TB
+    subgraph "Normal operations"
+        ins[opsInsert / opsDelete] -->|runTx| db[(Database)]
+    end
+
+    subgraph "toFull replay"
+        journal[Journal chunks] --> patch[patchParallel]
+        patch --> b1[Bucket 1]
+        patch --> b2[Bucket 2]
+        patch --> bN[Bucket N]
+        b1 -->|runTxReplay| db
+        b2 -->|runTxReplay| db
+        bN -->|runTxReplay| db
+    end
+
+    style b1 fill:#e8f5e9
+    style b2 fill:#e8f5e9
+    style bN fill:#e8f5e9
+```
+
+Bucket transactions are safe to run without a lock because
+`patchParallel` partitions operations by tree key prefix —
+each bucket writes to a disjoint subtree, so there are no
+data races.
 
 ### Parallel Replay
 

--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -363,7 +363,9 @@ openOps
     -> FromKV k v a
     -> Hashing a
     -> (forall b. Transaction m cf d ops b -> IO b)
-    -- ^ Transaction runner
+    -- ^ Transaction runner (guarded, for normal ops)
+    -> (forall b. Transaction m cf d ops b -> IO b)
+    -- ^ Unguarded runner for parallel replay
     -> (ReplayEvent -> IO ())
     -- ^ Trace callback
     -> IO (DbState m cf d ops k v a)
@@ -378,6 +380,7 @@ openOps
     fromKV
     hashing
     runTx
+    runTxReplay
     trace = do
         mRecovery <-
             runTx $ checkPatchRecovery journalCol
@@ -412,6 +415,7 @@ openOps
                     fromKV
                     hashing
                     runTx
+                    runTxReplay
                     trace
 
 -- ------------------------------------------------------------------
@@ -1060,7 +1064,9 @@ mkKVOnlyOps
     -> FromKV k v a
     -> Hashing a
     -> (forall b. Transaction m cf d ops b -> IO b)
-    -- ^ Transaction runner (must be thread-safe)
+    -- ^ Guarded runner for normal ops
+    -> (forall b. Transaction m cf d ops b -> IO b)
+    -- ^ Unguarded runner for parallel replay
     -> (ReplayEvent -> IO ())
     -- ^ Trace callback (called per replay chunk)
     -> Ops 'KVOnly m cf d ops k v a
@@ -1075,6 +1081,7 @@ mkKVOnlyOps
     fromKV
     hashing
     runTx
+    runTxReplay
     trace =
         OpsKVOnly
             { kvCommon =
@@ -1166,13 +1173,14 @@ mkKVOnlyOps
                         fromKV
                         hashing
                         runTx
+                        runTxReplay
                         trace
             }
       where
         totalBuckets = 2 ^ bucketBits :: Int
         replayLoop = do
             entries <-
-                runTx
+                runTxReplay
                     $ readJournalChunkT
                         journalCol
                         chunkSize
@@ -1201,7 +1209,7 @@ mkKVOnlyOps
                                 map fst bucketTxns
                             }
                     mapConcurrently_
-                        (runTx . snd)
+                        (runTxReplay . snd)
                         bucketTxns
                     trace ReplayStop
                     replayLoop
@@ -1230,7 +1238,9 @@ mkFullOps
     -> FromKV k v a
     -> Hashing a
     -> (forall b. Transaction m cf d ops b -> IO b)
-    -- ^ Transaction runner
+    -- ^ Guarded runner for normal ops
+    -> (forall b. Transaction m cf d ops b -> IO b)
+    -- ^ Unguarded runner for parallel replay
     -> (ReplayEvent -> IO ())
     -- ^ Trace callback (passed through to 'mkKVOnlyOps')
     -> Ops 'Full m cf d ops k v a
@@ -1245,6 +1255,7 @@ mkFullOps
     fromKV
     hashing
     runTx
+    runTxReplay
     trace =
         OpsFull
             { fullCommon =
@@ -1284,6 +1295,7 @@ mkFullOps
                                 fromKV
                                 hashing
                                 runTx
+                                runTxReplay
                                 trace
                     else pure Nothing
             }

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -367,6 +367,7 @@ mkCsmtKVOnlyOps = do
             fromKVHashes
             hashHashing
             runTx
+            runTx
             (const $ pure ())
         , RunTxPure runTx
         )
@@ -742,6 +743,7 @@ spec = do
                         fromKVHashes
                         hashHashing
                         runTx
+                        runTx
                         (const $ pure ())
             runTx (opsInsert (fullCommon fullOps) "k" "v")
             mKV <- toKVOnly fullOps
@@ -761,6 +763,7 @@ spec = do
                                 (iso id id)
                                 fromKVHashes
                                 hashHashing
+                                runTx
                                 runTx
                                 (const $ pure ())
                     mKV2 <- toKVOnly fullOps2
@@ -1204,6 +1207,7 @@ spec = do
                             fromKVHashes
                             hashHashing
                             rtx
+                            rtx
                             (const $ pure ())
                 mapM_
                     ( \(k, v) ->
@@ -1264,6 +1268,7 @@ spec = do
                         (iso id id)
                         fromKVHashes
                         hashHashing
+                        rtx
                         rtx
                         (const $ pure ())
                 case state0 of


### PR DESCRIPTION
## Summary

- Add second transaction runner parameter (`runTxReplay`) to `mkKVOnlyOps`, `mkFullOps`, and `openOps` for the parallel replay path
- Normal ops use the guarded `runTx`; `patchParallel`'s `mapConcurrently_` uses the unguarded `runTxReplay`
- Add mermaid diagrams to docs: crash-recovery state machine and dual tx runner flow

Closes #109