### PR TITLE
fix: maintain journalSizeKey counter in mkKVOnlyOps

### DIFF
--- a/lib/csmt/CSMT/MTS.hs
+++ b/lib/csmt/CSMT/MTS.hs
@@ -1145,6 +1145,12 @@ mkKVOnlyOps
                         insert journalCol k $ case tag of
                             JInsert -> encodeJournalInsert encoded
                             _ -> encodeJournalUpdate encoded
+                        -- New journal entry → journalSize +1
+                        when (isNothing mj)
+                            $ adjustCounter
+                                metricsCol
+                                journalSizeKey
+                                1
                     , opsDelete = \k -> do
                         mv <- query kvCol k
                         case mv of
@@ -1153,8 +1159,23 @@ mkKVOnlyOps
                                 delete kvCol k
                                 mj <- query journalCol k
                                 case fmap (fst . parseJournalEntry) mj of
-                                    Just JInsert ->
+                                    Just JInsert -> do
                                         delete journalCol k
+                                        adjustCounter
+                                            metricsCol
+                                            journalSizeKey
+                                            (-1)
+                                    Nothing -> do
+                                        insert
+                                            journalCol
+                                            k
+                                            ( encodeJournalDelete
+                                                (view journalIso v)
+                                            )
+                                        adjustCounter
+                                            metricsCol
+                                            journalSizeKey
+                                            1
                                     _ ->
                                         insert
                                             journalCol
@@ -1180,6 +1201,11 @@ mkKVOnlyOps
                         csmtCol
                     readCounter metricsCol journalSizeKey
                 replayLoop journalSize
+                -- Reset journal counter (entries were
+                -- deleted by patchParallel without
+                -- decrementing)
+                runTx
+                    $ insert metricsCol journalSizeKey 0
                 -- Merge + delete sentinel atomically
                 runTx $ do
                     mergeSubtreeRoots

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -884,6 +884,54 @@ spec = do
                         Nothing -> pure ()
                         Just _ ->
                             fail "toKVOnly should fail with non-empty journal"
+        it "toFull replay trace monotonic to zero"
+            $ property
+            $ forAll genBSPairs
+            $ \kvs -> do
+                ref <- newIORef emptyInMemoryDB
+                eventsRef <- newIORef ([] :: [ReplayEvent])
+                let run :: forall b. Pure b -> IO b
+                    run action = do
+                        s <- readIORef ref
+                        let (a, s') = runPure s action
+                        writeIORef ref s'
+                        pure a
+                    db = pureDatabase csmtCodecs
+                    rtx = run . runTransactionUnguarded db
+                    traceEvt evt =
+                        modifyIORef' eventsRef (evt :)
+                let kvOps =
+                        mkKVOnlyOps
+                            []
+                            2
+                            100
+                            StandaloneKVCol
+                            StandaloneCSMTCol
+                            StandaloneJournalCol
+                            StandaloneMetricsCol
+                            (iso id id)
+                            fromKVHashes
+                            hashHashing
+                            rtx
+                            rtx
+                            traceEvt
+                mapM_
+                    ( \(k, v) ->
+                        rtx (opsInsert (kvCommon kvOps) k v)
+                    )
+                    kvs
+                _ <- toFull kvOps
+                events <- reverse <$> readIORef eventsRef
+                let starts =
+                        [ rsEntriesRemaining
+                        | ReplayStart{rsEntriesRemaining} <-
+                            events
+                        ]
+                    monotonic xs =
+                        and $ zipWith (>=) xs (drop 1 xs)
+                not (null starts) `shouldBe` True
+                monotonic starts `shouldBe` True
+                last starts `shouldBe` 0
         -- ======================================================
         -- QC1: Genesis invariant — journal keys = KV keys,
         -- all entries are JInsert


### PR DESCRIPTION
## Summary

- `mkKVOnlyOps` insert/delete never adjusted the `journalSizeKey` counter, so `toFull` replay initialized `remaining` at 0, making `rsEntriesRemaining` go negative
- Added counter maintenance to the generic KVOnly insert/delete paths
- Reset counter to 0 after parallel replay (entries deleted by `patchParallel` without decrementing)
- Added QC property test for `mkKVOnlyOps` replay trace monotonicity

Closes #137