### PR TITLE
chore: fix cabal check warnings, add CI job

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -99,6 +99,17 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Check Formatting
         run: nix --quiet develop -c just format-check
+  cabal-check:
+    name: Cabal check
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Run cabal check
+        run: nix --quiet develop -c cabal check
   hlint:
     name: HLint
     runs-on: nixos

--- a/mts.cabal
+++ b/mts.cabal
@@ -21,6 +21,10 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
+source-repository head
+  type:     git
+  location: https://github.com/lambdasistemi/haskell-mts
+
 common warnings
   ghc-options:
     -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
@@ -83,7 +87,7 @@ library rollbacks
   build-depends:
     , base                                     >=4.19 && <5
     , bytestring                               >=0.12 && <0.13
-    , rocksdb-kv-transactions:kv-transactions
+    , rocksdb-kv-transactions:kv-transactions  >=0.1  && <0.2
     , transformers                             >=0.6  && <0.7
 
   hs-source-dirs:   lib/rollbacks/
@@ -191,7 +195,7 @@ library csmt-test-lib
     , mts
     , mts:csmt
     , QuickCheck                               >=2.14 && <2.18
-    , rocksdb-kv-transactions:kv-transactions
+    , rocksdb-kv-transactions:kv-transactions  >=0.1  && <0.2
 
   hs-source-dirs:   test-lib/csmt
   default-language: Haskell2010
@@ -214,7 +218,7 @@ library mpf-test-lib
 
 executable mts
   import:           warnings
-  ghc-options:      -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
   main-is:          app/cli/main.hs
   build-depends:
     , base      >=4.19 && <5
@@ -319,7 +323,7 @@ executable csmt-test-vectors
   import:           warnings
   main-is:          app/test-vectors/Main.hs
   build-depends:
-    , aiken-codegen
+    , aiken-codegen                            >=0.1  && <0.2
     , base                                     >=4.19 && <5
     , bytestring                               >=0.12 && <0.13
     , lens                                     >=5.3  && <5.4


### PR DESCRIPTION
## Summary
- Add `source-repository head` section to cabal file
- Add missing upper bounds for `rocksdb-kv-transactions` and `aiken-codegen`
- Remove `-O2` from `mts` executable (benchmarks keep it)
- Add `cabal-check` CI job

Only remaining warning is `-O2` on benchmarks (intentional, exit code 0).

## Test plan
- [x] `cabal check` passes (exit 0, only benchmark -O2 warning)
- [x] `cabal build all -O0` succeeds
- [ ] CI green