### PR TITLE
fix: verifyCompletenessProof accepts absolute-key leaves under non-empty prefix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,7 @@
     };
   };
 
-  outputs =
-    inputs@{ self, nixpkgs, flake-utils, haskellNix, mkdocs, asciinema
+  outputs = inputs@{ self, nixpkgs, flake-utils, haskellNix, mkdocs, asciinema
     , ghc-wasm-meta, ... }:
     let
       lib = nixpkgs.lib;

--- a/lib/csmt-core/CSMT/Core/Completeness.hs
+++ b/lib/csmt-core/CSMT/Core/Completeness.hs
@@ -29,6 +29,7 @@ module CSMT.Core.Completeness
     , foldMergeOps
     ) where
 
+import Data.List (isPrefixOf)
 import Data.Map.Strict qualified as Map
 
 import CSMT.Core.Proof (ProofStep (..))
@@ -95,17 +96,22 @@ foldMergeOps compose values = go (Map.fromList $ zip [0 ..] values)
 -- | Verify a completeness proof by computing the tree root hash.
 --
 -- The verifier provides the prefix (which they chose) and the
--- leaves (which they received). The root jump is derived from
--- the prefix, the subtree jump, and the inclusion step consumed
--- counts.
+-- leaves (which they received). Each leaf's @jump@ field is the
+-- *absolute* key in the column — it MUST start with @prefixKey@.
+-- The fold strips the prefix internally before reconstructing
+-- the subtree root, then walks the inclusion steps back to the
+-- column root.
 --
--- Returns 'Nothing' if the proof is malformed.
+-- Returns 'Nothing' if any leaf's jump does not start with
+-- @prefixKey@, if the merge fold fails, or if the proof is
+-- otherwise malformed.
 foldCompletenessProof
     :: Hashing a
     -> Key
     -- ^ The prefix this proof covers (verifier provides this)
     -> [Indirect a]
-    -- ^ Leaves under the prefix
+    -- ^ Leaves under the prefix, with jumps in absolute form
+    -- (each jump starts with @prefixKey@)
     -> CompletenessProof a
     -> Maybe a
     -- ^ Computed tree root hash
@@ -114,11 +120,23 @@ foldCompletenessProof
     prefixKey
     leaves
     CompletenessProof{cpMergeOps, cpInclusionSteps} = do
-        subtreeRoot <- case leaves of
+        relativeLeaves <- traverse (stripLeafPrefix prefixKey) leaves
+        subtreeRoot <- case relativeLeaves of
             [single] | null cpMergeOps -> Just single
-            _ -> foldMergeOps (combineHash hashing) leaves cpMergeOps
-        let Indirect subtreeJump subtreeValue = subtreeRoot
-            fullKey = prefixKey ++ subtreeJump
+            [] -> Nothing
+            _ ->
+                foldMergeOps
+                    (combineHash hashing)
+                    relativeLeaves
+                    cpMergeOps
+        let Indirect subtreeJumpRel subtreeValue = subtreeRoot
+            -- 'subtreeJumpRel' is the part of the subtree node's
+            -- absolute key beyond @prefixKey@. The full absolute
+            -- key for the subtree node is therefore
+            -- @prefixKey ++ subtreeJumpRel@; that is what the
+            -- inclusion-step consumed counts walk back to the
+            -- column root.
+            fullKey = prefixKey ++ subtreeJumpRel
             totalConsumed =
                 sum (map stepConsumed cpInclusionSteps)
             rootJumpLen = length fullKey - totalConsumed
@@ -131,6 +149,13 @@ foldCompletenessProof
                     (reverse keyAfterRoot)
                     cpInclusionSteps
         pure $ rootHash hashing (Indirect rootJump rootValue)
+      where
+        stripLeafPrefix
+            :: Key -> Indirect a -> Maybe (Indirect a)
+        stripLeafPrefix p (Indirect jmp val)
+            | p `isPrefixOf` jmp =
+                Just (Indirect (drop (length p) jmp) val)
+            | otherwise = Nothing
 
 -- | Fold inclusion steps from subtree outward to root.
 --

--- a/lib/csmt-write/CSMT/Proof/Completeness.hs
+++ b/lib/csmt-write/CSMT/Proof/Completeness.hs
@@ -53,6 +53,12 @@ import Database.KV.Transaction
 -- Navigates from the tree root to the target prefix, handling path
 -- compression (jumps that span beyond the prefix). Once the prefix
 -- is consumed, collects all leaves below that point.
+--
+-- Each returned 'Indirect' carries its *absolute* key (within the
+-- column) in the @jump@ field — i.e. starting with @targetPrefix@.
+-- This matches what 'foldCompletenessProof' / 'verifyCompletenessProof'
+-- expect, so callers can hand the result straight to the verifier
+-- alongside the same prefix they passed here.
 collectValues
     :: (Monad m, GCompare d)
     => Selector d Key (Indirect a)
@@ -60,7 +66,9 @@ collectValues
     -- ^ Prefix (use @[]@ for root)
     -> Key
     -> Transaction m cf d op [Indirect a]
-collectValues sel = navigate
+collectValues sel pfx targetPrefix = do
+    raw <- navigate pfx targetPrefix
+    pure (map (prefix targetPrefix) raw)
   where
     navigate currentKey remainingPrefix = do
         mi <- query sel currentKey

--- a/nix/wasm-packages.nix
+++ b/nix/wasm-packages.nix
@@ -1,9 +1,7 @@
 { pkgs, src, mkdocsAssets, fixtures, wasmBuild }:
 let
   mkWasmModule = pname: file:
-    pkgs.runCommand pname {
-      preferLocalBuild = true;
-    } ''
+    pkgs.runCommand pname { preferLocalBuild = true; } ''
       mkdir -p $out
       cp ${wasmBuild.wasm}/${file} $out/${file}
     '';

--- a/test/CSMT/Verify/CompletenessSpec.hs
+++ b/test/CSMT/Verify/CompletenessSpec.hs
@@ -25,6 +25,7 @@ import CSMT.Hashes (Hash, hashHashing, mkHash, renderHash)
 import CSMT.Interface (Hashing (..), Indirect (..))
 import CSMT.Proof.Completeness
     ( CompletenessProof
+    , collectValues
     , generateProof
     )
 import CSMT.Test.Lib
@@ -149,3 +150,94 @@ spec = describe "csmt-verify completeness" $ do
                 let bs = renderCompletenessProof proof
                 in  Verify.parseCompletenessProof bs `shouldBe` Just proof
             Nothing -> error "expected a proof"
+
+    -- See https://github.com/lambdasistemi/haskell-mts/issues/157.
+    -- The verifier's contract is "leaf jumps are absolute (within
+    -- the column) — they start with @prefixKey@". Two cases must
+    -- agree: leaves built manually from KV-row bytes (the
+    -- cardano-mpfs-offchain consumer's natural form) and leaves
+    -- returned by 'collectValues' (now also absolute).
+    describe "non-empty prefix populated case (issue #157)" $ do
+        let prefixKey :: [Direction]
+            prefixKey = [L, R, L, R]
+            -- Two leaves under the prefix; absolute keys of length
+            -- 8 (4 bits prefix + 4 bits suffix).
+            leafKeyA, leafKeyB :: [Direction]
+            leafKeyA = prefixKey ++ [L, L, L, L]
+            leafKeyB = prefixKey ++ [R, R, R, R]
+            valA = mkHash "leaf-A"
+            valB = mkHash "leaf-B"
+            absoluteLeaves =
+                [ indirect leafKeyA valA
+                , indirect leafKeyB valB
+                ]
+            (mp, mr, collectedAbs) = evalPureFromEmptyDB $ do
+                insertHashes absoluteLeaves
+                proof <-
+                    runPureTransaction hashCodecs
+                        $ generateProof
+                            StandaloneCSMTCol
+                            []
+                            prefixKey
+                rootI <-
+                    runPureTransaction hashCodecs
+                        $ query StandaloneCSMTCol []
+                collected <-
+                    runPureTransaction hashCodecs
+                        $ collectValues
+                            StandaloneCSMTCol
+                            []
+                            prefixKey
+                pure
+                    ( proof :: Maybe (CompletenessProof Hash)
+                    , rootI
+                    , collected
+                    )
+
+        it "verifies with collectValues output (absolute jumps)" $ do
+            case (mp, mr) of
+                (Just proof, Just rootI) -> do
+                    let rootBs =
+                            renderHash (rootHash hashHashing rootI)
+                        proofBs = renderCompletenessProof proof
+                    Verify.verifyCompletenessProof
+                        rootBs
+                        prefixKey
+                        (sort collectedAbs)
+                        proofBs
+                        `shouldBe` True
+                _ -> error "expected proof + root"
+
+        it "verifies with consumer-built absolute-key leaves" $ do
+            case (mp, mr) of
+                (Just proof, Just rootI) -> do
+                    let rootBs =
+                            renderHash (rootHash hashHashing rootI)
+                        proofBs = renderCompletenessProof proof
+                    Verify.verifyCompletenessProof
+                        rootBs
+                        prefixKey
+                        (sort absoluteLeaves)
+                        proofBs
+                        `shouldBe` True
+                _ -> error "expected proof + root"
+
+        it "rejects leaves whose jumps don't start with the prefix"
+            $ case (mp, mr) of
+                (Just proof, Just rootI) -> do
+                    let rootBs =
+                            renderHash (rootHash hashHashing rootI)
+                        proofBs = renderCompletenessProof proof
+                        -- Strip the prefix bits — these are NOT
+                        -- absolute, so the verifier must reject.
+                        relativeLeaves =
+                            [ indirect [L, L, L, L] valA
+                            , indirect [R, R, R, R] valB
+                            ]
+                    Verify.verifyCompletenessProof
+                        rootBs
+                        prefixKey
+                        (sort relativeLeaves)
+                        proofBs
+                        `shouldBe` False
+                _ -> error "expected proof + root"


### PR DESCRIPTION
Closes https://github.com/lambdasistemi/haskell-mts/issues/157
Unblocks https://github.com/cardano-foundation/cardano-mpfs-offchain/pull/245 (slice 2 of #243)

## Summary

The `verifyCompletenessProof` API contract was implicit: it
expected each leaf's `jump` field to be **relative** to
`prefixKey`. That happens to be what `collectValues` returned
— but consumers like `cardano-mpfs-offchain` build leaves
manually from KV-row bytes, where the natural `jump` is the
**absolute** key. With `prefixKey = []` the two coincided, so
all upstream tests passed; with a non-empty (per-cage) prefix
honest proofs were rejected.

Fix: make the contract explicit and consumer-friendly — leaves'
jumps must be **absolute (within the column)**, i.e. start with
`prefixKey`. `foldCompletenessProof` strips the prefix
internally and rejects any leaf whose jump fails the prefix
check (a free correctness guarantee that the leaves really do
live under the claimed prefix). `collectValues` is updated to
return absolute jumps too, so the same data flows from
`generateProof`/`collectValues` straight into the verifier
without any client-side massaging.

## Wire format

**Unchanged.** The proof bytes (`mergeOps` + `inclusionSteps`)
do not carry leaves. Only the function-boundary semantics shift.

## Diff surface

- `lib/csmt-core/CSMT/Core/Completeness.hs` — `foldCompletenessProof` strips `prefixKey` from each leaf, rejects bad ones, threads relative form through the merge fold, then reconstructs `fullKey = prefixKey ++ subtreeJumpRel` for the inclusion-step walk.
- `lib/csmt-write/CSMT/Proof/Completeness.hs` — `collectValues` prepends `targetPrefix` to each returned leaf via the existing `prefix` helper. With `targetPrefix = []` (the MTS path) this is a no-op.
- `test/CSMT/Verify/CompletenessSpec.hs` — three regression tests under "non-empty prefix populated case (issue #157)": collectValues output verifies, consumer-built absolute leaves verify, relative-jump leaves are rejected.

## Test plan

- [x] `nix develop --quiet -c just ci` passes locally
- [x] 510 unit tests pass (existing populated tests + 3 new #157 regression tests; one pending preserved)
- [x] All existing populated-prefix tests (`CSMT.Proof.CompletenessSpec`, `CSMT.TreePrefixSpec`, `MTS.Property completeness round-trip`) still pass — they used `collectValues` output and now receive absolute jumps which the new fold accepts.
- [x] Lean proofs build clean
- [x] `cabal check` clean