### PR TITLE
feat(mpf-test-lib): build on pure mpf-write so it cross-compiles to wasm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
               # Nix reports the real hash via a fixed-output hash
               # mismatch — replace this literal.
               dependenciesHash =
-                "sha256-SFSSjHHtQa6ZzcjewMNxKLw8K1s/Qf+VyHSSXeDQtng=";
+                "sha256-wjsKzZxunTciN3YkY+0f9v3OA2e0qF9W1VdxNCFDHWQ=";
             }
           else
             null;

--- a/mts.cabal
+++ b/mts.cabal
@@ -370,15 +370,12 @@ library mpf-test-lib
     , base                                     >=4.19 && <5
     , bytestring                               >=0.12 && <0.13
     , lens                                     >=5.3  && <5.4
-    , mts:mpf
+    , mts:mpf-write
     , rocksdb-kv-transactions:kv-transactions
     , text                                     >=2.1  && <2.2
 
   hs-source-dirs:   test-lib/mpf
   default-language: Haskell2010
-
-  if flag(wasm)
-    buildable: False
 
 executable mts
   import:           warnings

--- a/nix/wasm.nix
+++ b/nix/wasm.nix
@@ -132,7 +132,8 @@ let
           csmt-verify-wasm \
           csmt-write-wasm \
           mpf-verify-wasm \
-          mpf-write-wasm
+          mpf-write-wasm \
+          mts:mpf-test-lib
     '';
 
     installPhase = ''
@@ -178,11 +179,17 @@ let
 
     buildPhase = ''
       export CABAL_DIR=$NIX_BUILD_TOP/cabal
+      # mts:mpf-test-lib is a library, not a wasm executable, so it emits no
+      # .wasm artifact — building it here is the regression guard that proves
+      # MPF.Test.Lib (pure mpf-write, no rocksdb mpf) cross-compiles to
+      # wasm32-wasi. If the `flag(wasm) buildable: False` gate ever returns or
+      # mpf-write breaks the pure path, this build fails loudly.
       wasm32-wasi-cabal --project-file=${projectFile} build \
         csmt-verify-wasm \
         csmt-write-wasm \
         mpf-verify-wasm \
-        mpf-write-wasm
+        mpf-write-wasm \
+        mts:mpf-test-lib
     '';
 
     installPhase = ''


### PR DESCRIPTION
## What

`mpf-test-lib` now depends on the pure **`mts:mpf-write`** sub-library
instead of the rocksdb-bound `mts:mpf`, and the `if flag(wasm) buildable:
False` gate is removed.

## Why

`MPF.Test.Lib` is entirely pure: every module it imports
(`MPF.Backend.Pure`/`Standalone`, `MPF.Deletion`, `MPF.Hashes`,
`MPF.Insertion[.*]`, `MPF.Interface`, `MPF.Proof.*`) is exposed by
`mpf-write`, and it uses only the pure `kv-transactions` interface. The
dependency on `mts:mpf` and the wasm gate were legacy, not functional — they
forced pure consumers off the cross-target path.

This lets cross-target consumers (wasm32-wasi / GHC-JS) use the pure MPF
in-memory utilities. Specifically it unblocks `cardano-mpfs-cage`'s
`Cardano.MPFS.Cage.Trie.Pure` in the MPFS cage-helper wasm build
(lambdasistemi/cardano-mpfs-offchain#258).

## Validation

`cabal build mts:mpf-test-lib -f wasm` compiles `MPF.Test.Lib` against
`mpf-write` only (rocksdb `mpf` excluded by the flag). Native/default builds
unchanged.