### PR TITLE
fix: remove unused sparse-merkle-trees dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,12 +9,6 @@ packages:
 
 source-repository-package
   type: git
-  location: https://github.com/paolino/sparse-merkle-trees
-  tag: 082280d772a92511a9324a429e58a0535cf5da6b
-  --sha256: sha256-V9OuwDoHXB0/yzeZNZ5iGAkidBmmFmcfm+AR/TmEEX4=
-
-source-repository-package
-  type: git
   location: https://github.com/paolino/rocksdb-haskell.git
   tag: a3e86b39f9510fea54abf734ee84aec33d0d683f
   --sha256: 1gjzqhf81fy3bpc79ndmx3s77x3s1gf0lsk762acbfnpfh6g1hd0


### PR DESCRIPTION
## Summary
- Remove `sparse-merkle-trees` source-repository-package from `cabal.project`
- No module from it is imported anywhere; not in any `build-depends`

Closes #117