### PR TITLE
feat: persistent rollback point counter

### DIFF
--- a/lib/rollbacks/MTS/Rollbacks/Store.hs
+++ b/lib/rollbacks/MTS/Rollbacks/Store.hs
@@ -15,6 +15,14 @@
 -- Downstream chooses it (e.g. @WithOrigin slot@,
 -- @Maybe slot@). The library only requires
 -- @Ord key@.
+--
+-- == Counted variants
+--
+-- Functions prefixed with @counted@ maintain a
+-- persistent counter that tracks the number of
+-- rollback points. The counter is updated
+-- atomically in the same transaction. Use
+-- 'readCount' to query it.
 module MTS.Rollbacks.Store
     ( -- * Forward (store rollback point)
       storeRollbackPoint
@@ -35,11 +43,22 @@ module MTS.Rollbacks.Store
 
       -- * Inspection
     , countPoints
+
+      -- * Persistent counter
+    , RollbackCounter (..)
+    , readCount
+    , countedStore
+    , countedRollbackTo
+    , countedPruneBelow
+    , countedArmageddonCleanup
+    , countedArmageddonSetup
     )
 where
 
 import Control.Monad.Trans.Class (lift)
+import Data.ByteString (ByteString)
 import Data.Function (fix)
+import Data.Maybe (fromMaybe)
 import Database.KV.Cursor
     ( Entry (..)
     , firstEntry
@@ -50,10 +69,12 @@ import Database.KV.Cursor
     )
 import Database.KV.Transaction
     ( GCompare
+    , Selector
     , Transaction
     , delete
     , insert
     , iterating
+    , query
     )
 import MTS.Rollbacks.Column
     ( RollbackCol
@@ -233,3 +254,110 @@ countPoints col =
             Just _ -> do
                 next <- nextEntry
                 (+ 1) <$> go next
+
+-- ------------------------------------------------------------------
+-- Persistent counter
+-- ------------------------------------------------------------------
+
+-- | A persistent counter for rollback points,
+-- stored in a metrics column. The counter is
+-- updated atomically in the same transaction
+-- as the rollback point operations.
+data RollbackCounter t = RollbackCounter
+    { rcSelector :: Selector t ByteString Int
+    -- ^ Metrics column selector
+    , rcKey :: ByteString
+    -- ^ Counter key within the metrics column
+    }
+
+-- | Read the current rollback point count.
+readCount
+    :: (Monad m, GCompare t)
+    => RollbackCounter t
+    -> Transaction m cf t op Int
+readCount RollbackCounter{rcSelector, rcKey} =
+    fromMaybe 0 <$> query rcSelector rcKey
+
+-- | Adjust the counter by a delta.
+adjustCount
+    :: (Monad m, GCompare t)
+    => RollbackCounter t
+    -> Int
+    -> Transaction m cf t op ()
+adjustCount rc delta = do
+    current <- readCount rc
+    insert (rcSelector rc) (rcKey rc) (current + delta)
+
+-- | Store a rollback point and increment the
+-- counter.
+countedStore
+    :: (Ord key, Monad m, GCompare t)
+    => RollbackCol t key inv meta
+    -> RollbackCounter t
+    -> key
+    -> RollbackPoint inv meta
+    -> Transaction m cf t op ()
+countedStore col rc key rp = do
+    storeRollbackPoint col key rp
+    adjustCount rc 1
+
+-- | Roll back and decrement the counter by the
+-- number of deleted points.
+countedRollbackTo
+    :: (Ord key, Monad m, GCompare t)
+    => RollbackCol t key inv meta
+    -> RollbackCounter t
+    -> ( RollbackPoint inv meta
+         -> Transaction m cf t op ()
+       )
+    -> key
+    -> Transaction m cf t op RollbackResult
+countedRollbackTo col rc applyInverses key = do
+    result <- rollbackTo col applyInverses key
+    case result of
+        RollbackSucceeded n ->
+            adjustCount rc (negate n)
+        RollbackImpossible -> pure ()
+    pure result
+
+-- | Prune and decrement the counter by the
+-- number of pruned points.
+countedPruneBelow
+    :: (Ord key, Monad m, GCompare t)
+    => RollbackCol t key inv meta
+    -> RollbackCounter t
+    -> key
+    -> Transaction m cf t op Int
+countedPruneBelow col rc key = do
+    n <- pruneBelow col key
+    adjustCount rc (negate n)
+    pure n
+
+-- | Armageddon cleanup. Resets the counter to 0
+-- on the last batch (when no more entries remain).
+countedArmageddonCleanup
+    :: (Ord key, Monad m, GCompare t)
+    => RollbackCol t key inv meta
+    -> RollbackCounter t
+    -> Int
+    -> Transaction m cf t op Bool
+countedArmageddonCleanup col rc batchSz = do
+    more <- armageddonCleanup col batchSz
+    if more
+        then pure True
+        else do
+            insert (rcSelector rc) (rcKey rc) 0
+            pure False
+
+-- | Armageddon setup. Sets the counter to 1
+-- (the sentinel point).
+countedArmageddonSetup
+    :: (Ord key, Monad m, GCompare t)
+    => RollbackCol t key inv meta
+    -> RollbackCounter t
+    -> key
+    -> Maybe meta
+    -> Transaction m cf t op ()
+countedArmageddonSetup col rc key meta = do
+    armageddonSetup col key meta
+    insert (rcSelector rc) (rcKey rc) 1

--- a/mts.cabal
+++ b/mts.cabal
@@ -82,6 +82,7 @@ library rollbacks
 
   build-depends:
     , base                                     >=4.19 && <5
+    , bytestring                               >=0.12 && <0.13
     , rocksdb-kv-transactions:kv-transactions
     , transformers                             >=0.6  && <0.7
 
@@ -232,6 +233,7 @@ test-suite unit-tests
     , cereal                                   >=0.5  && <0.6
     , containers                               >=0.6  && <0.7
     , data-default                             >=0.8  && <0.9
+    , exceptions                               >=0.10 && <0.11
     , filepath                                 >=1.4  && <1.5
     , hspec                                    >=2.11 && <2.12
     , lens                                     >=5.3  && <5.4
@@ -240,6 +242,7 @@ test-suite unit-tests
     , mts:csmt-test-lib
     , mts:mpf
     , mts:mpf-test-lib
+    , mts:rollbacks
     , QuickCheck                               >=2.14 && <2.18
     , rocksdb-haskell-jprupp                   >=2.1  && <2.2
     , rocksdb-kv-transactions                  >=0.1  && <0.2
@@ -272,6 +275,7 @@ test-suite unit-tests
     MPF.Proof.InsertionSpec
     MPF.PropertySpec
     MTS.PropertySpec
+    MTS.RollbacksSpec
 
 benchmark bench
   import:           warnings

--- a/test/MTS/RollbacksSpec.hs
+++ b/test/MTS/RollbacksSpec.hs
@@ -1,0 +1,584 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module MTS.RollbacksSpec (spec) where
+
+import Control.Monad (forM_, when)
+import Control.Monad.Catch.Pure (Catch, runCatch)
+import Control.Monad.Trans.State.Strict
+    ( StateT (runStateT)
+    , gets
+    , modify'
+    )
+import Data.ByteString (ByteString)
+import Data.Function (fix)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Type.Equality ((:~:) (..))
+import Database.KV.Database
+    ( Database (..)
+    , Pos (..)
+    , QueryIterator (..)
+    )
+import Database.KV.Transaction
+    ( Codecs (..)
+    , Column (..)
+    , DMap
+    , DSum (..)
+    , GCompare (..)
+    , GEq (..)
+    , GOrdering (..)
+    , KV
+    , Transaction
+    , fromPairList
+    , runTransactionUnguarded
+    )
+import MTS.Rollbacks.Store
+    ( RollbackCounter (..)
+    , RollbackResult (..)
+    , armageddonSetup
+    , countPoints
+    , countedArmageddonCleanup
+    , countedArmageddonSetup
+    , countedPruneBelow
+    , countedRollbackTo
+    , countedStore
+    , readCount
+    , storeRollbackPoint
+    )
+import MTS.Rollbacks.Types
+    ( RollbackPoint (..)
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( Gen
+    , chooseInt
+    , forAll
+    , listOf1
+    , property
+    )
+
+import Control.Lens (Prism', iso, prism')
+import Data.IORef
+    ( newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Serialize
+    ( getWord64be
+    , putWord64be
+    )
+import Data.Serialize.Extra (evalGetM, evalPutM)
+import Data.Word (Word64)
+
+-- ----------------------------------------------------------
+-- Minimal pure backend for rollback + metrics columns
+-- ----------------------------------------------------------
+
+data TestCF = RollbackCF | MetricsCF
+    deriving (Eq, Ord)
+
+data TestCol c where
+    RollbackCol
+        :: TestCol (KV Int (RollbackPoint () ()))
+    MetricsCol
+        :: TestCol (KV ByteString Int)
+
+instance GEq TestCol where
+    geq RollbackCol RollbackCol = Just Refl
+    geq MetricsCol MetricsCol = Just Refl
+    geq _ _ = Nothing
+
+instance GCompare TestCol where
+    gcompare RollbackCol RollbackCol = GEQ
+    gcompare RollbackCol MetricsCol = GLT
+    gcompare MetricsCol RollbackCol = GGT
+    gcompare MetricsCol MetricsCol = GEQ
+
+type TestOp = (TestCF, ByteString, Maybe ByteString)
+
+data TestDB = TestDB
+    { dbRollbacks :: Map ByteString ByteString
+    , dbMetrics :: Map ByteString ByteString
+    , dbIterators :: Map Int TestCursor
+    }
+
+data TestCursor = TestCursor
+    { curPos :: Maybe ByteString
+    , curSnap :: Map ByteString ByteString
+    }
+
+type TestM = StateT TestDB Catch
+
+runTestM :: TestDB -> TestM a -> (a, TestDB)
+runTestM db m = case runCatch (runStateT m db) of
+    Left e -> error $ "runTestM: " ++ show e
+    Right r -> r
+
+emptyTestDB :: TestDB
+emptyTestDB = TestDB Map.empty Map.empty Map.empty
+
+intPrism :: Prism' ByteString Int
+intPrism = prism' encode decode
+  where
+    encode =
+        evalPutM . putWord64be . fromIntegral
+    decode =
+        fmap fromIntegral . evalGetM getWord64be
+
+rpPrism :: Prism' ByteString (RollbackPoint () ())
+rpPrism = prism' encode decode
+  where
+    encode RollbackPoint{rpInverses, rpMeta} =
+        evalPutM $ do
+            putWord64be
+                $ fromIntegral
+                $ length rpInverses
+            putWord64be
+                $ case rpMeta of
+                    Nothing -> 0
+                    Just () -> 1
+    decode = evalGetM $ do
+        n <- fromIntegral <$> getWord64be
+        meta <- getWord64be
+        pure
+            $ RollbackPoint
+                { rpInverses =
+                    replicate n ()
+                , rpMeta =
+                    if (meta :: Word64) == 0
+                        then Nothing
+                        else Just ()
+                }
+
+testCols
+    :: DMap
+        TestCol
+        (Column TestCF)
+testCols =
+    fromPairList
+        [ RollbackCol
+            :=> Column
+                { family = RollbackCF
+                , codecs =
+                    Codecs intPrism rpPrism
+                }
+        , MetricsCol
+            :=> Column
+                { family = MetricsCF
+                , codecs =
+                    Codecs (iso id id) intPrism
+                }
+        ]
+
+pureValueAt
+    :: TestCF
+    -> ByteString
+    -> TestM (Maybe ByteString)
+pureValueAt RollbackCF k =
+    gets (Map.lookup k . dbRollbacks)
+pureValueAt MetricsCF k =
+    gets (Map.lookup k . dbMetrics)
+
+pureApplyOps :: [TestOp] -> TestM ()
+pureApplyOps ops = forM_ ops $ \(cf, k, mv) ->
+    case (cf, mv) of
+        (RollbackCF, Nothing) ->
+            modify'
+                $ \db ->
+                    db
+                        { dbRollbacks =
+                            Map.delete
+                                k
+                                (dbRollbacks db)
+                        }
+        (RollbackCF, Just v) ->
+            modify'
+                $ \db ->
+                    db
+                        { dbRollbacks =
+                            Map.insert
+                                k
+                                v
+                                (dbRollbacks db)
+                        }
+        (MetricsCF, Nothing) ->
+            modify'
+                $ \db ->
+                    db
+                        { dbMetrics =
+                            Map.delete
+                                k
+                                (dbMetrics db)
+                        }
+        (MetricsCF, Just v) ->
+            modify'
+                $ \db ->
+                    db
+                        { dbMetrics =
+                            Map.insert
+                                k
+                                v
+                                (dbMetrics db)
+                        }
+
+mkTestOp
+    :: TestCF
+    -> ByteString
+    -> Maybe ByteString
+    -> TestOp
+mkTestOp = (,,)
+
+testIterator :: TestCF -> TestM (QueryIterator TestM)
+testIterator cf = do
+    snap <- gets $ case cf of
+        RollbackCF -> dbRollbacks
+        MetricsCF -> dbMetrics
+    nextId <-
+        gets
+            $ \db -> case Map.lookupMax (dbIterators db) of
+                Just (i, _) -> i + 1
+                Nothing -> 0
+    let cursor =
+            TestCursor
+                { curPos = Nothing
+                , curSnap = snap
+                }
+    modify'
+        $ \db ->
+            db
+                { dbIterators =
+                    Map.insert
+                        nextId
+                        cursor
+                        (dbIterators db)
+                }
+    pure
+        $ QueryIterator
+            { step = stepIt nextId
+            , isValid = validIt nextId
+            , entry = entryIt nextId
+            }
+
+stepIt :: Int -> Pos -> TestM ()
+stepIt itId PosDestroy =
+    modify'
+        $ \db ->
+            db
+                { dbIterators =
+                    Map.delete
+                        itId
+                        (dbIterators db)
+                }
+stepIt itId pos = do
+    iters <- gets dbIterators
+    case Map.lookup itId iters of
+        Nothing ->
+            error "stepIt: invalid iterator"
+        Just c -> do
+            let c' = case pos of
+                    PosFirst ->
+                        c
+                            { curPos =
+                                fst
+                                    <$> Map.lookupMin
+                                        (curSnap c)
+                            }
+                    PosLast ->
+                        c
+                            { curPos =
+                                fst
+                                    <$> Map.lookupMax
+                                        (curSnap c)
+                            }
+                    PosNext ->
+                        case curPos c of
+                            Nothing -> c
+                            Just k ->
+                                let (_, after) =
+                                        Map.split
+                                            k
+                                            (curSnap c)
+                                in  c
+                                        { curPos =
+                                            fst
+                                                <$> Map.lookupMin
+                                                    after
+                                        }
+                    PosPrev ->
+                        case curPos c of
+                            Nothing -> c
+                            Just k ->
+                                let (before, _) =
+                                        Map.split
+                                            k
+                                            (curSnap c)
+                                in  c
+                                        { curPos =
+                                            fst
+                                                <$> Map.lookupMax
+                                                    before
+                                        }
+                    PosAny k ->
+                        let (_, after) =
+                                Map.split k (curSnap c)
+                        in  c
+                                { curPos =
+                                    fst
+                                        <$> Map.lookupMin
+                                            after
+                                }
+            modify'
+                $ \db ->
+                    db
+                        { dbIterators =
+                            Map.insert
+                                itId
+                                c'
+                                (dbIterators db)
+                        }
+
+validIt :: Int -> TestM Bool
+validIt itId = do
+    iters <- gets dbIterators
+    case Map.lookup itId iters of
+        Nothing -> error "validIt: invalid"
+        Just c -> pure $ case curPos c of
+            Just _ -> True
+            Nothing -> False
+
+entryIt
+    :: Int
+    -> TestM (Maybe (ByteString, ByteString))
+entryIt itId = do
+    iters <- gets dbIterators
+    case Map.lookup itId iters of
+        Nothing -> error "entryIt: invalid"
+        Just c -> case curPos c of
+            Nothing -> pure Nothing
+            Just k ->
+                pure
+                    $ Map.lookup k (curSnap c)
+                        >>= \v -> Just (k, v)
+
+testDatabase
+    :: Database TestM TestCF TestCol TestOp
+testDatabase =
+    let db =
+            Database
+                { valueAt = pureValueAt
+                , applyOps = pureApplyOps
+                , columns = testCols
+                , mkOperation = mkTestOp
+                , newIterator = testIterator
+                , withSnapshot = \f -> f db
+                }
+    in  db
+
+runTx
+    :: Transaction TestM TestCF TestCol TestOp a
+    -> TestM a
+runTx = runTransactionUnguarded testDatabase
+
+-- ----------------------------------------------------------
+-- Helpers
+-- ----------------------------------------------------------
+
+mkRP :: RollbackPoint () ()
+mkRP =
+    RollbackPoint
+        { rpInverses = [()]
+        , rpMeta = Nothing
+        }
+
+emptyRP :: RollbackPoint () ()
+emptyRP =
+    RollbackPoint
+        { rpInverses = []
+        , rpMeta = Nothing
+        }
+
+rc :: RollbackCounter TestCol
+rc =
+    RollbackCounter
+        { rcSelector = MetricsCol
+        , rcKey = "rollback-count"
+        }
+
+-- ----------------------------------------------------------
+-- Generators
+-- ----------------------------------------------------------
+
+genSlots :: Gen [Int]
+genSlots = do
+    n <- chooseInt (1, 20)
+    pure [1 .. n]
+
+-- ----------------------------------------------------------
+-- Spec
+-- ----------------------------------------------------------
+
+spec :: Spec
+spec = describe "Rollbacks.Store counted" $ do
+    it "count matches countPoints after stores"
+        $ property
+        $ forAll genSlots
+        $ \slots -> do
+            ref <- newIORef emptyTestDB
+            let run :: forall a. TestM a -> IO a
+                run action = do
+                    s <- readIORef ref
+                    let (a, s') = runTestM s action
+                    writeIORef ref s'
+                    pure a
+            -- Setup sentinel at key 0
+            run
+                $ runTx
+                $ countedArmageddonSetup
+                    RollbackCol
+                    rc
+                    (0 :: Int)
+                    Nothing
+            -- Store rollback points
+            forM_ slots $ \slot ->
+                run
+                    $ runTx
+                    $ countedStore
+                        RollbackCol
+                        rc
+                        slot
+                        mkRP
+            -- Compare
+            cached <- run $ runTx $ readCount rc
+            actual <-
+                run $ runTx $ countPoints RollbackCol
+            cached `shouldBe` actual
+
+    it "count matches after rollback"
+        $ property
+        $ forAll genSlots
+        $ \slots -> do
+            ref <- newIORef emptyTestDB
+            let run :: forall a. TestM a -> IO a
+                run action = do
+                    s <- readIORef ref
+                    let (a, s') = runTestM s action
+                    writeIORef ref s'
+                    pure a
+            run
+                $ runTx
+                $ countedArmageddonSetup
+                    RollbackCol
+                    rc
+                    (0 :: Int)
+                    Nothing
+            forM_ slots $ \slot ->
+                run
+                    $ runTx
+                    $ countedStore
+                        RollbackCol
+                        rc
+                        slot
+                        mkRP
+            -- Rollback to midpoint
+            let mid = length slots `div` 2
+            run
+                $ runTx
+                $ countedRollbackTo
+                    RollbackCol
+                    rc
+                    (const $ pure ())
+                    mid
+            cached <- run $ runTx $ readCount rc
+            actual <-
+                run $ runTx $ countPoints RollbackCol
+            cached `shouldBe` actual
+
+    it "count matches after prune"
+        $ property
+        $ forAll genSlots
+        $ \slots -> do
+            ref <- newIORef emptyTestDB
+            let run :: forall a. TestM a -> IO a
+                run action = do
+                    s <- readIORef ref
+                    let (a, s') = runTestM s action
+                    writeIORef ref s'
+                    pure a
+            run
+                $ runTx
+                $ countedArmageddonSetup
+                    RollbackCol
+                    rc
+                    (0 :: Int)
+                    Nothing
+            forM_ slots $ \slot ->
+                run
+                    $ runTx
+                    $ countedStore
+                        RollbackCol
+                        rc
+                        slot
+                        mkRP
+            -- Prune below midpoint
+            let mid = length slots `div` 2
+            _ <-
+                run
+                    $ runTx
+                    $ countedPruneBelow
+                        RollbackCol
+                        rc
+                        mid
+            cached <- run $ runTx $ readCount rc
+            actual <-
+                run $ runTx $ countPoints RollbackCol
+            cached `shouldBe` actual
+
+    it "count is 1 after armageddon setup"
+        $ do
+            ref <- newIORef emptyTestDB
+            let run :: forall a. TestM a -> IO a
+                run action = do
+                    s <- readIORef ref
+                    let (a, s') = runTestM s action
+                    writeIORef ref s'
+                    pure a
+            -- Store some points first
+            run
+                $ runTx
+                $ storeRollbackPoint
+                    RollbackCol
+                    (1 :: Int)
+                    mkRP
+            run
+                $ runTx
+                $ storeRollbackPoint
+                    RollbackCol
+                    2
+                    mkRP
+            -- Armageddon
+            run
+                $ ($ ())
+                $ fix
+                $ \go _ -> do
+                    more <-
+                        runTx
+                            $ countedArmageddonCleanup
+                                RollbackCol
+                                rc
+                                100
+                    when more $ go ()
+            run
+                $ runTx
+                $ countedArmageddonSetup
+                    RollbackCol
+                    rc
+                    (0 :: Int)
+                    Nothing
+            cached <- run $ runTx $ readCount rc
+            cached `shouldBe` 1


### PR DESCRIPTION
## Summary

- `RollbackCounter` record: metrics column selector + key
- Counted variants of all Store operations: `countedStore`, `countedRollbackTo`, `countedPruneBelow`, `countedArmageddonCleanup`, `countedArmageddonSetup`
- `readCount`: query the cached count
- 4 QC properties verifying count matches `countPoints` scan after stores, rollback, prune, and armageddon

## Test plan

- [x] 268 tests pass (264 existing + 4 new)
- [x] `just ci` passes

Closes #110