### PR TITLE
feat: export wasm flake artifacts and demo apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ Requires a working Haskell environment and RocksDB development files:
 cabal install
 ```
 
+## WASM Outputs With Nix
+
+The flake exports both the combined WASM bundle and the individual modules:
+
+```bash
+nix build .#wasm-artifacts
+nix build .#csmt-verify-wasm
+nix build .#csmt-write-wasm
+nix build .#mpf-verify-wasm
+nix build .#mpf-write-wasm
+```
+
+It also exports runnable local preview commands for the static demo bundles:
+
+```bash
+PORT=8000 nix run .#csmt-verify-wasm-demo
+PORT=8001 nix run .#csmt-wasm-write-demo
+PORT=8002 nix run .#mpf-wasm-write-demo
+PORT=8003 nix run .#docs
+```
+
 ## CLI Tool
 
 The `mts` executable provides an interactive CLI for CSMT operations:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,6 +55,28 @@ Or via cabal provided you have a working Haskell environment and rocksdb develop
 cabal install
 ```
 
+## WASM Outputs And Preview Commands
+
+The flake exports the combined browser-WASM bundle plus one package per
+module:
+
+```bash
+nix build .#wasm-artifacts
+nix build .#csmt-verify-wasm
+nix build .#csmt-write-wasm
+nix build .#mpf-verify-wasm
+nix build .#mpf-write-wasm
+```
+
+It also exports local preview commands for each static bundle:
+
+```bash
+PORT=8000 nix run .#csmt-verify-wasm-demo
+PORT=8001 nix run .#csmt-wasm-write-demo
+PORT=8002 nix run .#mpf-wasm-write-demo
+PORT=8003 nix run .#docs
+```
+
 ## Start With The Tutorials
 
 Once the project builds, the fastest way to understand the current

--- a/docs/wasm-demo.md
+++ b/docs/wasm-demo.md
@@ -42,7 +42,9 @@ exit code `1` means it does not (or the input was malformed).
 ## Build it yourself
 
 ```bash
+nix build .#csmt-verify-wasm
 nix build .#csmt-verify-wasm-demo
+PORT=8000 nix run .#csmt-verify-wasm-demo
 ```
 
 The output is a plain tree of static files suitable for copying

--- a/docs/wasm-mpf-demo.md
+++ b/docs/wasm-mpf-demo.md
@@ -27,6 +27,15 @@ That matches the merged Aiken-parity exclusion-proof work: the browser
 transport reuses the canonical proof-step format instead of introducing
 a second exclusion-proof encoding.
 
+## What the demo ships
+
+- `mpf-write.wasm` - the write entry point exported via
+  `nix build .#mpf-write-wasm`
+- `mpf-verify.wasm` - the pure Aiken-compatible verifier exported via
+  `nix build .#mpf-verify-wasm`
+- `index.html` + `write.js` - the static page that runs both modules
+  under `@bjorn3/browser_wasi_shim`
+
 ## Workflow
 
 1. Insert or delete key/value pairs and watch the MPF root update.
@@ -73,7 +82,10 @@ do not carry the query context:
 ## Build it yourself
 
 ```bash
+nix build .#mpf-write-wasm
+nix build .#mpf-verify-wasm
 nix build .#mpf-wasm-write-demo
+PORT=8002 nix run .#mpf-wasm-write-demo
 ```
 
 The result is a static directory containing `index.html`, `write.js`,

--- a/docs/wasm-write-demo.md
+++ b/docs/wasm-write-demo.md
@@ -13,12 +13,13 @@ them against the root - happens inside sandboxed WASM.
 ## What the demo ships
 
 - `csmt-write.wasm` - the write entry point produced by
-  `wasm32-wasi-cabal` via `nix build .#csmt-wasm-write-demo`. It takes
+  `wasm32-wasi-cabal` via `nix build .#csmt-write-wasm`. It takes
   a prior `InMemoryDB` blob, a batch of inserts/deletes, and a query
   key; it returns the updated blob, the post-mutation root, and either
   an inclusion proof or an exclusion proof.
 - `csmt-verify.wasm` - the existing verifier, reused by the page to
-  independently re-check each proof it produces.
+  independently re-check each proof it produces, exported via
+  `nix build .#csmt-verify-wasm`.
 - `index.html` + `write.js` - the static page that drives both modules
   under `@bjorn3/browser_wasi_shim`.
 
@@ -63,7 +64,10 @@ no host-side translation is needed.
 ## Build it yourself
 
 ```bash
+nix build .#csmt-write-wasm
+nix build .#csmt-verify-wasm
 nix build .#csmt-wasm-write-demo
+PORT=8001 nix run .#csmt-wasm-write-demo
 ```
 
 The output is a plain tree of static files suitable for any static

--- a/flake.nix
+++ b/flake.nix
@@ -78,35 +78,24 @@
             null;
 
           wasmPackages = if wasmBuild != null then
-            let
-              demo = import ./nix/wasm-demo.nix {
-                inherit pkgs;
-                wasm = wasmBuild.wasm;
-                fixtures = ./verifiers/typescript/test/fixtures.json;
-              };
-              writeDemo = import ./nix/wasm-write-demo.nix {
-                inherit pkgs;
-                wasm = wasmBuild.wasm;
-              };
-              mpfWriteDemo = import ./nix/mpf-wasm-write-demo.nix {
-                inherit pkgs;
-                wasm = wasmBuild.wasm;
-              };
-              composedDocs = import ./nix/docs.nix {
-                inherit pkgs;
-                src = ./.;
-                mkdocsAssets = mkdocs.outPath;
-                verifyDemo = demo;
-                writeDemo = writeDemo;
-                mpfWriteDemo = mpfWriteDemo;
-              };
-            in {
-              csmt-verify-wasm = wasmBuild.wasm;
-              csmt-verify-wasm-deps = wasmBuild.deps;
-              csmt-verify-wasm-demo = demo;
-              csmt-wasm-write-demo = writeDemo;
-              mpf-wasm-write-demo = mpfWriteDemo;
-              docs = composedDocs;
+            import ./nix/wasm-packages.nix {
+              inherit pkgs wasmBuild;
+              src = ./.;
+              mkdocsAssets = mkdocs.outPath;
+              fixtures = ./verifiers/typescript/test/fixtures.json;
+            }
+          else
+            { };
+
+          wasmApps = if wasmBuild != null then
+            import ./nix/apps.nix {
+              inherit pkgs;
+              demos = lib.getAttrs [
+                "docs"
+                "csmt-verify-wasm-demo"
+                "csmt-wasm-write-demo"
+                "mpf-wasm-write-demo"
+              ] wasmPackages;
             }
           else
             { };
@@ -122,6 +111,7 @@
 
         in {
           packages = fullPackages // { default = fullPackages.mts; };
+          apps = wasmApps;
           inherit (project) devShells;
         };
 

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,27 @@
+{ pkgs, demos }:
+let
+  mkStaticSiteApp = name: root:
+    let
+      server = pkgs.writeShellApplication {
+        name = "serve-${name}";
+        runtimeInputs = [ pkgs.python3 ];
+        text = ''
+          host=''${HOST:-127.0.0.1}
+          port=''${PORT:-8000}
+          echo "Serving ${name} at http://$host:$port/"
+          exec python -m http.server "$port" --bind "$host" --directory ${root}
+        '';
+      };
+    in {
+      type = "app";
+      program = pkgs.lib.getExe server;
+    };
+in {
+  docs = mkStaticSiteApp "docs" demos.docs;
+  csmt-verify-wasm-demo =
+    mkStaticSiteApp "csmt-verify-wasm-demo" demos.csmt-verify-wasm-demo;
+  csmt-wasm-write-demo =
+    mkStaticSiteApp "csmt-wasm-write-demo" demos.csmt-wasm-write-demo;
+  mpf-wasm-write-demo =
+    mkStaticSiteApp "mpf-wasm-write-demo" demos.mpf-wasm-write-demo;
+}

--- a/nix/wasm-packages.nix
+++ b/nix/wasm-packages.nix
@@ -1,0 +1,41 @@
+{ pkgs, src, mkdocsAssets, fixtures, wasmBuild }:
+let
+  mkWasmModule = pname: file:
+    pkgs.runCommand pname {
+      preferLocalBuild = true;
+    } ''
+      mkdir -p $out
+      cp ${wasmBuild.wasm}/${file} $out/${file}
+    '';
+
+  verifyDemo = import ./wasm-demo.nix {
+    inherit pkgs fixtures;
+    wasm = wasmBuild.wasm;
+  };
+  writeDemo = import ./wasm-write-demo.nix {
+    inherit pkgs;
+    wasm = wasmBuild.wasm;
+  };
+  mpfWriteDemo = import ./mpf-wasm-write-demo.nix {
+    inherit pkgs;
+    wasm = wasmBuild.wasm;
+  };
+  docs = import ./docs.nix {
+    inherit pkgs src;
+    inherit mkdocsAssets;
+    inherit verifyDemo writeDemo mpfWriteDemo;
+  };
+in {
+  wasm-artifacts = wasmBuild.wasm;
+  wasm-artifacts-deps = wasmBuild.deps;
+
+  csmt-verify-wasm = mkWasmModule "csmt-verify-wasm" "csmt-verify.wasm";
+  csmt-write-wasm = mkWasmModule "csmt-write-wasm" "csmt-write.wasm";
+  mpf-verify-wasm = mkWasmModule "mpf-verify-wasm" "mpf-verify.wasm";
+  mpf-write-wasm = mkWasmModule "mpf-write-wasm" "mpf-write.wasm";
+
+  csmt-verify-wasm-demo = verifyDemo;
+  csmt-wasm-write-demo = writeDemo;
+  mpf-wasm-write-demo = mpfWriteDemo;
+  inherit docs;
+}


### PR DESCRIPTION
## Summary

This follow-up makes the WebAssembly surface exported by the flake match the actual artifacts we ship.

Before this branch, `packages.csmt-verify-wasm` was misleading: it exposed the full four-module WASM output directory, not the single `csmt-verify.wasm` binary its name suggested. The repository also had no `nix run` entrypoints for serving the static demo bundles locally.

This branch fixes that by exporting:

- `packages.wasm-artifacts` for the combined WASM output directory
- one package per raw module:
  - `packages.csmt-verify-wasm`
  - `packages.csmt-write-wasm`
  - `packages.mpf-verify-wasm`
  - `packages.mpf-write-wasm`
- runnable `apps` for the static bundles:
  - `apps.csmt-verify-wasm-demo`
  - `apps.csmt-wasm-write-demo`
  - `apps.mpf-wasm-write-demo`
  - `apps.docs`

## What Changed

### Flake packaging

- extracted the WASM packaging logic into `nix/wasm-packages.nix`
- added thin per-module derivations that copy a single `.wasm` file out of the combined `mts-wasm` build output
- kept the full bundle available as `wasm-artifacts` so downstream consumers can still fetch all four modules at once
- exposed the static demo bundles and docs site as flake `apps` backed by a simple local Python HTTP server

### Documentation

- updated `README.md` with the new `nix build` and `nix run` entrypoints
- updated `docs/installation.md` so the install/tutorial path includes the exported WASM outputs and preview commands
- corrected the CSMT and MPF demo pages so their “build it yourself” sections point at the raw module packages (`csmt-write-wasm`, `mpf-write-wasm`, etc.) instead of implying the demo bundle package is the module itself
- documented the new local preview commands directly on the demo pages

## Reviewer Notes

The main thing to check is naming parity:

- `nix build .#csmt-verify-wasm` now yields only `csmt-verify.wasm`
- `nix build .#wasm-artifacts` yields the combined directory with all four modules
- `nix run .#mpf-wasm-write-demo` (and the other demo apps) now serves the corresponding static bundle directly from the store

## Verification

Locally verified:

- `nix develop github:paolino/dev-assets?dir=mkdocs --quiet -c mkdocs build --strict`
- `nix eval --json .#apps.x86_64-linux --apply 'apps: builtins.attrNames apps'`
- `nix eval --json .#packages.x86_64-linux --apply 'pkgs: builtins.filter (name: builtins.elem name ["wasm-artifacts" "csmt-verify-wasm" "csmt-write-wasm" "mpf-verify-wasm" "mpf-write-wasm" "csmt-verify-wasm-demo" "csmt-wasm-write-demo" "mpf-wasm-write-demo" "docs"]) (builtins.attrNames pkgs)'`
- `nix build --quiet .#wasm-artifacts .#csmt-verify-wasm .#csmt-write-wasm .#mpf-verify-wasm .#mpf-write-wasm .#csmt-verify-wasm-demo .#csmt-wasm-write-demo .#mpf-wasm-write-demo .#docs`
- local app smoke for `nix run .#mpf-wasm-write-demo`: `index.html`, `mpf-write.wasm`, and `mpf-verify.wasm` all returned `200`

CI is the remaining gate before merge.
