### PR TITLE
Use localhost PR preview checks

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,4 +1,4 @@
-name: PR preview (WASM demo on Surge)
+name: PR preview check (WASM demos on localhost)
 
 on:
   pull_request:
@@ -27,50 +27,31 @@ jobs:
       - name: Build WASM MPF write demo
         run: nix --quiet build .#mpf-wasm-write-demo -o result-mpf-write-demo
 
-      - name: Deploy to Surge
+      - name: Prepare preview site
         run: |
-          mkdir -p surge-site
-          cp -L result-demo/* surge-site/
-          mkdir -p surge-site/write-csmt
-          cp -L result-write-demo/* surge-site/write-csmt/
-          mkdir -p surge-site/write-mpf
-          cp -L result-mpf-write-demo/* surge-site/write-mpf/
-          chmod -R u+w surge-site
-          nix --quiet shell nixpkgs#nodePackages.surge -c surge \
-            surge-site \
-            ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh \
-            --token ${{ secrets.SURGE_TOKEN }}
+          mkdir -p preview-site
+          cp -L result-demo/* preview-site/
+          mkdir -p preview-site/write-csmt
+          cp -L result-write-demo/* preview-site/write-csmt/
+          mkdir -p preview-site/write-mpf
+          cp -L result-mpf-write-demo/* preview-site/write-mpf/
+          chmod -R u+w preview-site
 
-      - name: Comment preview URL on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const url = `https://${context.repo.owner}-${context.repo.repo}-pr-${context.issue.number}.surge.sh`;
-            const marker = '<!-- surge-preview-url -->';
-            const body = [
-              marker,
-              `Verify demo (read side): ${url}`,
-              `Build + prove + verify demo (CSMT write side): ${url}/write-csmt/`,
-              `Build + prove + verify demo (MPF write side): ${url}/write-mpf/`,
-            ].join('\n');
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+      - name: Smoke test demos on localhost
+        run: |
+          nix --quiet shell nixpkgs#python3 nixpkgs#curl -c bash -euo pipefail <<'SCRIPT'
+          python3 -m http.server 4173 --bind 127.0.0.1 --directory preview-site &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4173/ >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          curl -fsS http://127.0.0.1:4173/ >/dev/null
+          curl -fsS http://127.0.0.1:4173/write-csmt/ >/dev/null
+          curl -fsS http://127.0.0.1:4173/write-mpf/ >/dev/null
+          SCRIPT


### PR DESCRIPTION
## Summary
- replace WASM demo PR preview deployment with localhost smoke checks on the `nixos` runner
- remove external preview-service CLI and PR comment usage

## Verification
- `nix run nixpkgs#actionlint -- -ignore 'label "nixos" is unknown' .github/workflows/pr-preview.yaml`\n- `rg -n "surge\\.sh|SURGE_TOKEN|SURGE_LOGIN|nodePackages\\.surge|npx .*surge|\\bSurge\\b|\\bsurge\\b" .github/workflows README.md` returned no matches