### PR TITLE
feat: csmt-verify completeness proofs cover absent prefixes

### DIFF
--- a/lib/csmt-core/CSMT/Core/CBOR.hs
+++ b/lib/csmt-core/CSMT/Core/CBOR.hs
@@ -196,14 +196,19 @@ decodeMergeOp = do
     j <- CBOR.decodeInt
     pure (i, j)
 
--- | Encode a 'CompletenessProof' as a fixed-length-2 CBOR list:
+-- | Encode a 'CompletenessProof' as a tagged CBOR list.
+--
+-- Tag @0@ = 'CompletenessWitness' — payload is a length-2 list:
 -- merge operations (each a 2-element @[i, j]@ list) followed by
--- inclusion proof steps (reusing 'encodeProofStep'). Symmetric with
--- 'encodeProof' for inclusion proofs.
+-- inclusion proof steps (reusing 'encodeProofStep').
+--
+-- Tag @1@ = 'CompletenessEmpty' — payload is the embedded
+-- 'ExclusionProof' (reusing 'encodeExclusionProof').
 encodeCompletenessProof :: CompletenessProof Hash -> CBOR.Encoding
 encodeCompletenessProof
-    CompletenessProof{cpMergeOps, cpInclusionSteps} =
-        CBOR.encodeListLen 2
+    (CompletenessWitness cpMergeOps cpInclusionSteps) =
+        CBOR.encodeListLen 3
+            <> CBOR.encodeWord 0
             <> ( CBOR.encodeListLen
                     (fromIntegral (length cpMergeOps))
                     <> foldMap encodeMergeOp cpMergeOps
@@ -212,16 +217,25 @@ encodeCompletenessProof
                     (fromIntegral (length cpInclusionSteps))
                     <> foldMap encodeProofStep cpInclusionSteps
                )
+encodeCompletenessProof (CompletenessEmpty exclusion) =
+    CBOR.encodeListLen 2
+        <> CBOR.encodeWord 1
+        <> encodeExclusionProof exclusion
 
 decodeCompletenessProof
     :: CBOR.Decoder s (CompletenessProof Hash)
 decodeCompletenessProof = do
     _ <- CBOR.decodeListLen
-    mergeOpsLen <- CBOR.decodeListLen
-    cpMergeOps <- replicateM mergeOpsLen decodeMergeOp
-    stepsLen <- CBOR.decodeListLen
-    cpInclusionSteps <- replicateM stepsLen decodeProofStep
-    pure CompletenessProof{cpMergeOps, cpInclusionSteps}
+    tag <- CBOR.decodeWord
+    case tag of
+        0 -> do
+            mergeOpsLen <- CBOR.decodeListLen
+            mergeOps <- replicateM mergeOpsLen decodeMergeOp
+            stepsLen <- CBOR.decodeListLen
+            steps <- replicateM stepsLen decodeProofStep
+            pure (CompletenessWitness mergeOps steps)
+        1 -> CompletenessEmpty <$> decodeExclusionProof
+        _ -> fail "Invalid completeness proof tag"
 
 -- | Render a completeness proof as CBOR bytes.
 renderCompletenessProof :: CompletenessProof Hash -> ByteString

--- a/lib/csmt-core/CSMT/Core/Completeness.hs
+++ b/lib/csmt-core/CSMT/Core/Completeness.hs
@@ -14,15 +14,24 @@
 -- "CSMT.Proof.Completeness" because they require a transactional
 -- KV store.
 --
--- A completeness proof contains:
+-- A completeness proof can take one of two shapes:
 --
--- * Merge operations that reconstruct the subtree root from leaves
--- * Inclusion proof steps anchoring the subtree root to the tree root
+-- * 'CompletenessWitness' — the prefix has at least one leaf;
+--   the proof carries merge operations to reconstruct the
+--   subtree root from the leaves, plus inclusion-proof steps
+--   anchoring the subtree root to the tree root.
 --
--- The verifier provides the prefix and a trusted root hash. The fold
--- function derives the root jump internally from the prefix, the
--- subtree jump (from the merge ops result), and the step consumed
--- counts.
+-- * 'CompletenessEmpty' — the prefix has no leaves under the
+--   trusted root; the proof carries a single 'ExclusionProof'
+--   whose target is the prefix itself. The witness's path
+--   diverges from the prefix within a jump, which the verifier
+--   interprets as "no key has the prefix as its prefix" — the
+--   exact emptiness claim.
+--
+-- The verifier supplies the prefix and a trusted root hash. The
+-- fold function dispatches on the constructor and the supplied
+-- leaf list (empty leaves ⇒ 'CompletenessEmpty', non-empty
+-- leaves ⇒ 'CompletenessWitness'); a mismatch fails the proof.
 module CSMT.Core.Completeness
     ( CompletenessProof (..)
     , foldCompletenessProof
@@ -32,6 +41,10 @@ module CSMT.Core.Completeness
 import Data.List (isPrefixOf)
 import Data.Map.Strict qualified as Map
 
+import CSMT.Core.Exclusion
+    ( ExclusionProof (..)
+    , verifyExclusionProof
+    )
 import CSMT.Core.Proof (ProofStep (..))
 import CSMT.Core.Types
     ( Hashing (..)
@@ -43,20 +56,33 @@ import CSMT.Core.Types
 
 -- | A completeness proof for a subtree under a given prefix.
 --
--- Contains merge operations to reconstruct the subtree root from
--- leaves, and inclusion steps to anchor the subtree root to the
--- tree root. The prefix is not stored — the verifier already knows
--- it. The root jump is derived during verification.
-data CompletenessProof a = CompletenessProof
-    { cpMergeOps :: [(Int, Int)]
-    -- ^ Merge operations: each @(i, j)@ combines leaves at those
-    -- indices. Applied to the leaf list, these reconstruct the
-    -- subtree root.
-    , cpInclusionSteps :: [ProofStep a]
-    -- ^ Inclusion proof steps from the subtree root outward to
-    -- the tree root. Empty when the prefix covers the whole tree
-    -- (prefix = []) or when the root jump subsumes the prefix.
-    }
+-- 'CompletenessWitness' is the populated case (one or more
+-- leaves). 'CompletenessEmpty' is the absent-prefix case, where
+-- the prefix has no entries under the trusted root.
+data CompletenessProof a
+    = -- | Populated subtree: merge operations reconstruct the
+      -- subtree root from the leaves, and inclusion steps
+      -- anchor the subtree root to the tree root. The prefix
+      -- is not stored — the verifier already knows it. The
+      -- root jump is derived during verification.
+      CompletenessWitness
+        { cpMergeOps :: [(Int, Int)]
+        -- ^ Merge operations: each @(i, j)@ combines leaves
+        -- at those indices. Applied to the leaf list, these
+        -- reconstruct the subtree root.
+        , cpInclusionSteps :: [ProofStep a]
+        -- ^ Inclusion proof steps from the subtree root
+        -- outward to the tree root. Empty when the prefix
+        -- covers the whole tree (prefix = []) or when the
+        -- root jump subsumes the prefix.
+        }
+    | -- | Absent prefix: an 'ExclusionProof' whose target key
+      -- is the prefix. Verified by 'verifyExclusionProof',
+      -- which checks the embedded inclusion-proof witness
+      -- against the trusted root and confirms the divergence
+      -- happens within a jump. A divergence within a jump is
+      -- exactly the guarantee that no key extends the prefix.
+      CompletenessEmpty (ExclusionProof a)
     deriving (Show, Eq)
 
 -- | A function to compose two indirect values into a combined hash.
@@ -64,8 +90,8 @@ type Compose a = Indirect a -> Indirect a -> a
 
 -- | Fold merge operations over a list of leaves.
 --
--- Returns the subtree root as an 'Indirect', or 'Nothing' if the
--- proof is invalid (e.g. key comparison fails).
+-- Returns the subtree root as an 'Indirect', or 'Nothing' if
+-- the proof is invalid (e.g. key comparison fails).
 foldMergeOps
     :: Compose a
     -> [Indirect a]
@@ -93,20 +119,34 @@ foldMergeOps compose values = go (Map.fromList $ zip [0 ..] values)
                         go m' xs
                 _ -> Nothing
 
--- | Verify a completeness proof by computing the tree root hash.
+-- | Verify a completeness proof against a trusted root hash.
 --
 -- The verifier provides the prefix (which they chose) and the
--- leaves (which they received). Each leaf's @jump@ field is the
--- *absolute* key in the column — it MUST start with @prefixKey@.
--- The fold strips the prefix internally before reconstructing
--- the subtree root, then walks the inclusion steps back to the
--- column root.
+-- leaves (which they received). The proof must match the leaf
+-- shape:
 --
--- Returns 'Nothing' if any leaf's jump does not start with
--- @prefixKey@, if the merge fold fails, or if the proof is
--- otherwise malformed.
+-- * non-empty leaves ⇒ 'CompletenessWitness';
+-- * empty leaves ⇒ 'CompletenessEmpty'.
+--
+-- For 'CompletenessWitness', each leaf's @jump@ field MUST be
+-- absolute (start with @prefixKey@). The fold strips the prefix
+-- internally before reconstructing the subtree root, then walks
+-- the inclusion steps back to the column root.
+--
+-- For 'CompletenessEmpty', the embedded 'ExclusionProof' is
+-- verified directly; the result is the trusted root on success
+-- (so the caller's @==@ check trivially holds) and 'Nothing' on
+-- failure.
+--
+-- Returns 'Nothing' on shape mismatch or any malformed input
+-- (including a witness leaf whose jump does not start with
+-- @prefixKey@).
 foldCompletenessProof
-    :: Hashing a
+    :: Eq a
+    => Hashing a
+    -> a
+    -- ^ Trusted root (used for the empty case; threaded through
+    -- so the same caller path works for both variants).
     -> Key
     -- ^ The prefix this proof covers (verifier provides this)
     -> [Indirect a]
@@ -114,12 +154,14 @@ foldCompletenessProof
     -- (each jump starts with @prefixKey@)
     -> CompletenessProof a
     -> Maybe a
-    -- ^ Computed tree root hash
+    -- ^ Recomputed tree root, or 'Nothing' on shape mismatch /
+    -- malformed proof.
 foldCompletenessProof
     hashing
+    _trustedRoot
     prefixKey
     leaves
-    CompletenessProof{cpMergeOps, cpInclusionSteps} = do
+    (CompletenessWitness cpMergeOps cpInclusionSteps) = do
         relativeLeaves <- traverse (stripLeafPrefix prefixKey) leaves
         subtreeRoot <- case relativeLeaves of
             [single] | null cpMergeOps -> Just single
@@ -156,6 +198,18 @@ foldCompletenessProof
             | p `isPrefixOf` jmp =
                 Just (Indirect (drop (length p) jmp) val)
             | otherwise = Nothing
+foldCompletenessProof
+    hashing
+    trustedRoot
+    prefixKey
+    leaves
+    (CompletenessEmpty exclusion) =
+        case (leaves, exclusion) of
+            ([], ExclusionWitness{epTargetKey})
+                | epTargetKey == prefixKey
+                , verifyExclusionProof hashing trustedRoot exclusion ->
+                    Just trustedRoot
+            _ -> Nothing
 
 -- | Fold inclusion steps from subtree outward to root.
 --

--- a/lib/csmt-verify/CSMT/Verify.hs
+++ b/lib/csmt-verify/CSMT/Verify.hs
@@ -85,6 +85,7 @@ verifyCompletenessProof trustedRootBs prefixKey leaves proofBs =
         (Just trustedRoot, Just proof) ->
             case foldCompletenessProof
                 hashHashing
+                trustedRoot
                 prefixKey
                 leaves
                 proof of

--- a/lib/csmt-write/CSMT/MTS.hs
+++ b/lib/csmt-write/CSMT/MTS.hs
@@ -550,16 +550,18 @@ csmtMerkleTreeStoreT prefix fromKV hashing =
             , mtsVerifyCompletenessProof = \leaves proof -> do
                 currentRoot <-
                     root hashing StandaloneCSMTCol prefix
-                let computed =
-                        foldCompletenessProof
+                pure $ case currentRoot of
+                    Just r ->
+                        case foldCompletenessProof
                             hashing
+                            r
                             []
                             leaves
-                            proof
-                pure $ case (currentRoot, computed) of
-                    (Just r, Just computedRoot) ->
-                        computedRoot == r
-                    _ -> False
+                            proof of
+                            Just computedRoot ->
+                                computedRoot == r
+                            Nothing -> False
+                    Nothing -> False
             }
 
 -- | Build an IO 'Full' 'MerkleTreeStore' for CSMT scoped to a

--- a/lib/csmt-write/CSMT/Proof/Completeness.hs
+++ b/lib/csmt-write/CSMT/Proof/Completeness.hs
@@ -120,7 +120,7 @@ generateProof sel pfx targetPrefix = do
         Nothing -> Nothing
         Just (mergeOps, _, inclusionSteps) ->
             Just
-                CompletenessProof
+                CompletenessWitness
                     { cpMergeOps = mergeOps
                     , cpInclusionSteps = reverse inclusionSteps
                     }

--- a/lib/csmt-write/CSMT/Proof/Completeness.hs
+++ b/lib/csmt-write/CSMT/Proof/Completeness.hs
@@ -31,6 +31,7 @@ import CSMT.Core.Completeness
     , foldCompletenessProof
     , foldMergeOps
     )
+import CSMT.Core.Exclusion (ExclusionProof (..))
 import CSMT.Interface
     ( Direction (..)
     , Indirect (..)
@@ -39,6 +40,7 @@ import CSMT.Interface
     , oppositeDirection
     , prefix
     )
+import CSMT.Proof.Exclusion (buildExclusionProof)
 import CSMT.Proof.Insertion (ProofStep (..))
 import Database.KV.Transaction
     ( GCompare
@@ -116,14 +118,36 @@ generateProof
     -> Transaction m cf d op (Maybe (CompletenessProof a))
 generateProof sel pfx targetPrefix = do
     result <- navigate 0 pfx targetPrefix []
-    pure $ case result of
-        Nothing -> Nothing
+    case result of
         Just (mergeOps, _, inclusionSteps) ->
-            Just
-                CompletenessWitness
-                    { cpMergeOps = mergeOps
-                    , cpInclusionSteps = reverse inclusionSteps
-                    }
+            pure
+                $ Just
+                    CompletenessWitness
+                        { cpMergeOps = mergeOps
+                        , cpInclusionSteps = reverse inclusionSteps
+                        }
+        Nothing -> do
+            -- The walker returns 'Nothing' both when the column
+            -- is empty and when the target prefix diverges from
+            -- the tree's path. We only promote the divergence
+            -- case to an emptiness proof: if the column is
+            -- empty we fall back to the older contract
+            -- ('Nothing') because 'verifyExclusionProof' on an
+            -- 'ExclusionEmpty' is unconditionally @True@ — sound
+            -- only when paired with a separate empty-tree-root
+            -- check, which the current MTS interface does not
+            -- carry. The divergence case produces an
+            -- 'ExclusionWitness' whose within-jump divergence is
+            -- exactly the prefix-emptiness guarantee.
+            mroot <- query sel pfx
+            case mroot of
+                Nothing -> pure Nothing
+                Just _ -> do
+                    mexcl <- buildExclusionProof pfx sel targetPrefix
+                    pure $ case mexcl of
+                        Just w@ExclusionWitness{} ->
+                            Just (CompletenessEmpty w)
+                        _ -> Nothing
   where
     navigate
         :: Int

--- a/test/CSMT/Proof/CompletenessSpec.hs
+++ b/test/CSMT/Proof/CompletenessSpec.hs
@@ -118,17 +118,17 @@ spec = do
                             $ query StandaloneCSMTCol []
                     return (mp', r')
               in
-                case mp of
-                    Nothing -> error "expected a proof"
-                    Just proof ->
-                        foldCompletenessProof
-                            word64Hashing
-                            []
-                            values
-                            proof
-                            `shouldBe` fmap
-                                (rootHash word64Hashing)
-                                r
+                case (mp, r) of
+                    (Just proof, Just rootIndirect) ->
+                        let tr = rootHash word64Hashing rootIndirect
+                        in  foldCompletenessProof
+                                word64Hashing
+                                tr
+                                []
+                                values
+                                proof
+                                `shouldBe` Just tr
+                    _ -> error "expected a proof"
         it "can verify completeness proof for random trees"
             $ property
             $ forAll manyRandomPaths
@@ -143,17 +143,17 @@ spec = do
                             runPureTransaction word64Codecs
                                 $ query StandaloneCSMTCol []
                         return (mp', r')
-                case mp of
-                    Nothing -> error "expected a proof"
-                    Just proof ->
-                        foldCompletenessProof
-                            word64Hashing
-                            []
-                            (sort values)
-                            proof
-                            `shouldBe` fmap
-                                (rootHash word64Hashing)
-                                r
+                case (mp, r) of
+                    (Just proof, Just rootIndirect) ->
+                        let tr = rootHash word64Hashing rootIndirect
+                        in  foldCompletenessProof
+                                word64Hashing
+                                tr
+                                []
+                                (sort values)
+                                proof
+                                `shouldBe` Just tr
+                    _ -> error "expected a proof"
         it "can verify completeness proof for random trees of hashes"
             $ property
             $ forAll manyRandomPaths
@@ -168,14 +168,14 @@ spec = do
                             runPureTransaction hashCodecs
                                 $ query StandaloneCSMTCol []
                         return (mp', r')
-                case mp of
-                    Nothing -> error "expected a proof"
-                    Just proof ->
-                        foldCompletenessProof
-                            hashHashing
-                            []
-                            (sort values)
-                            proof
-                            `shouldBe` fmap
-                                (rootHash hashHashing)
-                                r
+                case (mp, r) of
+                    (Just proof, Just rootIndirect) ->
+                        let tr = rootHash hashHashing rootIndirect
+                        in  foldCompletenessProof
+                                hashHashing
+                                tr
+                                []
+                                (sort values)
+                                proof
+                                `shouldBe` Just tr
+                    _ -> error "expected a proof"

--- a/test/CSMT/Proof/CompletenessSpec.hs
+++ b/test/CSMT/Proof/CompletenessSpec.hs
@@ -60,7 +60,7 @@ spec = do
                 collected
                     `shouldBe` sort values
     describe "generateProof" $ do
-        it "can generate proof for empty tree"
+        it "returns Nothing for empty tree (no sentinel root)"
             $ let mp =
                     evalPureFromEmptyDB
                         $ runPureTransaction hashCodecs

--- a/test/CSMT/TreePrefixSpec.hs
+++ b/test/CSMT/TreePrefixSpec.hs
@@ -282,19 +282,22 @@ spec = do
                     mapM_
                         ( \p -> do
                             let (collected, proof) = verifyP p
-                            case proof of
-                                Nothing -> collected `shouldBe` []
-                                Just pr ->
-                                    foldCompletenessProof
-                                        word64Hashing
-                                        p
-                                        (sort collected)
-                                        pr
-                                        `shouldBe` fmap
-                                            ( rootHash
+                            case (proof, treeRoot) of
+                                (Nothing, _) ->
+                                    collected `shouldBe` []
+                                (Just pr, Just rootIndirect) ->
+                                    let tr =
+                                            rootHash
                                                 word64Hashing
-                                            )
-                                            treeRoot
+                                                rootIndirect
+                                    in  foldCompletenessProof
+                                            word64Hashing
+                                            tr
+                                            p
+                                            (sort collected)
+                                            pr
+                                            `shouldBe` Just tr
+                                _ -> error "expected a tree root"
                         )
                         ([[L], [R]] :: [Key])
 
@@ -314,17 +317,19 @@ spec = do
                                     p <- generateProof StandaloneCSMTCol [] []
                                     r <- queryPrefix StandaloneCSMTCol [] []
                                     pure (c, p, r)
-                    case proof of
-                        Nothing -> collected `shouldBe` []
-                        Just p ->
-                            foldCompletenessProof
-                                word64Hashing
-                                []
-                                (sort collected)
-                                p
-                                `shouldBe` fmap
-                                    (rootHash word64Hashing)
-                                    treeRoot
+                    case (proof, treeRoot) of
+                        (Nothing, _) -> collected `shouldBe` []
+                        (Just p, Just rootIndirect) ->
+                            let tr =
+                                    rootHash word64Hashing rootIndirect
+                            in  foldCompletenessProof
+                                    word64Hashing
+                                    tr
+                                    []
+                                    (sort collected)
+                                    p
+                                    `shouldBe` Just tr
+                        _ -> error "expected a tree root"
 
         it "generateProof is Nothing iff collectValues is empty"
             $ property

--- a/test/CSMT/TreePrefixSpec.hs
+++ b/test/CSMT/TreePrefixSpec.hs
@@ -18,7 +18,8 @@ import CSMT.Backend.Pure
     )
 import CSMT.Interface (FromKV (..), Hashing (..))
 import CSMT.Proof.Completeness
-    ( collectValues
+    ( CompletenessProof (..)
+    , collectValues
     , foldCompletenessProof
     , generateProof
     , queryPrefix
@@ -35,7 +36,6 @@ import CSMT.Test.Lib
 import Control.Lens (simple)
 import Data.Foldable (foldl')
 import Data.List (sort)
-import Data.Maybe (isJust)
 import Data.Word (Word64)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import Test.QuickCheck
@@ -331,7 +331,7 @@ spec = do
                                     `shouldBe` Just tr
                         _ -> error "expected a tree root"
 
-        it "generateProof is Nothing iff collectValues is empty"
+        it "generateProof shape mirrors collectValues emptiness"
             $ property
             $ forAll (elements [1 .. 8])
             $ \n ->
@@ -339,14 +339,26 @@ spec = do
                     let kvs = zip keys [1 :: Word64 ..]
                         db = foldl' (\d (k, v) -> insertP k v d) emptyInMemoryDB kvs
                         consistent p =
-                            let (isEmpty, hasProof) =
+                            let (isEmpty, isWitness) =
                                     fst
                                         $ runPure db
                                         $ runPureTransaction word64Codecs
                                         $ do
-                                            c <- collectValues StandaloneCSMTCol [] p
-                                            pr <- generateProof StandaloneCSMTCol [] p
-                                            pure (null c, isJust pr)
-                            in  isEmpty /= hasProof
+                                            c <-
+                                                collectValues
+                                                    StandaloneCSMTCol
+                                                    []
+                                                    p
+                                            pr <-
+                                                generateProof
+                                                    StandaloneCSMTCol
+                                                    []
+                                                    p
+                                            pure (null c, isProofWitness pr)
+                            in  isEmpty /= isWitness
                     all consistent ([[], [L], [R]] :: [Key])
                         `shouldBe` True
+  where
+    isProofWitness :: Maybe (CompletenessProof a) -> Bool
+    isProofWitness (Just CompletenessWitness{}) = True
+    isProofWitness _ = False

--- a/test/CSMT/Verify/CompletenessSpec.hs
+++ b/test/CSMT/Verify/CompletenessSpec.hs
@@ -241,3 +241,93 @@ spec = describe "csmt-verify completeness" $ do
                         proofBs
                         `shouldBe` False
                 _ -> error "expected proof + root"
+
+    describe "empty-prefix (absent prefix)" $ do
+        -- A populated tree with a single anchor under [R,R,R,R];
+        -- the prefix [L,L,L,L,...] therefore has no leaves and
+        -- generateProof produces a CompletenessEmpty.
+        let absent :: [Direction]
+            absent = [L, L, L, L, L, L, L, L]
+            anchor = indirect [R, R, R, R] (mkHash "anchor")
+            (mp, mr) = evalPureFromEmptyDB $ do
+                insertHashes [anchor]
+                mp' <-
+                    runPureTransaction hashCodecs
+                        $ generateProof StandaloneCSMTCol [] absent
+                mr' <-
+                    runPureTransaction hashCodecs
+                        $ query StandaloneCSMTCol []
+                pure
+                    ( mp' :: Maybe (CompletenessProof Hash)
+                    , mr'
+                    )
+            withProof
+                :: ( ByteString
+                     -> [Indirect Hash]
+                     -> ByteString
+                     -> Bool
+                   )
+                -> IO ()
+            withProof k = case (mp, mr) of
+                (Just proof, Just rootIndirect) ->
+                    let rootBs =
+                            renderHash
+                                (rootHash hashHashing rootIndirect)
+                        proofBs = renderCompletenessProof proof
+                    in  k rootBs [] proofBs `shouldBe` True
+                _ -> error "expected proof + root"
+
+        it "verifies under the matching root"
+            $ withProof
+            $ \rootBs leaves proofBs ->
+                Verify.verifyCompletenessProof
+                    rootBs
+                    absent
+                    leaves
+                    proofBs
+
+        it "rejects when the verifier supplies a different prefix"
+            $ case (mp, mr) of
+                (Just proof, Just rootIndirect) -> do
+                    let rootBs =
+                            renderHash
+                                (rootHash hashHashing rootIndirect)
+                        proofBs = renderCompletenessProof proof
+                    Verify.verifyCompletenessProof
+                        rootBs
+                        ([R, R, R, R] :: [Direction])
+                        []
+                        proofBs
+                        `shouldBe` False
+                _ -> error "expected proof + root"
+
+        it "rejects when leaves are non-empty"
+            $ case (mp, mr) of
+                (Just proof, Just rootIndirect) -> do
+                    let rootBs =
+                            renderHash
+                                (rootHash hashHashing rootIndirect)
+                        proofBs = renderCompletenessProof proof
+                    Verify.verifyCompletenessProof
+                        rootBs
+                        absent
+                        [anchor]
+                        proofBs
+                        `shouldBe` False
+                _ -> error "expected proof + root"
+
+        it "rejects a tampered root"
+            $ case (mp, mr) of
+                (Just proof, Just rootIndirect) -> do
+                    let rootBs =
+                            renderHash
+                                (rootHash hashHashing rootIndirect)
+                        badRoot = B.map (`xor` 0xff) rootBs
+                        proofBs = renderCompletenessProof proof
+                    Verify.verifyCompletenessProof
+                        badRoot
+                        absent
+                        []
+                        proofBs
+                        `shouldBe` False
+                _ -> error "expected proof + root"


### PR DESCRIPTION
Closes https://github.com/lambdasistemi/haskell-mts/issues/155
Builds on #154 (codec/verifier exposure)
Unblocks https://github.com/cardano-foundation/cardano-mpfs-offchain/issues/243 (POST /tx/oracle/end)

## Summary

The codec PR #154 covered the populated-prefix case only — the
`POST /tx/oracle/end` flow in #243 needs to attest that a per-cage
script-address prefix has *no* requests under it. This PR makes
that case verifiable end-to-end:

- `CompletenessProof` becomes a sum: `CompletenessWitness` (the
  existing populated case) + `CompletenessEmpty (ExclusionProof a)`
  (the new absent-prefix case).
- `generateProof` falls back to `buildExclusionProof` on divergence
  and wraps the result as `CompletenessEmpty`. The "tree truly
  empty" case still returns `Nothing` (no soundness contract for
  that case yet — see "What I deliberately did NOT do" below).
- `verifyCompletenessProof` (and the underlying
  `foldCompletenessProof`) dispatches on the leaves the verifier
  supplies: empty leaves ⇒ Empty branch, non-empty ⇒ Witness
  branch. Mismatched shapes fail.

## The wire-format change

The CBOR layout for `CompletenessProof` gains a leading tag word:
- tag `0` = old `Witness` payload (length-2 list of merge-ops + steps),
- tag `1` = new `Empty` payload (an embedded `ExclusionProof` reusing
  the existing `encodeExclusionProof`).

This is a breaking change to the format from #154, but no consumer
has shipped against it yet (#243 is still in spec). Catching it
now keeps the format stable for #243 onwards.

## The stack (3 vertical commits, bisect-safe)

1. `refactor: split CompletenessProof into Witness/Empty constructors`
   - Type sum + tagged CBOR + `foldCompletenessProof` dispatch.
   - `foldCompletenessProof` gains a `trustedRoot :: a` parameter
     so the empty-case verifier can short-circuit on shape
     mismatch without recomputation.
   - All call sites (`CSMT.MTS`, `CSMT.Proof.CompletenessSpec`,
     `CSMT.TreePrefixSpec`) updated.
   - Empty-case behaviour is "always reject" at this commit so
     the refactor is bisect-safe.

2. `feat: generateProof emits CompletenessEmpty for absent prefixes`
   - Wraps `buildExclusionProof` on divergence.
   - Updated `TreePrefixSpec` invariant: proof shape mirrors
     leaf-set emptiness (was: proof is `Nothing` iff leaves empty).

3. `feat: verifyCompletenessProof accepts CompletenessEmpty`
   - Adds 4 new tests in `CSMT.Verify.CompletenessSpec` for the
     absent-prefix case: matching root accepts, wrong prefix
     rejects, non-empty leaves rejects, tampered root rejects.

## What I deliberately did NOT do

The whole-tree-emptiness case (column truly empty, prefix
trivially absent) still returns `Nothing` from `generateProof`.
`verifyExclusionProof` on `ExclusionEmpty` is unconditionally
`True` today, so a `CompletenessEmpty ExclusionEmpty` proof would
verify against any trusted root — sound only if paired with a
separate "trusted root is the empty-tree sentinel" check, which
the current MTS interface does not carry. Until the empty-tree
root convention is settled, treating this case as "no proof
generated" preserves soundness. The cardano-mpfs-offchain use
case (#243) doesn't exercise this — every cage prefix sits
inside a populated tree.

## Test plan

- [x] `nix develop --quiet -c just ci` passes locally
- [x] 511 unit tests pass (was 507 — 4 new empty-prefix cases)
- [x] Lean proofs build clean
- [x] `cabal check` passes (one warning was already there)
- [x] Existing populated-prefix tests still pass under the new
  type/codec