### PR TITLE
docs: refresh MPF post-merge guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ implementations:
 - **MPF** - Merkle Patricia Forest (16-ary trie, hex nibble keys, Aiken
   compatible)
 
-Both implementations share a common `MerkleTreeStore` record with 12
-QuickCheck properties proving feature parity.
+Both implementations share a common `MerkleTreeStore` record. The shared
+QuickCheck property suite currently contains 13 properties: CSMT passes all
+13, while MPF passes the first 10 and still leaves completeness proofs
+pending.
 
 > **Warning**: This project is in early development and is not production-ready.
 
@@ -23,16 +25,31 @@ QuickCheck properties proving feature parity.
   types
 - **Two trie backends**: Binary (CSMT) and 16-ary (MPF), swappable via the
   shared interface
-- **Merkle proofs**: Inclusion proofs for both implementations; CSMT also
-  supports completeness proofs
+- **Merkle proofs**: Inclusion and exclusion proofs for both implementations;
+  CSMT also supports completeness proofs
 - **Persistent storage**: RocksDB backend for both implementations
 - **Batch and streaming inserts**: MPF supports batch, chunked, and streaming
   insertion modes
-- **Aiken compatibility**: MPF produces root hashes matching the Aiken
-  reference implementation
+- **Aiken compatibility**: MPF produces root hashes and proof-step encodings
+  matching the Aiken reference implementation
+- **Browser demos**: three static demos shipped through the docs site
+  (`csmt-verify.wasm`, `csmt-write.wasm`, `mpf-write.wasm` +
+  `mpf-verify.wasm`)
 - **CLI tool**: Interactive command-line interface for CSMT operations
 - **TypeScript verifier**: Client-side CSMT proof verification in
   browser/Node.js
+- **Pure MPF verifier**: exact Aiken inclusion/exclusion verification in
+  Haskell via `MPF.Verify`
+
+## What Landed For MPF
+
+- explicit exclusion proofs with the same Aiken proof-step transport used for
+  inclusion proofs
+- a pure `MPF.Verify` module for exact Aiken proof-step verification
+- `mpf-write.wasm` and `mpf-verify.wasm`, wired into a browser demo that can
+  build, prove, and verify entirely in the browser
+- docs-site packaging for all three demos: CSMT verify, CSMT write, and MPF
+  write
 
 ## Quick Start
 
@@ -67,14 +84,18 @@ main = withStandaloneRocksDB "mydb" codecs $ \run db ->
 
 ```haskell
 import MPF.MTS (mpfMerkleTreeStore)
-import MPF.Hashes (fromHexKVHashes, mpfHashing)
+import MPF.Hashes (fromHexKVAikenHashes, mpfHashing)
 import MPF.Backend.RocksDB (withMPFStandaloneRocksDB)
 
 main :: IO ()
 main = withMPFStandaloneRocksDB "mydb" codecs $ \run db ->
-    let store = mpfMerkleTreeStore run db fromHexKVHashes mpfHashing
+    let store = mpfMerkleTreeStore run db fromHexKVAikenHashes mpfHashing
     in mtsInsert store "key" "value"
 ```
+
+Use `fromHexKVAikenHashes` when you want the same hashed key path that the
+Aiken-compatible proofs and browser demo use. `fromHexKVHashes` still exists
+for direct raw-byte-to-nibble routing.
 
 ## Installation
 
@@ -110,6 +131,14 @@ NrJMih3czFriydMUwvFKFK6VYKZYVjKpKGe1WC4e+VU=
 ## Documentation
 
 Full documentation at [lambdasistemi.github.io/haskell-mts](https://lambdasistemi.github.io/haskell-mts/)
+
+Useful entry points:
+
+- [Getting started](https://lambdasistemi.github.io/haskell-mts/installation/)
+- [CLI manual](https://lambdasistemi.github.io/haskell-mts/manual/)
+- [CSMT WASM verifier demo](https://lambdasistemi.github.io/haskell-mts/wasm-demo/)
+- [CSMT WASM write demo](https://lambdasistemi.github.io/haskell-mts/wasm-write-demo/)
+- [MPF WASM write demo](https://lambdasistemi.github.io/haskell-mts/wasm-mpf-demo/)
 
 ## License
 

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -14,6 +14,7 @@ graph TD
     CSMT -->|Read/Write| RDB1[RocksDB / In-Memory]
     MPF -->|Read/Write| RDB2[RocksDB / In-Memory]
     TS[TypeScript Verifier] -.->|Verify CSMT proofs| Client[Browser / Node.js]
+    WASM[Browser WASM Demos] -.->|Verify / mutate CSMT and MPF| Client
 ```
 
 ### Layers
@@ -23,7 +24,7 @@ graph TD
 | **MTS Interface** | Shared `MerkleTreeStore` record with type families. Mode-indexed by `KVOnly` / `Full`. |
 | **Ops GADT** | `CommonOps` + `Ops` GADT with bidirectional transitions (`toFull` / `toKVOnly`). |
 | **CSMT Implementation** | Binary trie with path compression, CBOR proofs, completeness proofs, CLI, crash recovery. |
-| **MPF Implementation** | 16-ary trie with hex nibble keys, batch/streaming inserts, Aiken-compatible hashes. |
+| **MPF Implementation** | 16-ary trie with hex nibble keys, batch/streaming inserts, Aiken-compatible hashes and proof-step verification. |
 | **Storage Backends** | RocksDB (persistent) and in-memory (testing) for both implementations. Three columns: KV, Trie, Journal. |
 
 ### Components
@@ -38,6 +39,8 @@ graph TD
   operations. Uses `CSMT_DB_PATH` for the RocksDB database path.
 - **TypeScript Verifier** (`@paolino/csmt-verify`): Client-side CSMT proof
   verification for browser/Node.js.
+- **Browser WASM demos**: static demos for CSMT read-only verification, CSMT
+  write/prove/verify, and MPF write/prove/verify.
 
 ## Planned
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -146,8 +146,14 @@ sibling hashes along the path, and jump paths at each level. See
 [Inclusion Proof Format](architecture/inclusion-proof.md) for the wire
 format specification.
 
-**MPF proofs** contain the key, value, a sequence of proof steps (each with
-a node type tag, sibling hash, and SMT proof hashes), and the root hash.
+**MPF proofs** use an Aiken-compatible proof-step model. The internal proof
+contains step information, while the Aiken wire format carries the proof-step
+list only. Browser/WASM verification therefore supplies the query key and,
+for inclusion mode, the value alongside the proof bytes.
+
+Both implementations also expose implementation-specific exclusion-proof APIs.
+The browser write demos exercise those explicit exclusion witnesses for both
+CSMT and MPF.
 
 ### Completeness Proofs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,20 +25,26 @@ can be written once and run against either backend.
 - **Shared interface**: `MerkleTreeStore` record with type families for key,
   value, hash, proof, leaf, and completeness proof types
   ([MTS Interface](interface.md))
-- **12 QuickCheck properties**: Verify feature parity across implementations
+- **13 QuickCheck properties**: Verify feature parity across implementations
   (insert-verify, order independence, batch equivalence, completeness
   round-trip, etc.)
 - **Two trie backends**: Binary (CSMT) and 16-ary (MPF), each with RocksDB
   and in-memory storage
-- **Merkle proofs**: Inclusion proofs for both implementations; CSMT also
-  supports completeness proofs over prefix-grouped subtrees
+- **Merkle proofs**: Inclusion and exclusion proofs for both
+  implementations; CSMT also supports completeness proofs over
+  prefix-grouped subtrees
 - **Batch and streaming inserts**: MPF supports `insertingBatch`,
   `insertingChunked`, and `insertingStream` for large datasets
-- **Aiken compatibility**: MPF produces root hashes matching the Aiken
-  `MerkleTree` implementation (verified against the 30-fruit test vector)
+- **Aiken compatibility**: MPF produces root hashes and proof-step
+  encodings matching the Aiken `MerkleTree` implementation (verified
+  against the 30-fruit test vector)
+- **Browser demos**: published static demos for read-only CSMT verify,
+  CSMT write/prove/verify, and MPF write/prove/verify
 - **CLI tool**: Interactive command-line interface for CSMT tree operations
 - **TypeScript verifier**: Client-side CSMT proof verification for
   browser/Node.js
+- **Pure MPF verifier**: exact Aiken inclusion/exclusion verification in
+  Haskell via `MPF.Verify`
 
 ## Quick Start
 
@@ -67,9 +73,9 @@ can be written once and run against either backend.
 
 ### Shared Interface (`mts`)
 - [x] `MerkleTreeStore` record with type families
-- [x] 12 shared QuickCheck properties
-- [x] CSMT passes all 12 properties
-- [x] MPF passes 9 of 12 (completeness proofs pending)
+- [x] 13 shared QuickCheck properties
+- [x] CSMT passes all 13 properties
+- [x] MPF passes 10 of 13 (completeness proofs pending)
 
 ### CSMT Implementation (`mts:csmt`)
 - [x] Insertion and deletion
@@ -83,12 +89,26 @@ can be written once and run against either backend.
 
 ### MPF Implementation (`mts:mpf`)
 - [x] Insertion and deletion
-- [x] Inclusion proof generation and verification
+- [x] Inclusion and exclusion proof generation
+- [x] Pure Aiken inclusion/exclusion verification (`MPF.Verify`)
 - [x] Batch, chunked, and streaming inserts
-- [x] Aiken-compatible root hashes
+- [x] Aiken-compatible root hashes and proof-step encoding
+- [x] Browser write/prove/verify demo (`mpf-write.wasm` + `mpf-verify.wasm`)
 - [x] Persistent storage (RocksDB)
 - [ ] Completeness proofs
 - [ ] Benchmarks
+
+## Tutorials And Demos
+
+Start here if you want a guided path through the repository:
+
+1. [Installation](installation.md) for local setup and build options
+2. [CLI Manual](manual.md) for the CSMT command-line workflow
+3. [CSMT WASM Verifier Demo](wasm-demo.md) for the read-only browser verifier
+4. [CSMT WASM Write Demo](wasm-write-demo.md) for browser-side mutation +
+   proof generation
+5. [MPF WASM Write Demo](wasm-mpf-demo.md) for the MPF browser flow with
+   Aiken-compatible proofs
 
 ### Planned
 - [ ] HTTP service with RESTful API

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,3 +54,14 @@ Or via cabal provided you have a working Haskell environment and rocksdb develop
 ```bash
 cabal install
 ```
+
+## Start With The Tutorials
+
+Once the project builds, the fastest way to understand the current
+user-facing behavior is:
+
+1. [CLI Manual](manual.md) for the CSMT command-line workflow
+2. [CSMT WASM Verifier Demo](wasm-demo.md) for read-only proof checking
+3. [CSMT WASM Write Demo](wasm-write-demo.md) for browser-side mutation
+4. [MPF WASM Write Demo](wasm-mpf-demo.md) for MPF build/prove/verify with
+   Aiken-compatible proofs

--- a/docs/library.md
+++ b/docs/library.md
@@ -240,11 +240,14 @@ use the `mts:mpf` sub-library directly.
 | Module | Purpose |
 |--------|---------|
 | `MPF` | Re-exports the public API |
-| `MPF.Hashes` | Blake2b-256 operations, `fromHexKVHashes`, `mpfHashing` |
+| `MPF.Hashes` | Blake2b-256 operations, `fromHexKVHashes`, `fromHexKVAikenHashes`, `mpfHashing` |
+| `MPF.Hashes.Aiken` | Aiken proof-step rendering/parsing helpers |
 | `MPF.Interface` | `FromHexKV`, `HexIndirect`, `HexKey`, `HexDigit` |
 | `MPF.Insertion` | `inserting`, `insertingBatch`, `insertingChunked`, `insertingStream` |
 | `MPF.Deletion` | `deleting` |
 | `MPF.Proof.Insertion` | `mkMPFInclusionProof`, `verifyMPFInclusionProof`, `foldMPFProof` |
+| `MPF.Proof.Exclusion` | `mkMPFExclusionProof`, `verifyMPFExclusionProof`, `foldMPFExclusionProof` |
+| `MPF.Verify` | `verifyAikenInclusionProof`, `verifyAikenExclusionProof` |
 | `MPF.Backend.RocksDB` | RocksDB persistent backend |
 | `MPF.Backend.Pure` | In-memory backend for testing |
 | `MPF.Backend.Standalone` | Column selectors and codecs |
@@ -271,11 +274,17 @@ insertingStream fromKV hashing kvCol mpfCol pairs
 ### Hex Key Operations
 
 ```haskell
+import MPF.Hashes (aikenKeyPath, fromHexKVAikenHashes)
 import MPF.Interface (byteStringToHexKey, hexKeyToByteString, HexDigit(..), HexKey)
 
 let key = byteStringToHexKey "hello"  -- [HexDigit 6, HexDigit 8, ...]
 let bs  = hexKeyToByteString key       -- round-trips back
+let aiken = aikenKeyPath "hello"       -- Blake2b(key) rendered as nibbles
 ```
+
+Use `fromHexKVAikenHashes` when you need the same hashed key routing used by
+the Aiken-compatible browser demo and `MPF.Verify`. Keep `fromHexKVHashes`
+for direct raw-byte-to-nibble routing.
 
 ### Column Selectors
 
@@ -283,6 +292,20 @@ MPF uses its own GADT column selectors:
 
 - `MPFStandaloneKVCol` - Key-value column
 - `MPFStandaloneMPFCol` - MPF tree column
+
+### Aiken Proof Verification
+
+For browser/WASM-style verification against raw key/value bytes:
+
+```haskell
+import MPF.Verify
+    ( verifyAikenExclusionProof
+    , verifyAikenInclusionProof
+    )
+```
+
+These functions verify the exact proof-step bytes emitted by
+`renderAikenProof`, which is the transport used by the MPF browser demo.
 
 ## Error Handling
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -2,9 +2,16 @@
 
 !!! note
     The `mts` CLI operates on a **CSMT** instance. MPF does not currently
-    have a dedicated CLI.
+    have a dedicated CLI. The current hands-on MPF tutorial is the
+    [MPF WASM write demo](wasm-mpf-demo.md).
 
 ## Demos
+
+For the browser-based tutorials, see:
+
+- [CSMT WASM Verifier Demo](wasm-demo.md)
+- [CSMT WASM Write Demo](wasm-write-demo.md)
+- [MPF WASM Write Demo](wasm-mpf-demo.md)
 
 ### Basic Operations
 

--- a/docs/mpf.md
+++ b/docs/mpf.md
@@ -18,7 +18,9 @@ MPF provides:
 - Leaf/branch distinction (`hexIsLeaf` flag) for different hash schemes
 - Aiken-compatible root hashes (verified against 30-fruit test vector)
 - Batch, chunked, and streaming insertion modes
-- Inclusion proofs with SMT proof steps
+- Aiken-compatible inclusion and exclusion proofs
+- Pure verification helpers in `MPF.Verify`
+- Browser-side build/prove/verify via `mpf-write.wasm` and `mpf-verify.wasm`
 
 ## Key Types
 
@@ -59,8 +61,10 @@ data FromHexKV k v a = FromHexKV
     }
 ```
 
-The default `fromHexKVHashes` hashes the key with Blake2b-256, converts
-to nibbles, and hashes the value.
+`fromHexKVHashes` converts the raw key bytes directly to nibbles and hashes the
+value. When you need Aiken/browser parity, use `fromHexKVAikenHashes`
+instead: it routes the trie path through `blake2b_256(key)` rendered as 64
+hex nibbles, while still storing the original user key in the KV column.
 
 ### `MPFHashing` - Hash Operations
 
@@ -126,26 +130,41 @@ MPF supports multiple insertion strategies:
 Streaming insertion groups keys by their first hex digit, processing
 each of the 16 subtrees independently.
 
-## Inclusion Proofs
+## Proofs
 
-MPF inclusion proofs contain:
+### Inclusion Proofs
 
-- The key and value
-- A sequence of proof steps, each with:
-    - Node type (leaf or branch)
-    - Sibling hash
-    - SMT proof: 4 intermediate hashes from the 16-element pairwise
-      reduction tree
-- The root hash
+MPF inclusion proofs are built from proof steps that mirror Aiken's
+proof-step model:
 
-The SMT proof encodes the path through the binary reduction of the
-16-slot array, collecting the opposite subtree's root at each of 4
-levels.
+- branch steps for nodes with many siblings
+- fork steps when exactly one non-empty sibling is another branch
+- leaf steps when exactly one non-empty sibling is a leaf
+
+Each step also carries the 4-hash SMT witness needed to reconstruct the
+16-slot branch reduction.
+
+The Aiken wire format emitted by `renderAikenProof` serializes the proof-step
+list only. The pure verifier therefore takes the raw query key and, for
+inclusion mode, the raw value as separate inputs.
+
+### Exclusion Proofs
+
+MPF exclusion proofs reuse the same Aiken proof-step encoding as inclusion
+proofs. The distinction is carried out-of-band:
+
+- `ptype = 0` for inclusion
+- `ptype = 1` for exclusion
+- `ptype = 0xff` for the empty-tree sentinel in the browser demo
+
+This keeps the browser/WASM transport aligned with upstream Aiken instead of
+inventing a second exclusion-proof payload format.
 
 ## Aiken Compatibility
 
 MPF produces root hashes matching the Aiken `MerkleTree` reference
-implementation. This is verified by the 30-fruit test vector from the
+implementation, and the browser write path now derives key paths the same way
+the pure verifier does. This is verified by the 30-fruit test vector from the
 Aiken test suite:
 
 ```
@@ -155,8 +174,20 @@ Expected root: 4acd78f345a686361df77541b2e0b533f53362e36620a1fdd3a13e0b61a3b078
 The test inserts 30 fruit key-value pairs (e.g. `"apple[uid: 58]"` ->
 hash of the emoji) and verifies the resulting root hash matches exactly.
 
+The same Aiken-parity work also backs the browser demo:
+
+- `mpf-write.wasm` mutates the forest and emits Aiken proof-step bytes
+- `mpf-verify.wasm` re-verifies those bytes against the root, raw key, and
+  raw value
+
 ## Completeness Proofs
 
 MPF completeness proofs are not yet implemented. The `mtsCollectLeaves`,
 `mtsMkCompletenessProof`, and `mtsVerifyCompletenessProof` fields
 currently raise an error.
+
+## Browser Demo
+
+For the end-to-end tutorial, see [MPF WASM Write Demo](wasm-mpf-demo.md).
+That page walks through insert, delete, inclusion proof generation, exclusion
+witness generation, and independent verification in the browser.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,7 +2,9 @@
 
 !!! note
     The TypeScript verifier supports **CSMT** proofs only. MPF proof
-    verification is not yet available in TypeScript.
+    verification is not yet available in TypeScript. For MPF in the
+    browser today, use the pure-Haskell WASM flow documented in
+    [MPF WASM Write Demo](wasm-mpf-demo.md).
 
 A TypeScript library for verifying CSMT inclusion proofs client-side.
 This enables browser and Node.js applications to verify proofs without

--- a/docs/wasm-demo.md
+++ b/docs/wasm-demo.md
@@ -8,7 +8,7 @@ in any WASI-capable host, including a browser using the
 <div id="demo-frame"></div>
 
 !!! tip "Try it"
-    [Open the standalone demo](demo/index.html){:target="_blank"}
+    <a href="../demo/index.html" target="_blank">Open the standalone demo</a>
 
 The demo ships:
 

--- a/docs/wasm-mpf-demo.md
+++ b/docs/wasm-mpf-demo.md
@@ -8,13 +8,16 @@ against the reported root.
 <div id="demo-frame"></div>
 
 !!! tip "Try it"
-    [Open the standalone demo](demo-write-mpf/index.html){:target="_blank"}
+    <a href="../demo-write-mpf/index.html" target="_blank">Open the standalone demo</a>
 
 ## What is different from CSMT
 
 - MPF proof bytes are the Aiken proof-step list only. The verifier also
   needs the query key and, for inclusion mode, the value as separate
   inputs.
+- Raw browser keys are routed through the same `blake2b_256(key)` path used
+  by Aiken, via `fromHexKVAikenHashes` / `aikenKeyPath`, so the write and
+  verify sides agree on the trie path.
 - Presence and absence share the same CBOR proof-step encoding. The
   write side distinguishes them with `ptype = 0` for inclusion and
   `ptype = 1` for exclusion.

--- a/docs/wasm-write-demo.md
+++ b/docs/wasm-write-demo.md
@@ -8,7 +8,7 @@ them against the root - happens inside sandboxed WASM.
 <div id="demo-frame"></div>
 
 !!! tip "Try it"
-    [Open the standalone demo](demo-write/index.html){:target="_blank"}
+    <a href="../demo-write/index.html" target="_blank">Open the standalone demo</a>
 
 ## What the demo ships
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MTS Documentation
-site_url: https://paolino.github.io/haskell-mts/
+site_url: https://lambdasistemi.github.io/haskell-mts/
 repo_url: https://github.com/lambdasistemi/haskell-mts
 
 theme:
@@ -56,6 +56,6 @@ nav:
     - CLI Manual: manual.md
     - Library API: library.md
     - TypeScript Verifier: typescript.md
-    - WASM Verifier Demo: wasm-demo.md
-    - WASM Write Demo: wasm-write-demo.md
-    - WASM MPF Demo: wasm-mpf-demo.md
+    - CSMT WASM Verifier Demo: wasm-demo.md
+    - CSMT WASM Write Demo: wasm-write-demo.md
+    - MPF WASM Write Demo: wasm-mpf-demo.md


### PR DESCRIPTION
## Summary

This PR refreshes the user-facing documentation after the merged MPF browser-write work.

The main goal is to make the README, docs home page, MPF guide, library reference, and tutorial entry points match the repository state after the MPF WASM/browser demo landed.

## What Changed

- updated the top-level README summary and feature list to mention:
  - MPF exclusion proofs
  - pure `MPF.Verify`
  - the three browser demos now shipped by the docs site
- corrected the MPF key-routing guidance:
  - documented the difference between `fromHexKVHashes` and `fromHexKVAikenHashes`
  - switched the README MPF store example to the Aiken-compatible helper
- refreshed the docs home page status section:
  - 13 shared QuickCheck properties
  - MPF passes 10 of 13, with completeness still pending
  - explicit MPF browser demo / verifier status
- updated the MPF-specific guides:
  - `docs/mpf.md`
  - `docs/library.md`
  - `docs/concepts.md`
  - `docs/architecture/system.md`
- refreshed the getting-started/tutorial surfaces:
  - `docs/installation.md`
  - `docs/manual.md`
  - clearer demo/tutorial paths in MkDocs nav
- fixed strict MkDocs link validation for the generated demo bundles by replacing the three markdown demo links with explicit relative HTML anchors
- corrected `mkdocs.yml` site URL to the current GitHub Pages location
- added a note in `docs/typescript.md` pointing MPF users at the WASM path instead of implying there is no browser-side option at all

## Verification

- `nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs build --strict`

## Review Guidance

Start with:

- `README.md`
- `docs/index.md`
- `docs/mpf.md`
- `docs/library.md`
- `docs/installation.md`
- `docs/manual.md`
- `mkdocs.yml`
