### PR TITLE
feat: csmt-verify sublibrary + WASM build

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -18,4 +18,10 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Stage WASM demo into docs/
+        run: |
+          nix --quiet build .#csmt-verify-wasm-demo -o result-demo
+          mkdir -p docs/demo
+          cp -L result-demo/* docs/demo/
+          chmod -R u+w docs/demo
       - run: nix --quiet develop github:paolino/dev-assets?dir=mkdocs -c mkdocs-deploy --force

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,61 @@
+name: PR preview (WASM demo on Surge)
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build WASM demo
+        run: nix --quiet build .#csmt-verify-wasm-demo -o result-demo
+
+      - name: Deploy to Surge
+        run: |
+          mkdir -p surge-site
+          cp -L result-demo/* surge-site/
+          chmod -R u+w surge-site
+          nix --quiet shell nixpkgs#nodePackages.surge -c surge \
+            surge-site \
+            ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh \
+            --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `https://${context.repo.owner}-${context.repo.repo}-pr-${context.issue.number}.surge.sh`;
+            const marker = '<!-- surge-preview-url -->';
+            const body = `${marker}\nWASM demo preview: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist-newstyle
 tmp
 secrets
 result
+result-*
+docs/demo
 .cabal-fmt*
 testdb
 **/*.bak

--- a/app/csmt-verify-wasm/Main.hs
+++ b/app/csmt-verify-wasm/Main.hs
@@ -1,0 +1,54 @@
+-- |
+-- Module      : Main
+-- Description : WASM entry point for csmt-verify
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- Minimal stdio-based verifier for the CSMT proof-carrying API.
+-- Intended to be compiled by @wasm32-wasi-cabal@ to a single
+-- @csmt-verify.wasm@ module that any WASI-capable runtime (including
+-- JS hosts via @wasi-js@) can drive.
+--
+-- Input protocol on stdin:
+--
+--   * 1 byte  — opcode: 0 = inclusion proof, 1 = exclusion proof
+--   * 32 bytes — trusted root hash
+--   * N bytes  — CBOR-encoded proof (as produced by the @csmt@ write
+--                side's @Write.renderProof@ / @Write.renderExclusion@)
+--
+-- Exit code: 0 if the proof verifies against the root, 1 otherwise.
+-- Any malformed input (short read, unknown opcode, bad CBOR) is
+-- treated as a verification failure and returns exit code 1.
+--
+-- This deliberately small surface exists so that a native WASM host
+-- (or a browser via @wasi-js@) can verify CSMT proofs with no C
+-- dependencies and no ceremony around buffer allocation. A richer
+-- JSON/FFI surface can be layered on later; for now a byte-level
+-- shim is enough to prove that the sublibrary cross-compiles cleanly.
+module Main (main) where
+
+import CSMT.Verify
+    ( verifyExclusionProof
+    , verifyInclusionProof
+    )
+import Data.ByteString qualified as B
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (stdin)
+
+main :: IO ()
+main = do
+    input <- B.hGetContents stdin
+    let ok = dispatch input
+    if ok then exitSuccess else exitFailure
+
+dispatch :: B.ByteString -> Bool
+dispatch bs
+    | B.length bs < 33 = False
+    | otherwise =
+        let opcode = B.head bs
+            rootBs = B.take 32 (B.drop 1 bs)
+            proofBs = B.drop 33 bs
+        in  case opcode of
+                0 -> verifyInclusionProof rootBs proofBs
+                1 -> verifyExclusionProof rootBs proofBs
+                _ -> False

--- a/cabal-wasm.project
+++ b/cabal-wasm.project
@@ -1,0 +1,38 @@
+-- WASM build configuration for the csmt-verify sublibrary.
+-- Usage:
+--   wasm32-wasi-cabal --project-file=cabal-wasm.project build csmt-verify-wasm
+--
+-- This project compiles ONLY the csmt-verify sublibrary (+ a tiny
+-- stdio entry point). It is deliberately disjoint from cabal.project
+-- which pulls in rocksdb and other C deps that do not cross-compile
+-- to WASM.
+
+allow-newer: *:template-haskell, *:base, *:deepseq, *:ghc-prim, *:time, *:text
+
+-- Set 1 day before the truncate-index boundary in nix/wasm.nix so
+-- every entry intended by that boundary is included. Hackage's
+-- 0.2.10.0 cborg tarball has the GHC.IntWord64 issue, so we pin
+-- cborg to a git revision with the fix (see source-repository-package
+-- below).
+index-state:
+  , hackage.haskell.org 2026-01-11T00:00:00Z
+
+packages:
+  mts.cabal
+
+-- cborg 0.2.10.0 on Hackage is broken on GHC 9.12 WASM (undefined
+-- GHC.IntWord64 operations). Git HEAD has the MIN_VERSION_base guard.
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/cborg.git
+  tag: 72a0e736e24c864b5a9b95d90adb37a9e8e6d761
+  subdir: cborg
+
+-- Build only the WASM executable (which pulls in csmt-verify). The
+-- native library, tests, benchmarks, and other sublibraries have C
+-- deps (rocksdb, crypton) that are not in scope for this project.
+package mts
+  flags: +wasm
+
+tests: False
+benchmarks: False

--- a/docs/wasm-demo.md
+++ b/docs/wasm-demo.md
@@ -1,0 +1,49 @@
+# WASM browser demo
+
+The `csmt-verify` sublibrary is cross-compiled to WebAssembly via
+the GHC WASM backend. The resulting `csmt-verify.wasm` module runs
+in any WASI-capable host, including a browser using the
+`@bjorn3/browser_wasi_shim` polyfill.
+
+<div id="demo-frame"></div>
+
+!!! tip "Try it"
+    [Open the standalone demo](demo/index.html){:target="_blank"}
+
+The demo ships:
+
+- `csmt-verify.wasm` — the actual binary produced by
+  `wasm32-wasi-cabal` via `nix build .#csmt-verify-wasm`
+- `index.html` + `verify.js` — a minimal static page that loads
+  the module, pipes a byte-level stdin into it, and reports the
+  exit code
+- `fixtures.json` — the same proof fixtures used by the TypeScript
+  verifier tests, so the page can exercise inclusion and exclusion
+  proofs out of the box
+
+The `Tamper root` / `Tamper proof` buttons flip a byte so you can
+watch the verifier reject a corrupted proof in real time — no
+server round-trip, the sandboxed WebAssembly module does the work.
+
+## Stdin protocol
+
+The WASM executable reads the entire stdin and returns via exit
+code:
+
+| Bytes     | Meaning                                  |
+|-----------|------------------------------------------|
+| 1         | opcode: `0` = inclusion, `1` = exclusion |
+| 32        | trusted root hash (raw bytes)            |
+| remainder | CBOR-encoded proof                       |
+
+Exit code `0` means the proof verifies against the supplied root;
+exit code `1` means it does not (or the input was malformed).
+
+## Build it yourself
+
+```bash
+nix build .#csmt-verify-wasm-demo
+```
+
+The output is a plain tree of static files suitable for copying
+into any static host.

--- a/flake.lock
+++ b/flake.lock
@@ -194,6 +194,45 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-wasm-meta": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "host": "gitlab.haskell.org",
+        "lastModified": 1775305067,
+        "narHash": "sha256-KFWRYVYPgsXu51stX/7/416qc31HFltfQiHPc6nEmH0=",
+        "owner": "haskell-wasm",
+        "repo": "ghc-wasm-meta",
+        "rev": "60098a5076557e327b326a1a3ba3b5fb4fec1e49",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.haskell.org",
+        "owner": "haskell-wasm",
+        "repo": "ghc-wasm-meta",
+        "type": "gitlab"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -571,7 +610,7 @@
     "mkdocs": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "dir": "mkdocs",
@@ -764,6 +803,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1774399958,
+        "narHash": "sha256-Q+g1Np4wyNYpylt8RFM8UprAmyRoA3q3EZj7lQV+ZuQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "735a15e91bcb1b3e0883a91d3c9dfd4475d1bc54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1763678758,
         "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
         "owner": "NixOS",
@@ -800,6 +855,7 @@
         "asciinema": "asciinema",
         "flake-parts": "flake-parts_2",
         "flake-utils": "flake-utils",
+        "ghc-wasm-meta": "ghc-wasm-meta",
         "haskellNix": "haskellNix",
         "mkdocs": "mkdocs",
         "nixpkgs": [
@@ -825,6 +881,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -88,9 +88,17 @@
 
           wasmPackages =
             if wasmBuild != null then
+              let
+                demo = import ./nix/wasm-demo.nix {
+                  inherit pkgs;
+                  wasm = wasmBuild.wasm;
+                  fixtures = ./verifiers/typescript/test/fixtures.json;
+                };
+              in
               {
                 csmt-verify-wasm = wasmBuild.wasm;
                 csmt-verify-wasm-deps = wasmBuild.deps;
+                csmt-verify-wasm-demo = demo;
               }
             else
               { };

--- a/flake.nix
+++ b/flake.nix
@@ -2,25 +2,40 @@
   description = "MTS, Merkle tree store with pluggable trie implementations";
   nixConfig = {
     extra-substituters = [ "https://cache.iog.io" ];
-    extra-trusted-public-keys =
-      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";
-    nixpkgs = { follows = "haskellNix/nixpkgs-unstable"; };
+    nixpkgs = {
+      follows = "haskellNix/nixpkgs-unstable";
+    };
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
     mkdocs.url = "github:paolino/dev-assets?dir=mkdocs";
     asciinema.url = "github:paolino/dev-assets?dir=asciinema";
+    ghc-wasm-meta = {
+      url = "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org";
+      flake = true;
+    };
   };
 
   outputs =
-    inputs@{ self, nixpkgs, flake-utils, haskellNix, mkdocs, asciinema, ... }:
+    inputs@{
+      self,
+      nixpkgs,
+      flake-utils,
+      haskellNix,
+      mkdocs,
+      asciinema,
+      ghc-wasm-meta,
+      ...
+    }:
     let
       lib = nixpkgs.lib;
       version = self.dirtyShortRev or self.shortRev;
 
-      perSystem = system:
+      perSystem =
+        system:
         let
           pkgs = import nixpkgs {
             overlays = [
@@ -39,8 +54,7 @@
             asciinema = asciinema.packages.${system};
           };
 
-          linux-artifacts =
-            import ./nix/linux-artifacts.nix { inherit pkgs version project; };
+          linux-artifacts = import ./nix/linux-artifacts.nix { inherit pkgs version project; };
           macos-artifacts = import ./nix/macos-artifacts.nix {
             inherit pkgs project version;
             rewrite-libs = rewrite-libs.packages.default;
@@ -53,19 +67,52 @@
           };
           docker.packages = { inherit docker-image; };
           info.packages = { inherit version; };
+
+          # WASM build of csmt-verify. Only wired on x86_64-linux
+          # because ghc-wasm-meta ships binary toolchains for that
+          # platform; darwin users can consume the same .wasm from
+          # CI or via a Linux builder. See nix/wasm.nix.
+          wasmBuild =
+            if system == "x86_64-linux" then
+              import ./nix/wasm.nix {
+                inherit pkgs;
+                src = ./.;
+                ghcWasmToolchain = ghc-wasm-meta.packages.${system}.all_9_12;
+                # Bump whenever the WASM dep set changes. First-run
+                # Nix reports the real hash via a fixed-output hash
+                # mismatch — replace this literal.
+                dependenciesHash = "sha256-kIYIc/5iM8VmCRMSDoLDtYB1s8wQ6e3yGaGmTqwkNAg=";
+              }
+            else
+              null;
+
+          wasmPackages =
+            if wasmBuild != null then
+              {
+                csmt-verify-wasm = wasmBuild.wasm;
+                csmt-verify-wasm-deps = wasmBuild.deps;
+              }
+            else
+              { };
+
           fullPackages = lib.mergeAttrsList [
             project.packages
             linux-artifacts.packages
             macos-artifacts.packages
             info.packages
             docker.packages
+            wasmPackages
           ];
 
-        in {
+        in
+        {
 
-          packages = fullPackages // { default = fullPackages.mts; };
+          packages = fullPackages // {
+            default = fullPackages.mts;
+          };
           inherit (project) devShells;
         };
 
-    in flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] perSystem;
+    in
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] perSystem;
 }

--- a/lib/csmt-verify/CSMT/Verify.hs
+++ b/lib/csmt-verify/CSMT/Verify.hs
@@ -1,0 +1,42 @@
+-- |
+-- Module      : CSMT.Verify
+-- Description : CSMT inclusion/exclusion proof verification
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- Top-level entry point for the @csmt-verify@ sublibrary: a
+-- database-free, WASM-friendly subset of the CSMT machinery that is
+-- just enough to verify an inclusion or exclusion proof carried on
+-- the wire. Callers that already hold raw proof and root bytes can
+-- use 'verifyInclusionProof' / 'verifyExclusionProof'; callers that
+-- need the structured types can import the submodules directly.
+module CSMT.Verify
+    ( verifyInclusionProof
+    , verifyExclusionProof
+    ) where
+
+import Data.ByteString (ByteString)
+
+import CSMT.Verify.CBOR (parseExclusionProof, parseProof)
+import CSMT.Verify.Exclusion qualified as Exclusion
+import CSMT.Verify.Hash (hashHashing, parseHash)
+import CSMT.Verify.Proof qualified as Proof
+
+-- | Verify an inclusion proof from a serialized 'ByteString' against
+-- a trusted root hash. Mirrors @CSMT.Hashes.verifyInclusionProof@ on
+-- the write side.
+verifyInclusionProof :: ByteString -> ByteString -> Bool
+verifyInclusionProof trustedRootBs proofBs =
+    case (parseHash trustedRootBs, parseProof proofBs) of
+        (Just trustedRoot, Just proof) ->
+            Proof.verifyInclusionProof hashHashing trustedRoot proof
+        _ -> False
+
+-- | Verify an exclusion proof from a serialized 'ByteString' against
+-- a trusted root hash.
+verifyExclusionProof :: ByteString -> ByteString -> Bool
+verifyExclusionProof trustedRootBs proofBs =
+    case (parseHash trustedRootBs, parseExclusionProof proofBs) of
+        (Just trustedRoot, Just proof) ->
+            Exclusion.verifyExclusionProof hashHashing trustedRoot proof
+        _ -> False

--- a/lib/csmt-verify/CSMT/Verify/Blake2b.hs
+++ b/lib/csmt-verify/CSMT/Verify/Blake2b.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- |
+-- Module      : CSMT.Verify.Blake2b
+-- Description : Pure-Haskell Blake2b-256 for proof verification
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- A self-contained Blake2b-256 implementation following RFC 7693.
+-- Exists so that the @csmt-verify@ sublibrary has no C dependencies
+-- and compiles on the GHC WASM backend without the @crypton@ /
+-- @memory@ / @ram@ recipe. Only the fixed-size (32-byte, unkeyed)
+-- variant is exposed — it is all that CSMT proof verification needs.
+--
+-- Performance is not a goal. Proofs are short, verification is
+-- called a handful of times per request, and correctness is
+-- cross-checked against the C implementation by the test suite.
+module CSMT.Verify.Blake2b
+    ( blake2b256
+    ) where
+
+import Control.Monad (forM_, when)
+import Control.Monad.ST (ST, runST)
+import Data.Array.ST
+    ( STUArray
+    , newArray_
+    , newListArray
+    , readArray
+    , writeArray
+    )
+import Data.Array.Unboxed (UArray, listArray, (!))
+import Data.Bits (complement, rotateR, shiftL, shiftR, xor, (.|.))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Data.Word (Word64, Word8)
+
+-- | Blake2b-256 hash of a byte string. Output is always 32 bytes.
+blake2b256 :: ByteString -> ByteString
+blake2b256 = blake2b 32
+
+-- | Blake2b with a configurable digest length (1..64 bytes).
+blake2b :: Int -> ByteString -> ByteString
+blake2b outLen input = runST $ do
+    h <- newListArray (0, 7) initialH
+    let blocks = allBlocks input
+        n = length blocks
+    forM_ (zip [1 ..] blocks) $ \(i, (t, blk)) ->
+        compress h blk t (i == n)
+    extract h
+  where
+    param0 :: Word64
+    param0 = 0x01010000 .|. fromIntegral outLen
+
+    initialH :: [Word64]
+    initialH =
+        zipWith xor ivList (param0 : replicate 7 0)
+
+    extract :: STUArray s Int Word64 -> ST s ByteString
+    extract h = do
+        ws <- mapM (readArray h) [0 .. 7]
+        pure
+            $ B.take outLen
+            $ B.concat (map word64LE ws)
+
+-- Returns a list of @(tCounter, 128-byte block)@ pairs. The counter
+-- is the cumulative number of input bytes processed through the end
+-- of the block (zeros added by padding do not count). Empty input
+-- yields a single all-zero block with counter 0.
+allBlocks :: ByteString -> [(Word64, ByteString)]
+allBlocks bs
+    | B.null bs = [(0, B.replicate 128 0)]
+    | otherwise = go 0 bs
+  where
+    go :: Word64 -> ByteString -> [(Word64, ByteString)]
+    go !acc xs
+        | B.length xs <= 128 =
+            let acc' = acc + fromIntegral (B.length xs)
+                pad = B.replicate (128 - B.length xs) 0
+            in  [(acc', xs <> pad)]
+        | otherwise =
+            let (hd, tl) = B.splitAt 128 xs
+                acc' = acc + 128
+            in  (acc', hd) : go acc' tl
+
+-- The Blake2b compression function (RFC 7693 §3.2). Mutates 'h' in
+-- place.
+compress
+    :: STUArray s Int Word64
+    -> ByteString
+    -- ^ 128-byte block
+    -> Word64
+    -- ^ counter t (low half; high half is always 0 for our inputs)
+    -> Bool
+    -- ^ final-block flag
+    -> ST s ()
+compress h blk t isLast = do
+    v <- newArray_ (0, 15)
+    forM_ [0 .. 7] $ \i -> readArray h i >>= writeArray v i
+    forM_ [0 .. 7] $ \i -> writeArray v (i + 8) (ivList !! i)
+    do
+        v12 <- readArray v 12
+        writeArray v 12 (v12 `xor` t)
+    when isLast $ do
+        v14 <- readArray v 14
+        writeArray v 14 (complement v14)
+    let m = parseMsgBlock blk
+    forM_ [0 .. 11] $ \r -> do
+        let s i = sigma ! (r, i)
+        mix v 0 4 8 12 (m !! s 0) (m !! s 1)
+        mix v 1 5 9 13 (m !! s 2) (m !! s 3)
+        mix v 2 6 10 14 (m !! s 4) (m !! s 5)
+        mix v 3 7 11 15 (m !! s 6) (m !! s 7)
+        mix v 0 5 10 15 (m !! s 8) (m !! s 9)
+        mix v 1 6 11 12 (m !! s 10) (m !! s 11)
+        mix v 2 7 8 13 (m !! s 12) (m !! s 13)
+        mix v 3 4 9 14 (m !! s 14) (m !! s 15)
+    forM_ [0 .. 7] $ \i -> do
+        hi <- readArray h i
+        vi <- readArray v i
+        vi8 <- readArray v (i + 8)
+        writeArray h i (hi `xor` vi `xor` vi8)
+
+-- The Blake2b \"G\" mixing function.
+mix
+    :: STUArray s Int Word64
+    -> Int
+    -> Int
+    -> Int
+    -> Int
+    -> Word64
+    -> Word64
+    -> ST s ()
+mix v a b c d x y = do
+    va <- readArray v a
+    vb <- readArray v b
+    vc <- readArray v c
+    vd <- readArray v d
+    let a1 = va + vb + x
+        d1 = rotateR (vd `xor` a1) 32
+        c1 = vc + d1
+        b1 = rotateR (vb `xor` c1) 24
+        a2 = a1 + b1 + y
+        d2 = rotateR (d1 `xor` a2) 16
+        c2 = c1 + d2
+        b2 = rotateR (b1 `xor` c2) 63
+    writeArray v a a2
+    writeArray v b b2
+    writeArray v c c2
+    writeArray v d d2
+
+-- Blake2b initialization vector (IV): the fractional parts of the
+-- square roots of the first 8 primes.
+ivList :: [Word64]
+ivList =
+    [ 0x6a09e667f3bcc908
+    , 0xbb67ae8584caa73b
+    , 0x3c6ef372fe94f82b
+    , 0xa54ff53a5f1d36f1
+    , 0x510e527fade682d1
+    , 0x9b05688c2b3e6c1f
+    , 0x1f83d9abfb41bd6b
+    , 0x5be0cd19137e2179
+    ]
+
+-- Sigma permutation table for 12 rounds × 16 indices (RFC 7693 §2.7).
+sigma :: UArray (Int, Int) Int
+sigma =
+    listArray
+        ((0, 0), (11, 15))
+        $ concat
+            [ [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+            , [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3]
+            , [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4]
+            , [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8]
+            , [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13]
+            , [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9]
+            , [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11]
+            , [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10]
+            , [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5]
+            , [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0]
+            , [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+            , [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3]
+            ]
+
+parseMsgBlock :: ByteString -> [Word64]
+parseMsgBlock bs = [readWord64LE (B.drop (i * 8) bs) | i <- [0 .. 15]]
+
+readWord64LE :: ByteString -> Word64
+readWord64LE bs =
+    foldr
+        (\i acc -> acc `shiftL` 8 .|. fromIntegral (B.index bs i))
+        0
+        [0 .. 7]
+
+word64LE :: Word64 -> ByteString
+word64LE w =
+    B.pack [fromIntegral (w `shiftR` (i * 8)) :: Word8 | i <- [0 .. 7]]

--- a/lib/csmt-verify/CSMT/Verify/CBOR.hs
+++ b/lib/csmt-verify/CSMT/Verify/CBOR.hs
@@ -1,0 +1,177 @@
+-- |
+-- Module      : CSMT.Verify.CBOR
+-- Description : CBOR encoding/decoding for CSMT proofs
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- CBOR parsers and encoders for inclusion and exclusion proofs.
+-- Mirrors @CSMT.Hashes.CBOR@ on the write side so bytes produced
+-- by the server deserialize to 'InclusionProof' / 'ExclusionProof'
+-- values the verifier can check.
+module CSMT.Verify.CBOR
+    ( renderProof
+    , parseProof
+    , renderExclusionProof
+    , parseExclusionProof
+    ) where
+
+import Codec.CBOR.Decoding qualified as CBOR
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Control.Monad (replicateM)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BL
+
+import CSMT.Verify.Core
+    ( Direction (..)
+    , Indirect (..)
+    , Key
+    )
+import CSMT.Verify.Exclusion
+    ( ExclusionProof (..)
+    )
+import CSMT.Verify.Hash
+    ( Hash (..)
+    , renderHash
+    )
+import CSMT.Verify.Proof
+    ( InclusionProof (..)
+    , ProofStep (..)
+    )
+
+encodeDirection :: Direction -> CBOR.Encoding
+encodeDirection L = CBOR.encodeWord 0
+encodeDirection R = CBOR.encodeWord 1
+
+decodeDirection :: CBOR.Decoder s Direction
+decodeDirection = do
+    w <- CBOR.decodeWord
+    case w of
+        0 -> pure L
+        1 -> pure R
+        _ -> fail "Invalid direction"
+
+encodeKey :: Key -> CBOR.Encoding
+encodeKey dirs =
+    CBOR.encodeListLen (fromIntegral $ length dirs)
+        <> foldMap encodeDirection dirs
+
+decodeKey :: CBOR.Decoder s Key
+decodeKey = do
+    len <- CBOR.decodeListLen
+    replicateM len decodeDirection
+
+encodeIndirect :: Indirect Hash -> CBOR.Encoding
+encodeIndirect Indirect{jump, value} =
+    CBOR.encodeListLen 2
+        <> encodeKey jump
+        <> CBOR.encodeBytes (renderHash value)
+
+decodeIndirect :: CBOR.Decoder s (Indirect Hash)
+decodeIndirect = do
+    _ <- CBOR.decodeListLen
+    jump <- decodeKey
+    value <- Hash <$> CBOR.decodeBytes
+    pure Indirect{jump, value}
+
+encodeProofStep :: ProofStep Hash -> CBOR.Encoding
+encodeProofStep ProofStep{stepConsumed, stepSibling} =
+    CBOR.encodeListLen 2
+        <> CBOR.encodeInt stepConsumed
+        <> encodeIndirect stepSibling
+
+decodeProofStep :: CBOR.Decoder s (ProofStep Hash)
+decodeProofStep = do
+    _ <- CBOR.decodeListLen
+    stepConsumed <- CBOR.decodeInt
+    stepSibling <- decodeIndirect
+    pure ProofStep{stepConsumed, stepSibling}
+
+encodeProof :: InclusionProof Hash -> CBOR.Encoding
+encodeProof
+    InclusionProof
+        { proofKey
+        , proofValue
+        , proofSteps
+        , proofRootJump
+        } =
+        CBOR.encodeListLen 4
+            <> encodeKey proofKey
+            <> CBOR.encodeBytes (renderHash proofValue)
+            <> ( CBOR.encodeListLen
+                    (fromIntegral $ length proofSteps)
+                    <> foldMap encodeProofStep proofSteps
+               )
+            <> encodeKey proofRootJump
+
+decodeProof :: CBOR.Decoder s (InclusionProof Hash)
+decodeProof = do
+    _ <- CBOR.decodeListLen
+    proofKey <- decodeKey
+    proofValue <- Hash <$> CBOR.decodeBytes
+    stepsLen <- CBOR.decodeListLen
+    proofSteps <- replicateM stepsLen decodeProofStep
+    proofRootJump <- decodeKey
+    pure
+        InclusionProof
+            { proofKey
+            , proofValue
+            , proofSteps
+            , proofRootJump
+            }
+
+-- | Render an inclusion proof as CBOR bytes.
+renderProof :: InclusionProof Hash -> ByteString
+renderProof =
+    BL.toStrict . CBOR.toLazyByteString . encodeProof
+
+-- | Parse CBOR bytes as an inclusion proof.
+parseProof :: ByteString -> Maybe (InclusionProof Hash)
+parseProof bs =
+    case CBOR.deserialiseFromBytes decodeProof (BL.fromStrict bs) of
+        Left _ -> Nothing
+        Right (_, pf) -> Just pf
+
+encodeExclusionProof :: ExclusionProof Hash -> CBOR.Encoding
+encodeExclusionProof ExclusionEmpty =
+    CBOR.encodeListLen 1 <> CBOR.encodeWord 0
+encodeExclusionProof
+    ExclusionWitness{epTargetKey, epWitnessProof} =
+        CBOR.encodeListLen 3
+            <> CBOR.encodeWord 1
+            <> encodeKey epTargetKey
+            <> encodeProof epWitnessProof
+
+decodeExclusionProof :: CBOR.Decoder s (ExclusionProof Hash)
+decodeExclusionProof = do
+    _ <- CBOR.decodeListLen
+    tag <- CBOR.decodeWord
+    case tag of
+        0 -> pure ExclusionEmpty
+        1 -> do
+            epTargetKey <- decodeKey
+            epWitnessProof <- decodeProof
+            pure
+                ExclusionWitness
+                    { epTargetKey
+                    , epWitnessProof
+                    }
+        _ -> fail "Invalid exclusion proof tag"
+
+-- | Render an exclusion proof as CBOR bytes.
+renderExclusionProof :: ExclusionProof Hash -> ByteString
+renderExclusionProof =
+    BL.toStrict
+        . CBOR.toLazyByteString
+        . encodeExclusionProof
+
+-- | Parse CBOR bytes as an exclusion proof.
+parseExclusionProof
+    :: ByteString -> Maybe (ExclusionProof Hash)
+parseExclusionProof bs =
+    case CBOR.deserialiseFromBytes
+        decodeExclusionProof
+        (BL.fromStrict bs) of
+        Left _ -> Nothing
+        Right (_, pf) -> Just pf

--- a/lib/csmt-verify/CSMT/Verify/Core.hs
+++ b/lib/csmt-verify/CSMT/Verify/Core.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Module      : CSMT.Verify.Core
+-- Description : Pure CSMT types and serialization for proof verification
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- Pure subset of the CSMT type algebra that a verifier needs: the
+-- path 'Direction', the 'Key' / 'Indirect' carriers, the 'Hashing'
+-- record that combines sibling hashes, and cereal-based byte
+-- serializers for them. No database effects, no C FFI. This is the
+-- dependency-light core of the @csmt-verify@ sublibrary — only
+-- @base@, @bytestring@, and @cereal@ are needed to build it.
+module CSMT.Verify.Core
+    ( -- * Keys
+      Direction (..)
+    , Key
+    , oppositeDirection
+    , compareKeys
+    , fromBool
+    , toBool
+
+      -- * Indirect values
+    , Indirect (..)
+    , prefix
+
+      -- * Hashing algebra
+    , Hashing (..)
+    , addWithDirection
+
+      -- * Byte serializers
+    , putKey
+    , getKey
+    , putDirection
+    , getDirection
+    , putIndirect
+    , getIndirect
+    , putSizedByteString
+    , getSizedByteString
+    ) where
+
+import Data.Bits (Bits (..))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Data.List (unfoldr)
+import Data.Serialize
+    ( Get
+    , PutM
+    , getByteString
+    , getWord16be
+    , getWord8
+    , putByteString
+    , putWord16be
+    , putWord8
+    )
+import Data.Word (Word8)
+
+-- | A direction in the binary tree — either Left or Right.
+data Direction = L | R deriving (Show, Eq, Ord)
+
+-- | Convert a 'Bool' to a 'Direction'. @True@ maps to 'R', @False@
+-- to 'L'.
+fromBool :: Bool -> Direction
+fromBool True = R
+fromBool False = L
+
+-- | Convert a 'Direction' to its 'Bool' representation.
+toBool :: Direction -> Bool
+toBool L = False
+toBool R = True
+
+-- | Flip a 'Direction'.
+oppositeDirection :: Direction -> Direction
+oppositeDirection L = R
+oppositeDirection R = L
+
+-- | A key is a path through the binary tree, represented as a list
+-- of directions. Each bit of the original key maps to a direction:
+-- 0 = L, 1 = R.
+type Key = [Direction]
+
+-- | An indirect reference to a value stored at a given position
+-- relative to a node. If 'jump' is empty, the value is at the
+-- current node; otherwise the value is at a descendant reachable
+-- by following the jump.
+data Indirect a = Indirect
+    { jump :: Key
+    , value :: a
+    }
+    deriving (Show, Eq, Functor, Ord)
+
+-- | Prepend a key prefix to an indirect reference's jump path.
+prefix :: Key -> Indirect a -> Indirect a
+prefix q Indirect{jump, value} = Indirect{jump = q ++ jump, value}
+
+-- | Compare two keys and return their common prefix and the
+-- remaining suffixes of each key after the common prefix.
+compareKeys :: Key -> Key -> (Key, Key, Key)
+compareKeys [] ys = ([], [], ys)
+compareKeys xs [] = ([], xs, [])
+compareKeys (x : xs) (y : ys)
+    | x == y =
+        let (j, o, r) = compareKeys xs ys
+        in  (x : j, o, r)
+    | otherwise = ([], x : xs, y : ys)
+
+-- | Hash combination functions for building the Merkle tree
+-- structure. 'rootHash' hashes a single indirect value (leaf node).
+-- 'combineHash' combines left and right child hashes into parent.
+data Hashing a = Hashing
+    { rootHash :: Indirect a -> a
+    , combineHash :: Indirect a -> Indirect a -> a
+    }
+
+-- | Combine two indirect values with the given direction
+-- determining order (so the caller's 'Direction' on the path
+-- decides which sibling is on the left and which on the right).
+addWithDirection
+    :: Hashing a -> Direction -> Indirect a -> Indirect a -> a
+addWithDirection Hashing{combineHash} L left right = combineHash left right
+addWithDirection Hashing{combineHash} R left right = combineHash right left
+
+bigendian :: [Int]
+bigendian = [7, 6 .. 0]
+
+-- | Serialize a 'Direction' to a single byte (0 for 'L', 1 for 'R').
+putDirection :: Direction -> PutM ()
+putDirection d = putWord8 $ if toBool d then 1 else 0
+
+-- | Deserialize a 'Direction' from a single byte.
+getDirection :: Get Direction
+getDirection = do
+    b <- getWord8
+    case b of
+        0 -> return L
+        1 -> return R
+        _ -> fail "Invalid direction byte"
+
+-- | Serialize a 'Key' to bytes: 2-byte length followed by
+-- bit-packed directions.
+putKey :: Key -> PutM ()
+putKey k = do
+    let bytes = B.pack $ unfoldr unconsDirection k
+    putWord16be $ fromIntegral $ length k
+    putByteString bytes
+  where
+    unconsDirection :: Key -> Maybe (Word8, Key)
+    unconsDirection [] = Nothing
+    unconsDirection ds =
+        let (byteBits, rest) = splitAt 8 ds
+            byte = foldl setBitFromDir 0 (zip bigendian byteBits)
+        in  Just (byte, rest)
+
+    setBitFromDir :: Bits b => b -> (Int, Direction) -> b
+    setBitFromDir b (i, dir)
+        | toBool dir = setBit b i
+        | otherwise = b
+
+-- | Deserialize a 'Key' from bytes.
+getKey :: Get Key
+getKey = do
+    len <- getWord16be
+    let (l, r) = len `divMod` 8
+        lr = if r == 0 then l else l + 1
+    bs <- getByteString (fromIntegral lr)
+    return
+        $ take (fromIntegral len)
+        $ concatMap byteToDirections (B.unpack bs)
+  where
+    byteToDirections :: Word8 -> Key
+    byteToDirections byte =
+        [if testBit byte i then R else L | i <- bigendian]
+
+-- | Serialize a 'ByteString' with a 2-byte length prefix.
+putSizedByteString :: ByteString -> PutM ()
+putSizedByteString bs = do
+    let len = fromIntegral $ B.length bs
+    putWord16be len
+    putByteString bs
+
+-- | Deserialize a length-prefixed 'ByteString'.
+getSizedByteString :: Get ByteString
+getSizedByteString = do
+    len <- getWord16be
+    getByteString (fromIntegral len)
+
+-- | Serialize an 'Indirect' 'ByteString' to bytes.
+putIndirect :: Indirect ByteString -> PutM ()
+putIndirect Indirect{jump, value} = do
+    putKey jump
+    putSizedByteString value
+
+-- | Deserialize an 'Indirect' 'ByteString' from bytes.
+getIndirect :: Get (Indirect ByteString)
+getIndirect = Indirect <$> getKey <*> getSizedByteString

--- a/lib/csmt-verify/CSMT/Verify/Exclusion.hs
+++ b/lib/csmt-verify/CSMT/Verify/Exclusion.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Module      : CSMT.Verify.Exclusion
+-- Description : Pure Merkle exclusion-proof verification
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- Exclusion-proof verification for CSMT. The proof structure and
+-- verification path mirror @CSMT.Proof.Exclusion@ — only the
+-- database-bound builder is dropped.
+module CSMT.Verify.Exclusion
+    ( ExclusionProof (..)
+    , verifyExclusionProof
+    ) where
+
+import CSMT.Verify.Core
+    ( Hashing
+    , Key
+    )
+import CSMT.Verify.Proof
+    ( InclusionProof (..)
+    , ProofStep (..)
+    , verifyInclusionProof
+    )
+
+-- | An exclusion proof for a key in a CSMT.
+data ExclusionProof a
+    = -- | The tree is empty; any key is trivially absent.
+      ExclusionEmpty
+    | -- | A witness key diverges from the target within a jump.
+      ExclusionWitness
+        { epTargetKey :: Key
+        , epWitnessProof :: InclusionProof a
+        }
+    deriving (Show, Eq)
+
+-- | Verify an exclusion proof against a trusted root hash.
+--
+-- For 'ExclusionEmpty': always 'True' (empty tree trivially
+-- excludes any key). Callers that need to distinguish an
+-- empty tree from a populated one should inspect the root
+-- separately.
+--
+-- For 'ExclusionWitness': verifies the witness inclusion proof
+-- against the trusted root, then checks that the target key
+-- diverges from the witness key within a jump region (not at
+-- a branch boundary).
+verifyExclusionProof
+    :: Eq a => Hashing a -> a -> ExclusionProof a -> Bool
+verifyExclusionProof _ _ ExclusionEmpty = True
+verifyExclusionProof
+    hashing
+    trustedRoot
+    ExclusionWitness{epTargetKey, epWitnessProof} =
+        let hashValid =
+                verifyInclusionProof
+                    hashing
+                    trustedRoot
+                    epWitnessProof
+            divergenceValid =
+                checkKeyDivergence
+                    epTargetKey
+                    (proofKey epWitnessProof)
+                    (proofRootJump epWitnessProof)
+                    ( map
+                        stepConsumed
+                        (proofSteps epWitnessProof)
+                    )
+        in  hashValid && divergenceValid
+
+checkKeyDivergence
+    :: Key
+    -- ^ Target key
+    -> Key
+    -- ^ Witness key
+    -> Key
+    -- ^ Root jump
+    -> [Int]
+    -- ^ stepConsumed values (leaf-to-root order)
+    -> Bool
+checkKeyDivergence targetKey witnessKey rootJump consumedList =
+    case firstDivergence targetKey witnessKey of
+        Nothing -> False
+        Just divPos ->
+            let branchPositions =
+                    scanBranchPositions
+                        (length rootJump)
+                        (reverse consumedList)
+            in  divPos `notElem` branchPositions
+                    && divPos < length witnessKey
+
+firstDivergence :: Key -> Key -> Maybe Int
+firstDivergence [] [] = Nothing
+firstDivergence [] _ = Nothing
+firstDivergence _ [] = Nothing
+firstDivergence (a : as') (b : bs)
+    | a /= b = Just 0
+    | otherwise = (+ 1) <$> firstDivergence as' bs
+
+scanBranchPositions :: Int -> [Int] -> [Int]
+scanBranchPositions = go
+  where
+    go _ [] = []
+    go pos (consumed : rest) =
+        pos : go (pos + consumed) rest

--- a/lib/csmt-verify/CSMT/Verify/Hash.hs
+++ b/lib/csmt-verify/CSMT/Verify/Hash.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Module      : CSMT.Verify.Hash
+-- Description : Blake2b-256 hash type for CSMT proof verification
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- The concrete 32-byte 'Hash' type plus the 'Hashing' record used by
+-- CSMT proof verification. Mirrors @CSMT.Hashes@ on the write side,
+-- but reaches the same byte-for-byte hash outputs through the
+-- pure-Haskell Blake2b-256 implementation in 'CSMT.Verify.Blake2b'.
+-- The sublibrary therefore has no C FFI, which is what lets it
+-- cross-compile to WASM without the crypton/memory recipe.
+module CSMT.Verify.Hash
+    ( Hash (..)
+    , renderHash
+    , mkHash
+    , parseHash
+    , hashHashing
+    , keyToHash
+    , byteStringToKey
+    , keyToByteString
+    ) where
+
+import Data.Bits (Bits (..))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Data.Serialize (PutM, runPutM)
+import Data.Word (Word8)
+
+import CSMT.Verify.Blake2b (blake2b256)
+import CSMT.Verify.Core
+    ( Direction (..)
+    , Hashing (..)
+    , Key
+    , putIndirect
+    , putKey
+    )
+
+-- | A 32-byte Blake2b-256 hash value.
+newtype Hash = Hash ByteString
+    deriving (Eq, Ord)
+
+instance Show Hash where
+    show (Hash h) = "Hash " <> hexEncode h
+
+-- | Extract the raw 'ByteString' from a 'Hash'.
+renderHash :: Hash -> ByteString
+renderHash (Hash h) = h
+
+-- | Parse a 32-byte 'ByteString' as a 'Hash'. Returns 'Nothing' if
+-- the length is not exactly 32 bytes.
+parseHash :: ByteString -> Maybe Hash
+parseHash bs
+    | B.length bs == 32 = Just (Hash bs)
+    | otherwise = Nothing
+
+-- | Compute a Blake2b-256 hash of a 'ByteString'.
+mkHash :: ByteString -> Hash
+mkHash = Hash . blake2b256
+
+runPut :: PutM a -> ByteString
+runPut p = snd (runPutM p)
+
+-- | Hashing functions for verifying a CSMT proof with Blake2b-256.
+-- 'rootHash' hashes a single serialized indirect value; 'combineHash'
+-- concatenates two serialized children and rehashes. Matches
+-- @CSMT.Hashes.hashHashing@ on the write side.
+hashHashing :: Hashing Hash
+hashHashing =
+    Hashing
+        { rootHash = mkHash . runPut . putIndirect . fmap renderHash
+        , combineHash = \left right -> mkHash . runPut $ do
+            putIndirect (fmap renderHash left)
+            putIndirect (fmap renderHash right)
+        }
+
+-- | Convert a 'Key' to its hash representation.
+keyToHash :: Key -> Hash
+keyToHash = mkHash . runPut . putKey
+
+-- | Expand a 'ByteString' to a 'Key' (one 'Direction' per bit, MSB
+-- first). Matches @CSMT.Hashes.byteStringToKey@.
+byteStringToKey :: ByteString -> Key
+byteStringToKey bs = concatMap byteToDirections (B.unpack bs)
+  where
+    byteToDirections :: Word8 -> Key
+    byteToDirections byte =
+        [if testBit byte i then R else L | i <- [7, 6 .. 0]]
+
+-- | Invert 'byteStringToKey': groups every 8 directions into a byte,
+-- MSB first.
+keyToByteString :: Key -> ByteString
+keyToByteString = B.pack . go
+  where
+    go [] = []
+    go ds =
+        let (byte, rest) = splitAt 8 ds
+            toByte =
+                foldl
+                    ( \acc (i, d) -> case d of
+                        R -> setBit acc i
+                        L -> acc
+                    )
+                    (0 :: Word8)
+                    (zip [7, 6 .. 0] byte)
+        in  toByte : go rest
+
+hexEncode :: ByteString -> String
+hexEncode = concatMap byteHex . B.unpack
+  where
+    byteHex :: Word8 -> String
+    byteHex b =
+        [ hex (fromIntegral (b `shiftR` 4))
+        , hex (fromIntegral (b .&. 0x0f))
+        ]
+
+    hex :: Int -> Char
+    hex n
+        | n < 10 = toEnum (fromEnum '0' + n)
+        | otherwise = toEnum (fromEnum 'a' + n - 10)

--- a/lib/csmt-verify/CSMT/Verify/Proof.hs
+++ b/lib/csmt-verify/CSMT/Verify/Proof.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Module      : CSMT.Verify.Proof
+-- Description : Pure Merkle inclusion-proof verification
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- Inclusion-proof verification for CSMT. The proof structure and
+-- root-hash recomputation mirror @CSMT.Proof.Insertion@ verbatim
+-- — we drop only the database-bound @buildInclusionProof@.
+module CSMT.Verify.Proof
+    ( -- * Types
+      InclusionProof (..)
+    , ProofStep (..)
+    , StepView (..)
+
+      -- * Verification
+    , verifyInclusionProof
+    , computeRootHash
+    , foldProof
+    ) where
+
+import CSMT.Verify.Core
+    ( Direction
+    , Hashing (..)
+    , Indirect (..)
+    , Key
+    , addWithDirection
+    )
+
+-- | A single step in an inclusion proof. Records how many key
+-- bits are consumed at this step (direction + jump length) and
+-- the sibling's indirect value needed to recompute the parent.
+data ProofStep a = ProofStep
+    { stepConsumed :: Int
+    , stepSibling :: Indirect a
+    }
+    deriving (Show, Eq)
+
+-- | An inclusion proof for a key-value pair. Contains the path
+-- data needed to recompute the root hash from a key-value pair.
+-- Verification requires an externally-supplied trusted root hash.
+data InclusionProof a = InclusionProof
+    { proofKey :: Key
+    , proofValue :: a
+    , proofSteps :: [ProofStep a]
+    , proofRootJump :: Key
+    }
+    deriving (Show, Eq)
+
+-- | What the callback sees at each proof step during a fold.
+data StepView = StepView
+    { svDirection :: Direction
+    , svJump :: Key
+    }
+    deriving (Show, Eq)
+
+-- | Verify an inclusion proof against a trusted root hash.
+verifyInclusionProof
+    :: Eq a => Hashing a -> a -> InclusionProof a -> Bool
+verifyInclusionProof hashing trustedRoot proof =
+    trustedRoot == computeRootHash hashing proof
+
+-- | Fold over an inclusion proof's steps with a callback,
+-- returning both the computed root hash and the final accumulator.
+foldProof
+    :: Hashing a
+    -> InclusionProof a
+    -> (acc -> StepView -> acc)
+    -> acc
+    -> (a, acc)
+foldProof
+    hashing
+    InclusionProof{proofKey, proofValue, proofSteps, proofRootJump}
+    step
+    acc0 =
+        let keyAfterRoot = drop (length proofRootJump) proofKey
+            (rootValue, accFinal) =
+                go proofValue acc0 (reverse keyAfterRoot) proofSteps
+        in  (rootHash hashing (Indirect proofRootJump rootValue), accFinal)
+      where
+        go hashAcc acc _ [] = (hashAcc, acc)
+        go hashAcc acc revKey (ProofStep{stepConsumed, stepSibling} : rest) =
+            let (consumedRev, remainingRev) =
+                    splitAt stepConsumed revKey
+                consumed = reverse consumedRev
+            in  case consumed of
+                    (direction : stepJump) ->
+                        let sv =
+                                StepView
+                                    { svDirection = direction
+                                    , svJump = stepJump
+                                    }
+                            acc' = step acc sv
+                        in  go
+                                ( addWithDirection
+                                    hashing
+                                    direction
+                                    (Indirect stepJump hashAcc)
+                                    stepSibling
+                                )
+                                acc'
+                                remainingRev
+                                rest
+                    [] ->
+                        error
+                            "foldProof: invalid proof step \
+                            \with zero consumed bits"
+
+-- | Recompute the root hash from an inclusion proof.
+computeRootHash :: Hashing a -> InclusionProof a -> a
+computeRootHash hashing proof =
+    fst $ foldProof hashing proof (\() _ -> ()) ()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,3 +56,4 @@ nav:
     - CLI Manual: manual.md
     - Library API: library.md
     - TypeScript Verifier: typescript.md
+    - WASM Browser Demo: wasm-demo.md

--- a/mts.cabal
+++ b/mts.cabal
@@ -25,6 +25,15 @@ source-repository head
   type:     git
   location: https://github.com/lambdasistemi/haskell-mts
 
+-- When set, build ONLY the csmt-verify sublibrary and its WASM
+-- entry point. Skips the native CLI, tests, benchmarks, and other
+-- components whose deps (rocksdb, crypton) do not cross-compile to
+-- the GHC WASM backend. See cabal-wasm.project.
+flag wasm
+  description: Build only csmt-verify + csmt-verify-wasm executable.
+  manual:      True
+  default:     False
+
 common warnings
   ghc-options:
     -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
@@ -74,6 +83,9 @@ library
   hs-source-dirs:   lib/mts/
   default-language: Haskell2010
 
+  if flag(wasm)
+    buildable: False
+
 -- Generic rollback library (swap-partition model)
 library rollbacks
   import:           warnings
@@ -92,6 +104,9 @@ library rollbacks
 
   hs-source-dirs:   lib/rollbacks/
   default-language: Haskell2010
+
+  if flag(wasm)
+    buildable: False
 
 -- CSMT (binary trie) implementation
 library csmt
@@ -142,6 +157,9 @@ library csmt
   other-modules:    Paths_mts
   hs-source-dirs:   lib/csmt/
   default-language: Haskell2010
+
+  if flag(wasm)
+    buildable: False
 
 -- Database-free CSMT proof verification. Pure Haskell — no C FFI,
 -- no system libs — so it cross-compiles to GHC's WASM backend
@@ -211,6 +229,9 @@ library mpf
   hs-source-dirs:   lib/mpf/
   default-language: Haskell2010
 
+  if flag(wasm)
+    buildable: False
+
 -- CSMT test utility library
 library csmt-test-lib
   import:           warnings
@@ -230,6 +251,9 @@ library csmt-test-lib
   hs-source-dirs:   test-lib/csmt
   default-language: Haskell2010
 
+  if flag(wasm)
+    buildable: False
+
 -- MPF test utility library
 library mpf-test-lib
   import:           warnings
@@ -246,6 +270,9 @@ library mpf-test-lib
   hs-source-dirs:   test-lib/mpf
   default-language: Haskell2010
 
+  if flag(wasm)
+    buildable: False
+
 executable mts
   import:           warnings
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N
@@ -255,6 +282,27 @@ executable mts
     , mts:csmt
 
   default-language: Haskell2010
+
+  if flag(wasm)
+    buildable: False
+
+-- Minimal stdio verifier that compiles to a single .wasm via the
+-- GHC WASM backend. Only built when the `wasm` flag is set, because
+-- outside of a wasm32-wasi cross-compile the executable is
+-- redundant with the native test suite.
+executable csmt-verify-wasm
+  import:           warnings
+  main-is:          Main.hs
+  hs-source-dirs:   app/csmt-verify-wasm
+  build-depends:
+    , base             >=4.19 && <5
+    , bytestring       >=0.12 && <0.13
+    , mts:csmt-verify
+
+  default-language: Haskell2010
+
+  if !flag(wasm)
+    buildable: False
 
 test-suite unit-tests
   import:             warnings
@@ -322,6 +370,9 @@ test-suite unit-tests
     MTS.Rollbacks.TypesSpec
     MTS.RollbacksSpec
 
+  if flag(wasm)
+    buildable: False
+
 benchmark bench
   import:           warnings
   ghc-options:      -O2
@@ -338,6 +389,9 @@ benchmark bench
     , mts:csmt
     , rocksdb-kv-transactions:kv-transactions
     , temporary                                >=1.3  && <1.4
+
+  if flag(wasm)
+    buildable: False
 
 benchmark populate-bench
   import:           warnings
@@ -356,6 +410,9 @@ benchmark populate-bench
     , rocksdb-kv-transactions:kv-transactions
     , temporary                                >=1.3  && <1.4
     , time                                     >=1.12 && <1.14
+
+  if flag(wasm)
+    buildable: False
 
 benchmark unified
   import:           warnings
@@ -377,6 +434,9 @@ benchmark unified
     , temporary                                >=1.3  && <1.4
     , time                                     >=1.12 && <1.14
 
+  if flag(wasm)
+    buildable: False
+
 benchmark mpf-bench
   import:           warnings
   ghc-options:      -O2
@@ -390,6 +450,9 @@ benchmark mpf-bench
     , mts:mpf
     , mts:mpf-test-lib
     , time              >=1.12 && <1.14
+
+  if flag(wasm)
+    buildable: False
 
 benchmark mpf-bench-rocksdb
   import:           warnings
@@ -407,6 +470,9 @@ benchmark mpf-bench-rocksdb
     , rocksdb-kv-transactions:kv-transactions
     , time                                     >=1.12 && <1.14
 
+  if flag(wasm)
+    buildable: False
+
 executable csmt-test-vectors
   import:           warnings
   main-is:          app/test-vectors/Main.hs
@@ -420,6 +486,9 @@ executable csmt-test-vectors
 
   default-language: Haskell2010
 
+  if flag(wasm)
+    buildable: False
+
 executable csmt-fixtures
   import:           warnings
   main-is:          app/fixtures/Main.hs
@@ -432,6 +501,9 @@ executable csmt-fixtures
 
   default-language: Haskell2010
 
+  if flag(wasm)
+    buildable: False
+
 executable space-leak
   import:           warnings
   main-is:          lib/csmt/CSMT/Frontend/CLI/SpaceLeak.hs
@@ -442,3 +514,6 @@ executable space-leak
     , rocksdb-kv-transactions:kv-transactions
 
   default-language: Haskell2010
+
+  if flag(wasm)
+    buildable: False

--- a/mts.cabal
+++ b/mts.cabal
@@ -143,6 +143,31 @@ library csmt
   hs-source-dirs:   lib/csmt/
   default-language: Haskell2010
 
+-- Database-free CSMT proof verification. Pure Haskell — no C FFI,
+-- no system libs — so it cross-compiles to GHC's WASM backend
+-- without the crypton/memory/ram recipe.
+library csmt-verify
+  import:           warnings
+  visibility:       public
+  exposed-modules:
+    CSMT.Verify
+    CSMT.Verify.Blake2b
+    CSMT.Verify.CBOR
+    CSMT.Verify.Core
+    CSMT.Verify.Exclusion
+    CSMT.Verify.Hash
+    CSMT.Verify.Proof
+
+  build-depends:
+    , array       >=0.5  && <0.6
+    , base        >=4.19 && <5
+    , bytestring  >=0.12 && <0.13
+    , cborg       >=0.2  && <0.3
+    , cereal      >=0.5  && <0.6
+
+  hs-source-dirs:   lib/csmt-verify/
+  default-language: Haskell2010
+
 -- MPF (16-ary trie) implementation
 library mpf
   import:           warnings
@@ -241,14 +266,17 @@ test-suite unit-tests
     , bytestring                               >=0.12 && <0.13
     , cereal                                   >=0.5  && <0.6
     , containers                               >=0.6  && <0.7
+    , crypton                                  >=1.0  && <1.1
     , data-default                             >=0.8  && <0.9
     , exceptions                               >=0.10 && <0.11
     , filepath                                 >=1.4  && <1.5
     , hspec                                    >=2.11 && <2.12
     , lens                                     >=5.3  && <5.4
+    , memory                                   >=0.18 && <0.19
     , mts
     , mts:csmt
     , mts:csmt-test-lib
+    , mts:csmt-verify
     , mts:mpf
     , mts:mpf-test-lib
     , mts:rollbacks
@@ -277,6 +305,8 @@ test-suite unit-tests
     CSMT.Proof.ExclusionSpec
     CSMT.Proof.InsertionSpec
     CSMT.TreePrefixSpec
+    CSMT.Verify.Blake2bSpec
+    CSMT.VerifySpec
     Data.Serialize.ExtraSpec
     MPF.Backend.RocksDBSpec
     MPF.Hashes.AikenSpec

--- a/nix/wasm-demo.nix
+++ b/nix/wasm-demo.nix
@@ -1,0 +1,25 @@
+# Static browser demo for csmt-verify.wasm.
+#
+# Ships an index.html + verify.js that load the WASM artifact
+# produced by ./wasm.nix and run it under the browser_wasi_shim
+# polyfill. The output is a plain tree of static files suitable
+# for copying into a docs site or any static host.
+{ pkgs, wasm, fixtures }:
+pkgs.runCommand "csmt-verify-wasm-demo"
+  {
+    preferLocalBuild = true;
+    nativeBuildInputs = [ pkgs.coreutils ];
+  }
+  ''
+    mkdir -p $out
+    cp ${../verifiers/browser/verify.js}  $out/verify.js
+    cp ${fixtures}                        $out/fixtures.json
+    cp ${wasm}/csmt-verify.wasm           $out/csmt-verify.wasm
+
+    # Content-hash the JS + WASM into the script tag so browsers
+    # never serve a stale module after a build.
+    version=$(sha256sum $out/verify.js $out/csmt-verify.wasm \
+      | sha256sum | cut -c1-16)
+    sed "s/@VERSION@/$version/" \
+      ${../verifiers/browser/index.html} > $out/index.html
+  ''

--- a/nix/wasm.nix
+++ b/nix/wasm.nix
@@ -1,0 +1,200 @@
+# Build csmt-verify to WASM using GHC's WASM backend.
+#
+# Two-phase strategy, adapted from cardano-addresses's WASM recipe
+# but stripped of the crypton / ram / WASI-mmap bits — csmt-verify
+# has no C dependencies, so only the pure Haskell graph needs to
+# reach the WASI target:
+#
+#   1. Fetch + truncate Hackage at a pinned index-state
+#      (deterministic, via haskell.nix's nix-tools).
+#   2. Bootstrap the cabal package cache (mkLocalHackageRepo +
+#      cabal v2-update).
+#   3. Download package tarballs offline via
+#      wasm32-wasi-cabal --only-download (Nix FOD).
+#   4. Build WASM offline from the cached deps in a regular
+#      derivation.
+#
+# The single source-repository-package dep is cborg (Hackage's
+# 0.2.10.0 is broken on GHC 9.12 WASM).
+{
+  pkgs,
+  ghcWasmToolchain,
+  src,
+  dependenciesHash,
+}:
+
+let
+  haskell-nix = pkgs.haskell-nix;
+  projectFile = "cabal-wasm.project";
+
+  # Must match cabal-wasm.project. The truncate-index boundary cuts
+  # at midnight so project's index-state should be ~1 day before
+  # this to guarantee that all intended entries are included.
+  # Cap is the latest index-state known to the pinned haskell.nix.
+  hackageIndexState = "2026-01-12T00:00:00Z";
+
+  truncatedHackageIndex = pkgs.fetchurl {
+    name = "01-index.tar.gz-at-${hackageIndexState}";
+    url = "https://hackage.haskell.org/01-index.tar.gz";
+    downloadToTemp = true;
+    postFetch = ''
+      ${haskell-nix.nix-tools}/bin/truncate-index \
+        -o $out -i $downloadedFile -s '${hackageIndexState}'
+    '';
+    outputHashAlgo = "sha256";
+    outputHash = (import haskell-nix.indexStateHashesPath).${hackageIndexState};
+  };
+
+  mkLocalHackageRepo = haskell-nix.mkLocalHackageRepo;
+
+  bootstrappedHackage =
+    pkgs.runCommand "cabal-bootstrap-hackage.haskell.org"
+      {
+        nativeBuildInputs = [
+          haskell-nix.nix-tools.exes.cabal
+        ]
+        ++ haskell-nix.cabal-issue-8352-workaround;
+      }
+      ''
+        HOME=$(mktemp -d)
+        mkdir -p $HOME/.cabal/packages/hackage.haskell.org
+        cat <<EOF > $HOME/.cabal/config
+        repository hackage.haskell.org
+          url: file:${
+            mkLocalHackageRepo {
+              name = "hackage.haskell.org";
+              index = truncatedHackageIndex;
+            }
+          }
+          secure: True
+          root-keys: aaa
+          key-threshold: 0
+        EOF
+        cabal v2-update hackage.haskell.org
+        cp -r $HOME/.cabal/packages/hackage.haskell.org $out
+      '';
+
+  dotCabal =
+    pkgs.runCommand "dot-cabal-wasm"
+      {
+        nativeBuildInputs = [ pkgs.xorg.lndir ];
+      }
+      ''
+        mkdir -p $out/packages/hackage.haskell.org
+        lndir ${bootstrappedHackage} $out/packages/hackage.haskell.org
+
+        cat > $out/config <<EOF
+        repository hackage.haskell.org
+          url: http://hackage.haskell.org/
+          secure: True
+
+        executable-stripping: False
+        shared: True
+        EOF
+      '';
+
+  # Deterministic source-repository-package clones.
+  cborg-src = pkgs.fetchgit {
+    url = "https://github.com/well-typed/cborg.git";
+    rev = "72a0e736e24c864b5a9b95d90adb37a9e8e6d761";
+    hash = "sha256-SDzMk6gWXelE3OH6gCC6XSn+h5VbrKpaisyza9bCtVM=";
+  };
+
+  # Cabal metadata slice used to plan the dep graph without pulling
+  # in the native sources (tests, benches, rocksdb stuff).
+  srcMetadata = pkgs.lib.cleanSourceWith {
+    inherit src;
+    filter =
+      name: type:
+      let
+        baseName = baseNameOf (toString name);
+      in
+      type == "directory" || pkgs.lib.hasSuffix ".cabal" baseName || baseName == projectFile;
+  };
+
+  deps = pkgs.stdenv.mkDerivation {
+    pname = "csmt-verify-wasm-deps";
+    version = "0.1.0";
+    src = srcMetadata;
+
+    nativeBuildInputs = [
+      ghcWasmToolchain
+      pkgs.cacert
+      pkgs.git
+      pkgs.curl
+    ];
+
+    buildPhase = ''
+      export HOME=$NIX_BUILD_TOP/home
+      mkdir -p $HOME
+      export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+      export CURL_CA_BUNDLE=$SSL_CERT_FILE
+
+      export CABAL_DIR=$NIX_BUILD_TOP/cabal
+      mkdir -p $CABAL_DIR
+      cp -rL ${dotCabal}/* $CABAL_DIR/
+      chmod -R u+w $CABAL_DIR
+
+      wasm32-wasi-cabal --project-file=${projectFile} build \
+        --only-download csmt-verify-wasm
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r $CABAL_DIR/* $out/
+
+      find $out -name 'hackage-security-lock' -delete
+      find $out -name '01-index.timestamp' -delete
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = dependenciesHash;
+  };
+
+  wasm = pkgs.stdenv.mkDerivation {
+    pname = "csmt-verify-wasm";
+    version = "0.1.0";
+    inherit src;
+
+    nativeBuildInputs = [
+      ghcWasmToolchain
+      pkgs.git
+    ];
+
+    configurePhase = ''
+      export HOME=$NIX_BUILD_TOP/home
+      mkdir -p $HOME
+
+      export CABAL_DIR=$NIX_BUILD_TOP/cabal
+      mkdir -p $CABAL_DIR
+      cp -rL ${deps}/* $CABAL_DIR/
+      chmod -R u+w $CABAL_DIR
+
+      # Replace the source-repository-package block with a packages
+      # list that points at the pre-fetched nix stores.
+      cp ${projectFile} ${projectFile}.orig
+      sed -i '/^source-repository-package/,/^$/d' ${projectFile}
+      cat >> ${projectFile} <<EOF
+
+      packages:
+        mts.cabal
+        ${cborg-src}/cborg/cborg.cabal
+      EOF
+    '';
+
+    buildPhase = ''
+      export CABAL_DIR=$NIX_BUILD_TOP/cabal
+      wasm32-wasi-cabal --project-file=${projectFile} build csmt-verify-wasm
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      find dist-newstyle -name "csmt-verify-wasm.wasm" -type f \
+        -exec cp {} $out/csmt-verify.wasm \;
+    '';
+  };
+
+in
+{
+  inherit deps wasm;
+}

--- a/test/CSMT/Verify/Blake2bSpec.hs
+++ b/test/CSMT/Verify/Blake2bSpec.hs
@@ -1,0 +1,38 @@
+-- |
+-- Module      : CSMT.Verify.Blake2bSpec
+-- Description : Pure-Haskell Blake2b-256 vs crypton cross-check
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- Validates the pure-Haskell Blake2b-256 in 'CSMT.Verify.Blake2b'
+-- against @crypton@'s C implementation across a wide range of input
+-- sizes. The rest of the csmt-verify cross-check (proof-level) lives
+-- in 'CSMT.VerifySpec' and trusts this module as its foundation —
+-- if this spec fails, proof verification can still accidentally
+-- succeed on inputs that both impls happen to agree on, so this
+-- spec is the load-bearing one for WASM reproducibility.
+module CSMT.Verify.Blake2bSpec (spec) where
+
+import CSMT.Verify.Blake2b (blake2b256)
+import Crypto.Hash (Blake2b_256, Digest, hash)
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Test.Hspec (Spec, describe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (arbitrary, choose, forAll, vectorOf, (===))
+
+spec :: Spec
+spec = describe "Blake2b" $ do
+    prop "pure Blake2b-256 matches crypton on arbitrary input"
+        $ forAll
+            ( do
+                n <- choose (0, 2000)
+                B.pack <$> vectorOf n arbitrary
+            )
+        $ \bs ->
+            let ours = blake2b256 bs
+                theirs =
+                    convert (hash bs :: Digest Blake2b_256)
+                        :: ByteString
+            in  ours === theirs

--- a/test/CSMT/VerifySpec.hs
+++ b/test/CSMT/VerifySpec.hs
@@ -1,0 +1,121 @@
+-- |
+-- Module      : CSMT.VerifySpec
+-- Description : Cross-check @csmt-verify@ against @csmt@ write side
+-- Copyright   : (c) Paolo Veronelli, 2024
+-- License     : Apache-2.0
+--
+-- The @csmt-verify@ sublibrary is an independent, database-free
+-- reimplementation of the Merkle path arithmetic that the full
+-- @csmt@ library uses on the write side. This spec makes sure the
+-- two implementations agree on:
+--
+--   * the CBOR wire format for inclusion proofs, and
+--   * the computed root hash for any given proof.
+--
+-- If either of those drifts, a server-rendered proof will fail to
+-- verify on the client, which is the exact failure mode we want to
+-- catch here rather than in production.
+module CSMT.VerifySpec (spec) where
+
+import CSMT.Hashes (Hash, mkHash, renderHash)
+import CSMT.Hashes.CBOR qualified as Write
+import CSMT.Interface (Direction (..), Indirect (..))
+import CSMT.Proof.Insertion
+    ( InclusionProof (..)
+    , ProofStep (..)
+    , computeRootHash
+    )
+import CSMT.Verify qualified as Verify
+import Data.Bits (xor)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Data.Word (Word8)
+import Test.Hspec (Spec, describe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+    ( Gen
+    , arbitrary
+    , choose
+    , elements
+    , forAll
+    , listOf
+    , vectorOf
+    , (===)
+    )
+
+import CSMT.Hashes qualified as CSMT
+
+genBS :: Gen ByteString
+genBS = B.pack <$> listOf (arbitrary :: Gen Word8)
+
+genKey :: Gen [Direction]
+genKey = listOf (elements [L, R])
+
+-- | A structurally-valid inclusion proof. The total bits consumed
+-- by the steps equal @length proofKey - length proofRootJump@, and
+-- each 'stepConsumed' is at least 1 (as 'foldProof' requires a
+-- direction at each step).
+genProof :: Gen (InclusionProof Hash)
+genProof = do
+    totalKeyLen <- choose (0, 16 :: Int)
+    rootJumpLen <- choose (0, totalKeyLen)
+    let remaining = totalKeyLen - rootJumpLen
+    consumed <- partitionSteps remaining
+    proofKey <- vectorOf totalKeyLen (elements [L, R])
+    let proofRootJump = take rootJumpLen proofKey
+    proofValue <- mkHash <$> genBS
+    proofSteps <- traverse mkStep consumed
+    pure
+        InclusionProof
+            { proofKey
+            , proofValue
+            , proofSteps
+            , proofRootJump
+            }
+  where
+    mkStep stepConsumed = do
+        siblingValue <- mkHash <$> genBS
+        siblingJump <- genKey
+        pure
+            ProofStep
+                { stepConsumed
+                , stepSibling =
+                    Indirect
+                        { jump = siblingJump
+                        , value = siblingValue
+                        }
+                }
+
+    partitionSteps 0 = pure []
+    partitionSteps n = do
+        step <- choose (1, n)
+        (step :) <$> partitionSteps (n - step)
+
+spec :: Spec
+spec = describe "csmt-verify cross-check" $ do
+    prop "write-side render parses and verifies on csmt-verify"
+        $ forAll genProof
+        $ \proof ->
+            let rootBytes =
+                    renderHash
+                        (computeRootHash CSMT.hashHashing proof)
+                proofBytes = Write.renderProof proof
+            in  Verify.verifyInclusionProof rootBytes proofBytes
+                    === True
+
+    prop "csmt-verify rejects a tampered root"
+        $ forAll genProof
+        $ \proof ->
+            let trueRoot =
+                    renderHash
+                        (computeRootHash CSMT.hashHashing proof)
+                badRoot = B.map (`xor` 0xff) trueRoot
+                proofBytes = Write.renderProof proof
+            in  Verify.verifyInclusionProof badRoot proofBytes
+                    === False
+
+    prop "rejects garbage proof bytes"
+        $ forAll ((,) <$> vectorOf 32 arbitrary <*> genBS)
+        $ \(rootBs, garbage) ->
+            Verify.verifyInclusionProof (B.pack rootBs) garbage
+                === False

--- a/verifiers/browser/index.html
+++ b/verifiers/browser/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CSMT proof verifier (WASM)</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 52rem;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        background: #111;
+        color: #eee;
+        line-height: 1.4;
+      }
+      h1 {
+        font-size: 1.4rem;
+      }
+      code,
+      textarea,
+      input {
+        font-family: ui-monospace, Menlo, monospace;
+      }
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        background: #1a1a1a;
+        color: #eee;
+        border: 1px solid #333;
+        padding: 0.4rem;
+      }
+      label {
+        display: block;
+        margin-top: 0.8rem;
+        font-size: 0.85rem;
+        color: #aaa;
+      }
+      button,
+      select {
+        background: #1a1a1a;
+        color: #eee;
+        border: 1px solid #333;
+        padding: 0.4rem 0.8rem;
+        font: inherit;
+      }
+      button {
+        cursor: pointer;
+      }
+      button:hover {
+        background: #2a2a2a;
+      }
+      .row {
+        display: flex;
+        gap: 0.6rem;
+        align-items: center;
+        margin-top: 0.8rem;
+      }
+      .ok {
+        color: #5f5;
+      }
+      .bad {
+        color: #f55;
+      }
+      .muted {
+        color: #888;
+        font-size: 0.85rem;
+      }
+      pre {
+        background: #1a1a1a;
+        padding: 0.6rem;
+        border: 1px solid #333;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>CSMT proof verifier — running in your browser</h1>
+    <p class="muted">
+      This page loads <code>csmt-verify.wasm</code>, a pure-Haskell
+      verifier compiled with the GHC WASM backend, and runs it under
+      a WASI polyfill. No server, no Haskell runtime on the page — the
+      entire verification happens in the sandboxed WebAssembly module.
+    </p>
+
+    <div class="row">
+      <label for="fixture">Fixture</label>
+      <select id="fixture"></select>
+      <button id="tamper-root" type="button">Tamper root</button>
+      <button id="tamper-proof" type="button">Tamper proof</button>
+    </div>
+
+    <label for="opcode">Opcode</label>
+    <select id="opcode">
+      <option value="0">0 — inclusion</option>
+      <option value="1">1 — exclusion</option>
+    </select>
+
+    <label for="root">Root hash (64 hex chars)</label>
+    <textarea id="root" rows="2" spellcheck="false"></textarea>
+
+    <label for="proof">Proof CBOR (hex)</label>
+    <textarea id="proof" rows="6" spellcheck="false"></textarea>
+
+    <div class="row">
+      <button id="verify" type="button">Verify</button>
+      <span id="result" class="muted">idle</span>
+    </div>
+
+    <label>Wasm stdout / stderr</label>
+    <pre id="log"></pre>
+
+    <p class="muted">
+      Artifact: <code>csmt-verify.wasm</code>
+      (<span id="wasm-size">...</span> bytes).
+      Source: <a href="https://github.com/lambdasistemi/haskell-mts">
+        lambdasistemi/haskell-mts</a>.
+    </p>
+
+    <script type="module" src="./verify.js?v=@VERSION@"></script>
+  </body>
+</html>

--- a/verifiers/browser/verify.js
+++ b/verifiers/browser/verify.js
@@ -1,0 +1,160 @@
+import {
+    WASI,
+    File,
+    OpenFile,
+    ConsoleStdout,
+} from "https://esm.sh/@bjorn3/browser_wasi_shim@0.3.0";
+
+const $ = (id) => document.getElementById(id);
+
+const hexToBytes = (s) => {
+    const clean = s.replace(/\s+/g, "");
+    if (clean.length % 2 !== 0) {
+        throw new Error("hex string must have even length");
+    }
+    const out = new Uint8Array(clean.length / 2);
+    for (let i = 0; i < out.length; i++) {
+        out[i] = parseInt(clean.substr(i * 2, 2), 16);
+    }
+    return out;
+};
+
+const concatBytes = (parts) => {
+    const total = parts.reduce((n, p) => n + p.length, 0);
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) {
+        out.set(p, off);
+        off += p.length;
+    }
+    return out;
+};
+
+const wasmUrl = new URL("./csmt-verify.wasm", import.meta.url);
+const fixturesUrl = new URL("./fixtures.json", import.meta.url);
+
+const [wasmResp, fixtures] = await Promise.all([
+    fetch(wasmUrl),
+    fetch(fixturesUrl).then((r) => r.json()),
+]);
+const wasmBytes = new Uint8Array(await wasmResp.arrayBuffer());
+$("wasm-size").textContent = wasmBytes.length.toLocaleString();
+const wasmModule = await WebAssembly.compile(wasmBytes);
+
+const options = [];
+for (let i = 0; i < fixtures.proofs.length; i++) {
+    const p = fixtures.proofs[i];
+    options.push({
+        label: `inclusion: key=${p.key} value=${p.value}`,
+        opcode: 0,
+        root: fixtures.rootHash,
+        proof: p.cbor,
+    });
+}
+for (let i = 0; i < fixtures.exclusionProofs.length; i++) {
+    const p = fixtures.exclusionProofs[i];
+    options.push({
+        label: `exclusion: key=${p.targetKey}`,
+        opcode: 1,
+        root: fixtures.rootHash,
+        proof: p.cbor,
+    });
+}
+
+const fixtureSel = $("fixture");
+for (let i = 0; i < options.length; i++) {
+    const opt = document.createElement("option");
+    opt.value = String(i);
+    opt.textContent = options[i].label;
+    fixtureSel.appendChild(opt);
+}
+
+const applyFixture = (idx) => {
+    const o = options[idx];
+    $("opcode").value = String(o.opcode);
+    $("root").value = o.root;
+    $("proof").value = o.proof;
+    $("result").textContent = "idle";
+    $("result").className = "muted";
+    $("log").textContent = "";
+};
+applyFixture(0);
+fixtureSel.addEventListener("change", (e) =>
+    applyFixture(Number(e.target.value)),
+);
+
+$("tamper-root").addEventListener("click", () => {
+    const bytes = hexToBytes($("root").value);
+    bytes[0] ^= 0xff;
+    $("root").value = [...bytes]
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+});
+
+$("tamper-proof").addEventListener("click", () => {
+    const bytes = hexToBytes($("proof").value);
+    if (bytes.length > 0) bytes[bytes.length - 1] ^= 0xff;
+    $("proof").value = [...bytes]
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+});
+
+const runVerifier = async (opcode, root, proof) => {
+    if (root.length !== 32) {
+        throw new Error(
+            `root must be 32 bytes, got ${root.length}`,
+        );
+    }
+    const stdinBytes = concatBytes([new Uint8Array([opcode]), root, proof]);
+
+    const logLines = [];
+    const stdoutFd = ConsoleStdout.lineBuffered((line) =>
+        logLines.push(`[stdout] ${line}`),
+    );
+    const stderrFd = ConsoleStdout.lineBuffered((line) =>
+        logLines.push(`[stderr] ${line}`),
+    );
+    const stdinFd = new OpenFile(new File(stdinBytes));
+
+    const wasi = new WASI([], [], [stdinFd, stdoutFd, stderrFd]);
+    const instance = await WebAssembly.instantiate(wasmModule, {
+        wasi_snapshot_preview1: wasi.wasiImport,
+    });
+    let exitCode = 0;
+    try {
+        const rc = wasi.start(instance);
+        if (typeof rc === "number") exitCode = rc;
+    } catch (e) {
+        if (e && typeof e.code === "number") {
+            exitCode = e.code;
+        } else {
+            throw e;
+        }
+    }
+    return { exitCode, log: logLines.join("\n") };
+};
+
+$("verify").addEventListener("click", async () => {
+    const resultEl = $("result");
+    const logEl = $("log");
+    resultEl.textContent = "running...";
+    resultEl.className = "muted";
+    logEl.textContent = "";
+    try {
+        const opcode = Number($("opcode").value);
+        const root = hexToBytes($("root").value);
+        const proof = hexToBytes($("proof").value);
+        const { exitCode, log } = await runVerifier(opcode, root, proof);
+        logEl.textContent = log || "(no output)";
+        if (exitCode === 0) {
+            resultEl.textContent = "valid (exit 0)";
+            resultEl.className = "ok";
+        } else {
+            resultEl.textContent = `invalid (exit ${exitCode})`;
+            resultEl.className = "bad";
+        }
+    } catch (e) {
+        resultEl.textContent = `error: ${e.message}`;
+        resultEl.className = "bad";
+    }
+});


### PR DESCRIPTION
## Goal

Real client-side CSMT proof verification for the MPFS proof-carrying
API (issue #213), targeting WASM/browser delivery.

## Commits

### 1. `csmt-verify` sublibrary (pure Haskell, no C FFI)

New `library csmt-verify` stanza in `mts.cabal` with a minimal dep set:
`{array, base, bytestring, cborg, cereal}`. No C FFI anywhere in the
transitive closure.

Validated against the existing `csmt` write side:

- `CSMT.Verify.Blake2bSpec` — our pure Blake2b-256 (RFC 7693) vs
  `crypton`'s C implementation, 100 random inputs over [0, 2000] bytes.
- `CSMT.VerifySpec` — for every structurally-valid inclusion proof,
  the write-side CBOR render parses and verifies on `csmt-verify`, and
  tampered roots / garbage bytes are rejected.

### 2. WASM build via GHC WASM backend

`nix build .#csmt-verify-wasm` produces a real `.wasm` artifact
(~3.8 MB) that runs in wasmtime. The no-C-FFI claim is enforced by
an actual cross-compile:

- `flake.nix` — new `ghc-wasm-meta` input, `wasmBuild` wired on
  `x86_64-linux` only.
- `nix/wasm.nix` — two-phase FOD: truncate-index + `mkLocalHackageRepo`
  for a deterministic offline Hackage, then `wasm32-wasi-cabal` build.
- `cabal-wasm.project` — WASM-only project pinning index-state
  `2026-01-11T00:00:00Z`, enabling the `wasm` flag.
- `app/csmt-verify-wasm/Main.hs` — stdio verifier: 1 byte opcode +
  32 byte root + N byte CBOR → exit 0/1.
- `mts.cabal` — `flag wasm` gates every C-dep-heavy stanza.

### 3. Browser demo published in docs

`nix build .#csmt-verify-wasm-demo` bundles the `.wasm` with a static
page that loads it under `@bjorn3/browser_wasi_shim` — no server, no
Haskell runtime on the page. End-to-end smoke-tested with Playwright:
valid proof → exit 0, tamper root → exit 1.

- `verifiers/browser/` — `index.html` + `verify.js` source.
- `nix/wasm-demo.nix` — derivation composing those with the built
  `.wasm` and the TypeScript verifier's fixtures. Content-hashes the
  JS + wasm into the `<script>` tag's `?v=` query to prevent stale
  module caching across deploys.
- `docs/wasm-demo.md` + `mkdocs.yml` nav entry.
- `.github/workflows/deploy-docs.yaml` — new step stages the demo
  output into `docs/demo/` before `mkdocs gh-deploy`.

## Reuse model

Source-level, not artifact linking. `cardano-mpfs-offchain` will pin
this repo via `source-repository-package` and depend on
`mts:csmt-verify` directly. Its own WASM build compiles csmt-verify
into the combined module. The standalone `csmt-verify.wasm` here is
a regression gate and a minimal JS-only verifier.

## Test plan

- [x] `cabal test mts-test` — 100% pass, both new specs green
- [x] `nix run .#unit-tests` — 455 examples, 0 failures
- [x] `nix run .#bench` + `.#populate-bench` — green
- [x] `nix run ./verifiers/typescript#test` — 42 tests pass
- [x] `nix --quiet develop -c just format-check` — green
- [x] `nix --quiet develop -c just hlint` — no hints
- [x] `nix --quiet develop -c cabal check` — no distribution errors
- [x] `nix build .#mts` / `.#csmt-verify-wasm` / `.#csmt-verify-wasm-demo`
- [x] Browser demo verified end-to-end in Playwright
- [x] `mkdocs build --strict` — `site/demo/` + `site/wasm-demo/` present
- [ ] Downstream wire-up in cardano-mpfs-offchain (separate PR)

## Live preview

https://haskell-mts-csmt-verify-pr141.surge.sh/
