### PR TITLE
fix(csmt): emit completeness inclusion steps in subtree-to-root order

### DIFF
--- a/lib/csmt-write/CSMT/Insertion.hs
+++ b/lib/csmt-write/CSMT/Insertion.hs
@@ -58,6 +58,7 @@ import Data.List (foldl')
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 
+import CSMT.Deletion (deletingTreeOnly)
 import CSMT.Interface
     ( Direction (..)
     , FromKV (..)
@@ -68,6 +69,7 @@ import CSMT.Interface
     , oppositeDirection
     )
 import Control.Lens (view)
+import Control.Monad (forM_)
 import Database.KV.Transaction
     ( GCompare
     , Selector
@@ -117,7 +119,10 @@ inserting
     -> k
     -> v
     -> Transaction m cf d ops ()
-inserting pfx FromKV{isoK, fromV, treePrefix} hashing kVCol csmtCol k v = do
+inserting pfx fromKV@FromKV{isoK, fromV, treePrefix} hashing kVCol csmtCol k v = do
+    mOld <- query kVCol k
+    forM_ mOld $ \old ->
+        deletingTreeOnly pfx fromKV hashing csmtCol k old
     insert kVCol k v
     let treeKey = treePrefix v <> view isoK k
     c <- buildComposeTree csmtCol pfx treeKey (fromV v)

--- a/lib/csmt-write/CSMT/Insertion.hs
+++ b/lib/csmt-write/CSMT/Insertion.hs
@@ -32,6 +32,7 @@ module CSMT.Insertion
     ( -- * Single insertion
       inserting
     , insertingTreeOnly
+    , updatingTreeOnly
 
       -- * Batch insertion
     , insertingBatch
@@ -69,7 +70,7 @@ import CSMT.Interface
     , oppositeDirection
     )
 import Control.Lens (view)
-import Control.Monad (forM_)
+import Control.Monad (forM_, when)
 import Database.KV.Transaction
     ( GCompare
     , Selector
@@ -144,6 +145,26 @@ insertingTreeOnly pfx FromKV{isoK, fromV, treePrefix} hashing csmtCol k v = do
     let treeKey = treePrefix v <> view isoK k
     c <- buildComposeTree csmtCol pfx treeKey (fromV v)
     mapM_ (uncurry $ insert csmtCol) $ snd $ scanCompose pfx hashing c
+
+-- | Update the tree column only (no KV write).
+-- Used during journal replay when KV is already up to date.
+-- When the value-derived prefix changes, the old leaf must be
+-- removed before the replacement leaf is inserted.
+updatingTreeOnly
+    :: (Monad m, GCompare d)
+    => Key
+    -- ^ Prefix (use @[]@ for root)
+    -> FromKV k v a
+    -> Hashing a
+    -> Selector d Key (Indirect a)
+    -> k
+    -> v
+    -> v
+    -> Transaction m cf d ops ()
+updatingTreeOnly pfx fromKV@FromKV{treePrefix} hashing csmtCol k old new = do
+    when (treePrefix old /= treePrefix new)
+        $ deletingTreeOnly pfx fromKV hashing csmtCol k old
+    insertingTreeOnly pfx fromKV hashing csmtCol k new
 
 -- |
 -- Scan a Compose tree bottom-up, computing hashes and collecting database operations.

--- a/lib/csmt-write/CSMT/MTS.hs
+++ b/lib/csmt-write/CSMT/MTS.hs
@@ -216,18 +216,32 @@ type instance MtsCompletenessProof CsmtImpl = CompletenessProof Hash
 type instance MtsPrefix CsmtImpl = Key
 
 -- | Journal entry tag bytes.
-journalInsertTag, journalUpdateTag, journalDeleteTag :: ByteString
+journalInsertTag
+    , journalUpdateTag
+    , journalUpdateOldNewTag
+    , journalDeleteTag
+        :: ByteString
 journalInsertTag = B.singleton 0x01
 journalUpdateTag = B.singleton 0x02
+journalUpdateOldNewTag = B.singleton 0x03
 journalDeleteTag = B.singleton 0x00
 
 -- | Encode a journal insert entry (new key): @0x01 ++ value@.
 encodeJournalInsert :: ByteString -> ByteString
 encodeJournalInsert v = journalInsertTag <> v
 
--- | Encode a journal update entry (overwrite): @0x02 ++ value@.
-encodeJournalUpdate :: ByteString -> ByteString
-encodeJournalUpdate v = journalUpdateTag <> v
+-- | Encode a legacy journal update entry: @0x02 ++ value@.
+encodeJournalUpdateLegacy :: ByteString -> ByteString
+encodeJournalUpdateLegacy v = journalUpdateTag <> v
+
+-- | Encode a journal update entry with the old CSMT value
+-- and the replacement KV value.
+encodeJournalUpdate :: ByteString -> ByteString -> ByteString
+encodeJournalUpdate old new =
+    journalUpdateOldNewTag
+        <> encodeLength (B.length old)
+        <> old
+        <> new
 
 -- | Encode a journal delete entry: @0x00 ++ oldValue@.
 encodeJournalDelete :: ByteString -> ByteString
@@ -241,13 +255,47 @@ encodeJournalDelete v = journalDeleteTag <> v
 data JournalTag = JInsert | JUpdate | JDelete
     deriving stock (Eq)
 
+data JournalEntry
+    = JournalInsert ByteString
+    | JournalUpdateLegacy ByteString
+    | JournalUpdate ByteString ByteString
+    | JournalDelete ByteString
+
+encodeLength :: Int -> ByteString
+encodeLength n =
+    B.pack
+        [ fromIntegral $ n `div` 16777216
+        , fromIntegral $ n `div` 65536
+        , fromIntegral $ n `div` 256
+        , fromIntegral n
+        ]
+
+decodeLength :: ByteString -> Int
+decodeLength =
+    B.foldl' (\acc w -> acc * 256 + fromIntegral w) 0
+
+parseJournalReplayEntry :: ByteString -> JournalEntry
+parseJournalReplayEntry bs = case B.uncons bs of
+    Just (0x01, rest) -> JournalInsert rest
+    Just (0x02, rest) -> JournalUpdateLegacy rest
+    Just (0x03, rest) ->
+        let (lenBytes, payload) = B.splitAt 4 rest
+            oldLen = decodeLength lenBytes
+            (old, new) = B.splitAt oldLen payload
+        in  if B.length lenBytes /= 4 || B.length old /= oldLen
+                then error "parseJournalEntry: invalid update payload"
+                else JournalUpdate old new
+    Just (0x00, rest) -> JournalDelete rest
+    _ -> error "parseJournalEntry: invalid tag byte"
+
 -- | Parse a journal entry into tag + value payload.
 parseJournalEntry :: ByteString -> (JournalTag, ByteString)
-parseJournalEntry bs = case B.uncons bs of
-    Just (0x01, rest) -> (JInsert, rest)
-    Just (0x02, rest) -> (JUpdate, rest)
-    Just (0x00, rest) -> (JDelete, rest)
-    _ -> error "parseJournalEntry: invalid tag byte"
+parseJournalEntry bs =
+    case parseJournalReplayEntry bs of
+        JournalInsert v -> (JInsert, v)
+        JournalUpdateLegacy v -> (JUpdate, v)
+        JournalUpdate _ new -> (JUpdate, new)
+        JournalDelete v -> (JDelete, v)
 
 -- ------------------------------------------------------------------
 -- Crash recovery sentinel
@@ -656,18 +704,22 @@ csmtKVOnlyStoreT _fromKV =
             { mtsInsert = \k v -> do
                 mj <- query StandaloneJournalCol k
                 existing <- query StandaloneKVCol k
-                let tag = case mj of
-                        Just jv -> case fst $ parseJournalEntry jv of
-                            JInsert -> JInsert
-                            JUpdate -> JUpdate
-                            JDelete -> JUpdate
-                        Nothing -> case existing of
-                            Nothing -> JInsert
-                            Just _ -> JUpdate
+                let journalValue =
+                        case parseJournalReplayEntry <$> mj of
+                            Just (JournalInsert _) ->
+                                encodeJournalInsert v
+                            Just (JournalUpdate old _) ->
+                                encodeJournalUpdate old v
+                            Just (JournalUpdateLegacy _) ->
+                                encodeJournalUpdateLegacy v
+                            Just (JournalDelete old) ->
+                                encodeJournalUpdate old v
+                            Nothing ->
+                                case existing of
+                                    Nothing -> encodeJournalInsert v
+                                    Just old -> encodeJournalUpdate old v
                 insert StandaloneKVCol k v
-                insert StandaloneJournalCol k $ case tag of
-                    JInsert -> encodeJournalInsert v
-                    _ -> encodeJournalUpdate v
+                insert StandaloneJournalCol k journalValue
                 -- Metrics: new KV key → kvCount +1
                 when (isNothing existing)
                     $ adjustCounter
@@ -691,8 +743,8 @@ csmtKVOnlyStoreT _fromKV =
                             kvCountKey
                             (-1)
                         mj <- query StandaloneJournalCol k
-                        case fmap (fst . parseJournalEntry) mj of
-                            Just JInsert -> do
+                        case parseJournalReplayEntry <$> mj of
+                            Just (JournalInsert _) -> do
                                 delete StandaloneJournalCol k
                                 adjustCounter
                                     StandaloneMetricsCol
@@ -707,11 +759,21 @@ csmtKVOnlyStoreT _fromKV =
                                     StandaloneMetricsCol
                                     journalSizeKey
                                     1
-                            _ ->
+                            Just (JournalUpdate old _) ->
+                                insert
+                                    StandaloneJournalCol
+                                    k
+                                    (encodeJournalDelete old)
+                            Just (JournalUpdateLegacy _) ->
                                 insert
                                     StandaloneJournalCol
                                     k
                                     (encodeJournalDelete v)
+                            Just (JournalDelete old) ->
+                                insert
+                                    StandaloneJournalCol
+                                    k
+                                    (encodeJournalDelete old)
             , mtsMetrics =
                 readMetricsT StandaloneMetricsCol
             }
@@ -983,10 +1045,9 @@ replayEntries prefix fromKV hashing entries = do
         entries
   where
     applyEntry e =
-        let (tag, v) = parseJournalEntry (entryValue e)
-            k = entryKey e
-        in  case tag of
-                JInsert ->
+        let k = entryKey e
+        in  case parseJournalReplayEntry (entryValue e) of
+                JournalInsert v ->
                     insertingTreeOnly
                         prefix
                         fromKV
@@ -994,7 +1055,7 @@ replayEntries prefix fromKV hashing entries = do
                         StandaloneCSMTCol
                         k
                         v
-                JUpdate ->
+                JournalUpdateLegacy v ->
                     insertingTreeOnly
                         prefix
                         fromKV
@@ -1002,7 +1063,22 @@ replayEntries prefix fromKV hashing entries = do
                         StandaloneCSMTCol
                         k
                         v
-                JDelete ->
+                JournalUpdate old new -> do
+                    deletingTreeOnly
+                        prefix
+                        fromKV
+                        hashing
+                        StandaloneCSMTCol
+                        k
+                        old
+                    insertingTreeOnly
+                        prefix
+                        fromKV
+                        hashing
+                        StandaloneCSMTCol
+                        k
+                        new
+                JournalDelete v ->
                     deletingTreeOnly
                         prefix
                         fromKV
@@ -1121,32 +1197,44 @@ mkKVOnlyOps
                       --
                       -- INSERT (journal × KV → journal'):
                       --   Nothing × Nothing → JInsert  (new key)
-                      --   Nothing × Just _  → JUpdate  (key from CSMT)
+                      --   Nothing × Just old
+                      --     → JUpdate old new (key from CSMT)
                       --   JInsert × _       → JInsert  (still new)
-                      --   JUpdate × _       → JUpdate  (still CSMT)
-                      --   JDelete × _       → JUpdate  (re-insert, CSMT has it)
+                      --   JUpdate old _ × _
+                      --     → JUpdate old new (still CSMT)
+                      --   JDelete old × _
+                      --     → JUpdate old new (re-insert, CSMT has it)
                       --
                       -- DELETE (journal → journal'):
                       --   Nothing           → JDelete  (key from CSMT)
                       --   JInsert           → ∅ elide   (new, not in CSMT)
-                      --   JUpdate           → JDelete  (CSMT key removed)
+                      --   JUpdate old _     → JDelete old
                       --   JDelete           → ⊥         (KV empty, unreachable)
                       opsInsert = \k v -> do
                         mj <- query journalCol k
                         existing <- query kvCol k
                         let encoded = view journalIso v
-                            tag = case mj of
-                                Just jv -> case fst $ parseJournalEntry jv of
-                                    JInsert -> JInsert
-                                    JUpdate -> JUpdate
-                                    JDelete -> JUpdate
-                                Nothing -> case existing of
-                                    Nothing -> JInsert
-                                    Just _ -> JUpdate
+                            journalValue =
+                                case parseJournalReplayEntry <$> mj of
+                                    Just (JournalInsert _) ->
+                                        encodeJournalInsert encoded
+                                    Just (JournalUpdate old _) ->
+                                        encodeJournalUpdate old encoded
+                                    Just (JournalUpdateLegacy _) ->
+                                        encodeJournalUpdateLegacy encoded
+                                    Just (JournalDelete old) ->
+                                        encodeJournalUpdate old encoded
+                                    Nothing ->
+                                        case existing of
+                                            Nothing ->
+                                                encodeJournalInsert
+                                                    encoded
+                                            Just old ->
+                                                encodeJournalUpdate
+                                                    (view journalIso old)
+                                                    encoded
                         insert kvCol k v
-                        insert journalCol k $ case tag of
-                            JInsert -> encodeJournalInsert encoded
-                            _ -> encodeJournalUpdate encoded
+                        insert journalCol k journalValue
                         -- New journal entry → journalSize +1
                         when (isNothing mj)
                             $ adjustCounter
@@ -1160,8 +1248,8 @@ mkKVOnlyOps
                             Just v -> do
                                 delete kvCol k
                                 mj <- query journalCol k
-                                case fmap (fst . parseJournalEntry) mj of
-                                    Just JInsert -> do
+                                case parseJournalReplayEntry <$> mj of
+                                    Just (JournalInsert _) -> do
                                         delete journalCol k
                                         adjustCounter
                                             metricsCol
@@ -1178,13 +1266,23 @@ mkKVOnlyOps
                                             metricsCol
                                             journalSizeKey
                                             1
-                                    _ ->
+                                    Just (JournalUpdate old _) ->
+                                        insert
+                                            journalCol
+                                            k
+                                            (encodeJournalDelete old)
+                                    Just (JournalUpdateLegacy _) ->
                                         insert
                                             journalCol
                                             k
                                             ( encodeJournalDelete
                                                 (view journalIso v)
                                             )
+                                    Just (JournalDelete old) ->
+                                        insert
+                                            journalCol
+                                            k
+                                            (encodeJournalDelete old)
                     , opsQuery = query kvCol
                     }
             , toFull = do
@@ -1248,10 +1346,14 @@ mkKVOnlyOps
                 else do
                     let n = length entries
                         remaining' = remaining - n
-                        ops =
-                            journalEntriesToPatchOps
+                        (updateTxns, ops) =
+                            journalEntriesToReplayWork
                                 journalIso
                                 fromKV
+                                hashing
+                                csmtCol
+                                journalCol
+                                prefix
                                 entries
                         bucketTxns =
                             patchParallel
@@ -1271,6 +1373,7 @@ mkKVOnlyOps
                             , rsEntriesRemaining =
                                 remaining'
                             }
+                    mapM_ runTxReplay updateTxns
                     mapConcurrently_
                         (runTxReplay . snd)
                         bucketTxns
@@ -1390,6 +1493,92 @@ readJournalChunkT journalCol chunkSize = do
                 | otherwise ->
                     collectN (chunkSize - 1) [e]
     pure [(entryKey e, entryValue e) | e <- entries]
+
+-- | Convert journal entries into replay work.
+--
+-- Inserts and deletes can be replayed through bucketed
+-- 'patchParallel'. Updates need one atomic transaction because the
+-- old and new value-derived tree keys may belong to different
+-- buckets; deleting the journal entry before both tree operations
+-- complete would lose the update during crash recovery.
+journalEntriesToReplayWork
+    :: (Monad m, GCompare d, Ord k)
+    => Iso' v ByteString
+    -- ^ Journal value serialization
+    -> FromKV k v a
+    -> Hashing a
+    -> Selector d Key (Indirect a)
+    -- ^ CSMT column
+    -> Selector d k ByteString
+    -- ^ Journal column
+    -> Key
+    -- ^ Prefix
+    -> [(k, ByteString)]
+    -- ^ (journal key, encoded journal value)
+    -> ( [Transaction m cf d op ()]
+       , [(k, PatchOp Key a)]
+       )
+journalEntriesToReplayWork
+    journalIso
+    fromKV
+    hashing
+    csmtCol
+    journalCol
+    prefix =
+        foldr convert ([], [])
+      where
+        treeKey v =
+            treePrefix fromKV v
+
+        convert (k, raw) (txns, ops) =
+            case parseJournalReplayEntry raw of
+                JournalInsert serializedV ->
+                    ( txns
+                    , patchInsert k serializedV : ops
+                    )
+                JournalUpdateLegacy serializedV ->
+                    ( txns
+                    , patchInsert k serializedV : ops
+                    )
+                JournalUpdate serializedOld serializedNew ->
+                    let old = review journalIso serializedOld
+                        new = review journalIso serializedNew
+                        txn = do
+                            deletingTreeOnly
+                                prefix
+                                fromKV
+                                hashing
+                                csmtCol
+                                k
+                                old
+                            insertingTreeOnly
+                                prefix
+                                fromKV
+                                hashing
+                                csmtCol
+                                k
+                                new
+                            delete journalCol k
+                    in  (txn : txns, ops)
+                JournalDelete serializedV ->
+                    ( txns
+                    , patchDelete k serializedV : ops
+                    )
+
+        patchInsert k serializedV =
+            let v = review journalIso serializedV
+            in  ( k
+                , PatchInsert
+                    (treeKey v <> view (isoK fromKV) k)
+                    (fromV fromKV v)
+                )
+
+        patchDelete k serializedV =
+            let v = review journalIso serializedV
+            in  ( k
+                , PatchDelete
+                    (treeKey v <> view (isoK fromKV) k)
+                )
 
 -- | Convert journal entries to 'PatchOp' pairs for
 -- 'patchParallel'.

--- a/lib/csmt-write/CSMT/MTS.hs
+++ b/lib/csmt-write/CSMT/MTS.hs
@@ -85,13 +85,22 @@ import CSMT.Backend.Standalone
     , StandaloneCF
     , StandaloneOp
     )
-import CSMT.Deletion (deleteSubtree, deleting, deletingTreeOnly)
+import CSMT.Deletion
+    ( deleteSubtree
+    , deleting
+    , deletingDirect
+    , deletingTreeOnly
+    )
 import CSMT.Hashes (Hash)
 import CSMT.Insertion
-    ( expandToBucketDepth
+    ( allPrefixes
+    , bucketIndex
+    , expandToBucketDepth
     , inserting
+    , insertingDirect
     , insertingTreeOnly
     , mergeSubtreeRoots
+    , updatingTreeOnly
     )
 import CSMT.Interface
     ( FromKV (..)
@@ -121,6 +130,8 @@ import Control.Monad (unless, when)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.List (foldl')
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Serialize (getWord8, putWord8)
 import Data.Serialize.Extra (evalGetM, evalPutM)
@@ -247,20 +258,13 @@ encodeJournalUpdate old new =
 encodeJournalDelete :: ByteString -> ByteString
 encodeJournalDelete v = journalDeleteTag <> v
 
--- | Tag for journal entry.
---
--- * 'JInsert' — new key, not in CSMT (safe to elide on delete)
--- * 'JUpdate' — overwrite of key already in CSMT
--- * 'JDelete' — key removed, CSMT needs to delete it
-data JournalTag = JInsert | JUpdate | JDelete
-    deriving stock (Eq)
-
 data JournalEntry
     = JournalInsert ByteString
     | JournalUpdateLegacy ByteString
     | JournalUpdate ByteString ByteString
     | JournalDelete ByteString
 
+-- | Encode a big-endian 32-bit byte length.
 encodeLength :: Int -> ByteString
 encodeLength n =
     B.pack
@@ -274,8 +278,13 @@ decodeLength :: ByteString -> Int
 decodeLength =
     B.foldl' (\acc w -> acc * 256 + fromIntegral w) 0
 
-parseJournalReplayEntry :: ByteString -> JournalEntry
-parseJournalReplayEntry bs = case B.uncons bs of
+-- | Parse a journal entry without discarding update payloads.
+--
+-- Tag @0x03@ stores both the old and new value. Replay needs
+-- the old value to remove a value-derived tree prefix before
+-- inserting the replacement.
+parseJournalEntry :: ByteString -> JournalEntry
+parseJournalEntry bs = case B.uncons bs of
     Just (0x01, rest) -> JournalInsert rest
     Just (0x02, rest) -> JournalUpdateLegacy rest
     Just (0x03, rest) ->
@@ -287,15 +296,6 @@ parseJournalReplayEntry bs = case B.uncons bs of
                 else JournalUpdate old new
     Just (0x00, rest) -> JournalDelete rest
     _ -> error "parseJournalEntry: invalid tag byte"
-
--- | Parse a journal entry into tag + value payload.
-parseJournalEntry :: ByteString -> (JournalTag, ByteString)
-parseJournalEntry bs =
-    case parseJournalReplayEntry bs of
-        JournalInsert v -> (JInsert, v)
-        JournalUpdateLegacy v -> (JUpdate, v)
-        JournalUpdate _ new -> (JUpdate, new)
-        JournalDelete v -> (JDelete, v)
 
 -- ------------------------------------------------------------------
 -- Crash recovery sentinel
@@ -705,7 +705,7 @@ csmtKVOnlyStoreT _fromKV =
                 mj <- query StandaloneJournalCol k
                 existing <- query StandaloneKVCol k
                 let journalValue =
-                        case parseJournalReplayEntry <$> mj of
+                        case parseJournalEntry <$> mj of
                             Just (JournalInsert _) ->
                                 encodeJournalInsert v
                             Just (JournalUpdate old _) ->
@@ -743,7 +743,7 @@ csmtKVOnlyStoreT _fromKV =
                             kvCountKey
                             (-1)
                         mj <- query StandaloneJournalCol k
-                        case parseJournalReplayEntry <$> mj of
+                        case parseJournalEntry <$> mj of
                             Just (JournalInsert _) -> do
                                 delete StandaloneJournalCol k
                                 adjustCounter
@@ -1046,7 +1046,7 @@ replayEntries prefix fromKV hashing entries = do
   where
     applyEntry e =
         let k = entryKey e
-        in  case parseJournalReplayEntry (entryValue e) of
+        in  case parseJournalEntry (entryValue e) of
                 JournalInsert v ->
                     insertingTreeOnly
                         prefix
@@ -1055,28 +1055,18 @@ replayEntries prefix fromKV hashing entries = do
                         StandaloneCSMTCol
                         k
                         v
-                JournalUpdateLegacy v ->
-                    insertingTreeOnly
-                        prefix
-                        fromKV
-                        hashing
-                        StandaloneCSMTCol
-                        k
-                        v
+                JournalUpdateLegacy _ ->
+                    error
+                        "replayEntries: legacy journal update \
+                        \cannot relocate value-derived tree prefix"
                 JournalUpdate old new -> do
-                    deletingTreeOnly
+                    updatingTreeOnly
                         prefix
                         fromKV
                         hashing
                         StandaloneCSMTCol
                         k
                         old
-                    insertingTreeOnly
-                        prefix
-                        fromKV
-                        hashing
-                        StandaloneCSMTCol
-                        k
                         new
                 JournalDelete v ->
                     deletingTreeOnly
@@ -1215,7 +1205,7 @@ mkKVOnlyOps
                         existing <- query kvCol k
                         let encoded = view journalIso v
                             journalValue =
-                                case parseJournalReplayEntry <$> mj of
+                                case parseJournalEntry <$> mj of
                                     Just (JournalInsert _) ->
                                         encodeJournalInsert encoded
                                     Just (JournalUpdate old _) ->
@@ -1248,7 +1238,7 @@ mkKVOnlyOps
                             Just v -> do
                                 delete kvCol k
                                 mj <- query journalCol k
-                                case parseJournalReplayEntry <$> mj of
+                                case parseJournalEntry <$> mj of
                                     Just (JournalInsert _) -> do
                                         delete journalCol k
                                         adjustCounter
@@ -1346,7 +1336,7 @@ mkKVOnlyOps
                 else do
                     let n = length entries
                         remaining' = remaining - n
-                        (updateTxns, ops) =
+                        (normalOps, updateOps, updateFinalizers) =
                             journalEntriesToReplayWork
                                 journalIso
                                 fromKV
@@ -1355,14 +1345,24 @@ mkKVOnlyOps
                                 journalCol
                                 prefix
                                 entries
-                        bucketTxns =
+                        normalBucketTxns =
                             patchParallel
                                 bucketBits
                                 prefix
                                 hashing
                                 csmtCol
                                 journalCol
-                                ops
+                                normalOps
+                        updateBucketTxns =
+                            patchParallelTreeOnly
+                                bucketBits
+                                prefix
+                                hashing
+                                csmtCol
+                                updateOps
+                        bucketTxns =
+                            normalBucketTxns
+                                <> updateBucketTxns
                     trace
                         ReplayStart
                             { rsChunkSize = n
@@ -1373,10 +1373,10 @@ mkKVOnlyOps
                             , rsEntriesRemaining =
                                 remaining'
                             }
-                    mapM_ runTxReplay updateTxns
                     mapConcurrently_
                         (runTxReplay . snd)
                         bucketTxns
+                    mapM_ runTxReplay updateFinalizers
                     trace ReplayStop
                     replayLoop remaining'
 
@@ -1496,13 +1496,14 @@ readJournalChunkT journalCol chunkSize = do
 
 -- | Convert journal entries into replay work.
 --
--- Inserts and deletes can be replayed through bucketed
--- 'patchParallel'. Updates need one atomic transaction because the
--- old and new value-derived tree keys may belong to different
--- buckets; deleting the journal entry before both tree operations
--- complete would lose the update during crash recovery.
+-- Inserts and deletes are replayed through bucketed
+-- 'patchParallel', which also deletes their journal entries.
+-- Updates become two tree-only bucket operations: delete the old
+-- value-derived tree key and insert the new one. Their journal entry
+-- is deleted only after both bucket operations have completed, so a
+-- crash can safely replay the idempotent update again.
 journalEntriesToReplayWork
-    :: (Monad m, GCompare d, Ord k)
+    :: (GCompare d, Ord k)
     => Iso' v ByteString
     -- ^ Journal value serialization
     -> FromKV k v a
@@ -1515,54 +1516,62 @@ journalEntriesToReplayWork
     -- ^ Prefix
     -> [(k, ByteString)]
     -- ^ (journal key, encoded journal value)
-    -> ( [Transaction m cf d op ()]
-       , [(k, PatchOp Key a)]
+    -> ( [(k, PatchOp Key a)]
+       , [PatchOp Key a]
+       , [Transaction m cf d op ()]
        )
 journalEntriesToReplayWork
     journalIso
     fromKV
-    hashing
-    csmtCol
+    _hashing
+    _csmtCol
     journalCol
-    prefix =
-        foldr convert ([], [])
+    _prefix =
+        foldr convert ([], [], [])
       where
-        treeKey v =
-            treePrefix fromKV v
+        treeKey =
+            treePrefix fromKV
 
-        convert (k, raw) (txns, ops) =
-            case parseJournalReplayEntry raw of
+        convert (k, raw) (normalOps, updateOps, finalizers) =
+            case parseJournalEntry raw of
                 JournalInsert serializedV ->
-                    ( txns
-                    , patchInsert k serializedV : ops
+                    ( patchInsert k serializedV : normalOps
+                    , updateOps
+                    , finalizers
                     )
-                JournalUpdateLegacy serializedV ->
-                    ( txns
-                    , patchInsert k serializedV : ops
-                    )
+                JournalUpdateLegacy _ ->
+                    error
+                        "journalEntriesToReplayWork: legacy journal \
+                        \update cannot relocate value-derived tree \
+                        \prefix"
                 JournalUpdate serializedOld serializedNew ->
                     let old = review journalIso serializedOld
                         new = review journalIso serializedNew
-                        txn = do
-                            deletingTreeOnly
-                                prefix
-                                fromKV
-                                hashing
-                                csmtCol
-                                k
-                                old
-                            insertingTreeOnly
-                                prefix
-                                fromKV
-                                hashing
-                                csmtCol
-                                k
-                                new
-                            delete journalCol k
-                    in  (txn : txns, ops)
+                        oldTreeKey =
+                            treeKey old <> view (isoK fromKV) k
+                        newTreeKey =
+                            treeKey new <> view (isoK fromKV) k
+                        updateOps' =
+                            if oldTreeKey == newTreeKey
+                                then
+                                    PatchInsert
+                                        newTreeKey
+                                        (fromV fromKV new)
+                                        : updateOps
+                                else
+                                    PatchDelete oldTreeKey
+                                        : PatchInsert
+                                            newTreeKey
+                                            (fromV fromKV new)
+                                        : updateOps
+                    in  ( normalOps
+                        , updateOps'
+                        , delete journalCol k : finalizers
+                        )
                 JournalDelete serializedV ->
-                    ( txns
-                    , patchDelete k serializedV : ops
+                    ( patchDelete k serializedV : normalOps
+                    , updateOps
+                    , finalizers
                     )
 
         patchInsert k serializedV =
@@ -1580,6 +1589,46 @@ journalEntriesToReplayWork
                     (treeKey v <> view (isoK fromKV) k)
                 )
 
+patchParallelTreeOnly
+    :: (GCompare d, Monad m)
+    => Int
+    -> Key
+    -> Hashing a
+    -> Selector d Key (Indirect a)
+    -> [PatchOp Key a]
+    -> [(Int, Transaction m cf d ops ())]
+patchParallelTreeOnly bucketBits pfx hashing csmtCol entries =
+    map mkBucketTx (Map.toList buckets)
+  where
+    prefixes = allPrefixes bucketBits
+
+    buckets =
+        foldl' addEntry Map.empty entries
+
+    addEntry m op =
+        let treeKey = opKey op
+            (bucket, stripped) = splitAt bucketBits treeKey
+            idx = bucketIndex bucket
+            op' = setOpKey stripped op
+        in  Map.insertWith (++) idx [op'] m
+
+    mkBucketTx (idx, ops) =
+        let bpfx = pfx <> (prefixes !! idx)
+        in  ( length ops
+            , mapM_ (applyOp bpfx) ops
+            )
+
+    applyOp bpfx (PatchInsert k v) =
+        insertingDirect bpfx hashing csmtCol k v
+    applyOp bpfx (PatchDelete k) =
+        deletingDirect bpfx hashing csmtCol k
+
+    opKey (PatchInsert k _) = k
+    opKey (PatchDelete k) = k
+
+    setOpKey k (PatchInsert _ v) = PatchInsert k v
+    setOpKey k (PatchDelete _) = PatchDelete k
+
 -- | Convert journal entries to 'PatchOp' pairs for
 -- 'patchParallel'.
 journalEntriesToPatchOps
@@ -1592,15 +1641,29 @@ journalEntriesToPatchOps
 journalEntriesToPatchOps journalIso fromKV = map convert
   where
     convert (k, raw) =
-        let (tag, serializedV) = parseJournalEntry raw
-            v = review journalIso serializedV
+        case parseJournalEntry raw of
+            JournalInsert serializedV ->
+                patchInsert k serializedV
+            JournalUpdateLegacy _ ->
+                error
+                    "journalEntriesToPatchOps: legacy journal update \
+                    \cannot relocate value-derived tree prefix"
+            JournalUpdate _ _ ->
+                error
+                    "journalEntriesToPatchOps: journal update needs \
+                    \update-aware replay"
+            JournalDelete serializedV ->
+                patchDelete k serializedV
+
+    patchInsert k serializedV =
+        let v = review journalIso serializedV
             treeKey =
                 treePrefix fromKV v <> view (isoK fromKV) k
             hash = fromV fromKV v
-        in  case tag of
-                JInsert ->
-                    (k, PatchInsert treeKey hash)
-                JUpdate ->
-                    (k, PatchInsert treeKey hash)
-                JDelete ->
-                    (k, PatchDelete treeKey)
+        in  (k, PatchInsert treeKey hash)
+
+    patchDelete k serializedV =
+        let v = review journalIso serializedV
+            treeKey =
+                treePrefix fromKV v <> view (isoK fromKV) k
+        in  (k, PatchDelete treeKey)

--- a/lib/csmt-write/CSMT/Proof/Completeness.hs
+++ b/lib/csmt-write/CSMT/Proof/Completeness.hs
@@ -124,7 +124,7 @@ generateProof sel pfx targetPrefix = do
                 $ Just
                     CompletenessWitness
                         { cpMergeOps = mergeOps
-                        , cpInclusionSteps = reverse inclusionSteps
+                        , cpInclusionSteps = inclusionSteps -- subtree→root for 'foldInclusionSteps'
                         }
         Nothing -> do
             -- The walker returns 'Nothing' both when the column

--- a/mts.cabal
+++ b/mts.cabal
@@ -519,6 +519,7 @@ test-suite unit-tests
     CSMT.InsertionSpec
     CSMT.InterfaceSpec
     CSMT.NamespaceSpec
+    CSMT.PrefixReconciliationSpec
     CSMT.Proof.CompletenessSpec
     CSMT.Proof.ExclusionSpec
     CSMT.Proof.InsertionSpec

--- a/test/CSMT/DeletionSpec.hs
+++ b/test/CSMT/DeletionSpec.hs
@@ -6,6 +6,7 @@ where
 
 import CSMT
     ( Direction (L, R)
+    , Indirect (value)
     , Standalone (StandaloneCSMTCol)
     )
 import CSMT.Backend.Pure
@@ -19,7 +20,14 @@ import CSMT.Deletion
     , deletionPathToOps
     , newDeletionPath
     )
-import CSMT.Interface (Key)
+import CSMT.Insertion
+    ( insertingTreeOnly
+    , updatingTreeOnly
+    )
+import CSMT.Interface (FromKV (..), Key)
+import CSMT.Proof.Completeness
+    ( collectValues
+    )
 import CSMT.Test.Lib
     ( deleteWord64
     , genPaths
@@ -31,6 +39,7 @@ import CSMT.Test.Lib
     , word64Codecs
     , word64Hashing
     )
+import Control.Lens (simple)
 import Data.Word (Word64)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.QuickCheck
@@ -40,6 +49,14 @@ import Test.QuickCheck
     , getSize
     , shuffle
     )
+
+prefixedFromKV :: FromKV Key Word64 Word64
+prefixedFromKV =
+    FromKV
+        { isoK = simple
+        , fromV = id
+        , treePrefix = \v -> if even v then [L] else [R]
+        }
 
 spec :: Spec
 spec = do
@@ -173,6 +190,38 @@ spec = do
                 rs1 = deleteWord64 rs0 [L]
               in
                 rs1 `shouldBe` emptyInMemoryDB
+        it "tree-only update removes the old value-derived prefix" $ do
+            let ((), db) =
+                    runPure emptyInMemoryDB
+                        $ runPureTransaction word64Codecs
+                        $ do
+                            insertingTreeOnly
+                                []
+                                prefixedFromKV
+                                word64Hashing
+                                StandaloneCSMTCol
+                                [R]
+                                (2 :: Word64)
+                            updatingTreeOnly
+                                []
+                                prefixedFromKV
+                                word64Hashing
+                                StandaloneCSMTCol
+                                [R]
+                                (2 :: Word64)
+                                (3 :: Word64)
+                collectedL =
+                    fst
+                        $ runPure db
+                        $ runPureTransaction word64Codecs
+                        $ collectValues StandaloneCSMTCol [] [L]
+                collectedR =
+                    fst
+                        $ runPure db
+                        $ runPureTransaction word64Codecs
+                        $ collectValues StandaloneCSMTCol [] [R]
+            collectedL `shouldBe` []
+            map value collectedR `shouldBe` [3]
         it "deletes one of two sibling keys"
             $ let
                 rs0 = insertWord64 emptyInMemoryDB [L] (1 :: Word64)

--- a/test/CSMT/PrefixReconciliationSpec.hs
+++ b/test/CSMT/PrefixReconciliationSpec.hs
@@ -1,0 +1,531 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module CSMT.PrefixReconciliationSpec (spec) where
+
+import CSMT.Backend.Pure
+    ( InMemoryDB
+    , Pure
+    , emptyInMemoryDB
+    , pureDatabase
+    , runPure
+    , runPureTransaction
+    )
+import CSMT.Backend.Standalone
+    ( Standalone (..)
+    , StandaloneCF
+    , StandaloneCodecs (..)
+    , StandaloneOp
+    )
+import CSMT.Deletion qualified
+import CSMT.Hashes
+    ( Hash
+    , fromKVHashes
+    , hashHashing
+    , isoHash
+    )
+import CSMT.Insertion qualified
+import CSMT.Interface
+    ( Direction (L, R)
+    , FromKV (..)
+    , Indirect (..)
+    , root
+    )
+import CSMT.MTS
+    ( CommonOps (..)
+    , DbState (..)
+    , Ops (..)
+    , ReadyState (..)
+    , mkKVOnlyOps
+    , openOps
+    )
+import CSMT.Proof.Completeness (collectValues)
+import Control.Lens (iso, view)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Data.IORef
+    ( newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Database.KV.Cursor
+    ( Cursor
+    , Entry (..)
+    , firstEntry
+    , nextEntry
+    )
+import Database.KV.Database (KeyOf, ValueOf)
+import Database.KV.Transaction
+    ( Transaction
+    , iterating
+    , runTransactionUnguarded
+    )
+import MTS.Interface (Mode (..))
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( Gen
+    , arbitrary
+    , chooseInt
+    , elements
+    , forAllShrink
+    , frequency
+    , property
+    , shrinkList
+    , vectorOf
+    )
+
+data KVOp
+    = Put ByteString ByteString
+    | Del ByteString
+    deriving stock (Eq, Show)
+
+data Relocation = Relocation ByteString ByteString ByteString
+    deriving stock (Eq, Show)
+
+newtype EquivalentModel = EquivalentModel [(ByteString, ByteString)]
+    deriving stock (Eq, Show)
+
+type LeafSet = Set ([Direction], Hash)
+
+csmtCodecs :: StandaloneCodecs ByteString ByteString Hash
+csmtCodecs =
+    StandaloneCodecs
+        { keyCodec = iso id id
+        , valueCodec = iso id id
+        , nodeCodec = isoHash
+        }
+
+prefixedFromKV :: FromKV ByteString ByteString Hash
+prefixedFromKV =
+    fromKVHashes
+        { treePrefix = \v ->
+            case B.uncons v of
+                Just (w, _) | w < 128 -> [L]
+                _ -> [R]
+        }
+
+genKey :: Gen ByteString
+genKey =
+    elements
+        [ "103d753d77c8c541"
+        , "wallet-input-0"
+        , "wallet-input-1"
+        , "wallet-input-2"
+        , "request-input"
+        , "state-input"
+        ]
+
+genPayload :: Gen ByteString
+genPayload = B.pack <$> vectorOf 7 arbitrary
+
+genValueWithPrefix :: Word -> Gen ByteString
+genValueWithPrefix marker =
+    B.cons (fromIntegral marker) <$> genPayload
+
+genValue :: Gen ByteString
+genValue =
+    frequency
+        [ (1, genValueWithPrefix 0)
+        , (1, genValueWithPrefix 255)
+        , (2, B.cons <$> arbitrary <*> genPayload)
+        ]
+
+genOps :: Gen [KVOp]
+genOps = do
+    n <- chooseInt (1, 40)
+    vectorOf n genOp
+  where
+    genOp =
+        frequency
+            [ (7, Put <$> genKey <*> genValue)
+            , (3, Del <$> genKey)
+            ]
+
+shrinkOps :: [KVOp] -> [[KVOp]]
+shrinkOps =
+    shrinkList shrinkOp
+  where
+    shrinkOp (Put k v) =
+        [Put k' v | k' <- shrinkBS k]
+            <> [Put k v' | v' <- shrinkValue v]
+            <> [Del k]
+    shrinkOp (Del k) =
+        [Del k' | k' <- shrinkBS k]
+
+shrinkBS :: ByteString -> [ByteString]
+shrinkBS bs =
+    [ B.take n bs
+    | n <- [1 .. B.length bs - 1]
+    ]
+
+shrinkValue :: ByteString -> [ByteString]
+shrinkValue v =
+    [ v'
+    | v' <- shrinkBS v
+    , not (B.null v')
+    ]
+
+genRelocation :: Gen Relocation
+genRelocation =
+    Relocation
+        <$> genKey
+        <*> genValueWithPrefix 0
+        <*> genValueWithPrefix 255
+
+shrinkRelocation :: Relocation -> [Relocation]
+shrinkRelocation (Relocation k old new) =
+    [Relocation k' old new | k' <- shrinkBS k]
+        <> [Relocation k old' new | old' <- shrinkValue old, oldPrefix old']
+        <> [Relocation k old new' | new' <- shrinkValue new, newPrefix new']
+  where
+    oldPrefix v = treePrefix prefixedFromKV v == [L]
+    newPrefix v = treePrefix prefixedFromKV v == [R]
+
+genEquivalentModel :: Gen EquivalentModel
+genEquivalentModel = do
+    n <- chooseInt (1, 12)
+    pairs <- vectorOf n ((,) <$> genKey <*> genValue)
+    pure $ EquivalentModel $ Map.toList $ Map.fromList pairs
+
+shrinkEquivalentModel :: EquivalentModel -> [EquivalentModel]
+shrinkEquivalentModel (EquivalentModel pairs) =
+    [ EquivalentModel $ Map.toList $ Map.fromList pairs'
+    | pairs' <- shrinkList shrinkPair pairs
+    , not (null pairs')
+    ]
+  where
+    shrinkPair (k, v) =
+        [(k', v) | k' <- shrinkBS k]
+            <> [(k, v') | v' <- shrinkValue v]
+
+modelOps :: [KVOp] -> Map ByteString ByteString
+modelOps =
+    foldl apply Map.empty
+  where
+    apply m = \case
+        Put k v -> Map.insert k v m
+        Del k -> Map.delete k m
+
+expectedLeaves :: Map ByteString ByteString -> LeafSet
+expectedLeaves =
+    Set.fromList
+        . map expectedLeaf
+        . Map.toList
+  where
+    expectedLeaf (k, v) =
+        ( treePrefix prefixedFromKV v
+            <> view (isoK prefixedFromKV) k
+        , fromV prefixedFromKV v
+        )
+
+collectAll :: (Monad m) => Cursor m c [(KeyOf c, ValueOf c)]
+collectAll = do
+    me <- firstEntry
+    case me of
+        Nothing -> pure []
+        Just e -> go [(entryKey e, entryValue e)]
+  where
+    go acc = do
+        me <- nextEntry
+        case me of
+            Nothing -> pure $ reverse acc
+            Just e -> go ((entryKey e, entryValue e) : acc)
+
+leafSetT
+    :: Transaction
+        Pure
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+        LeafSet
+leafSetT =
+    Set.fromList
+        . map (\Indirect{jump, value} -> (jump, value))
+        <$> collectValues StandaloneCSMTCol [] []
+
+kvMapT
+    :: Transaction
+        Pure
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+        (Map ByteString ByteString)
+kvMapT =
+    Map.fromList <$> iterating StandaloneKVCol collectAll
+
+rootT
+    :: Transaction
+        Pure
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+        (Maybe Hash)
+rootT = root hashHashing StandaloneCSMTCol []
+
+runFull :: [KVOp] -> InMemoryDB
+runFull ops =
+    snd
+        $ runPure emptyInMemoryDB
+        $ mapM_ apply ops
+  where
+    apply = \case
+        Put k v ->
+            runPureTransaction csmtCodecs
+                $ CSMT.Insertion.inserting
+                    []
+                    prefixedFromKV
+                    hashHashing
+                    StandaloneKVCol
+                    StandaloneCSMTCol
+                    k
+                    v
+        Del k ->
+            runPureTransaction csmtCodecs
+                $ CSMT.Deletion.deleting
+                    []
+                    prefixedFromKV
+                    hashHashing
+                    StandaloneKVCol
+                    StandaloneCSMTCol
+                    k
+
+data KVOnlyResult = KVOnlyResult
+    { kvOnlyRoot :: Maybe Hash
+    , kvOnlyLeaves :: LeafSet
+    , kvOnlyKV :: Map ByteString ByteString
+    }
+
+withKVOnly
+    :: [KVOp]
+    -> ( Ops
+            'KVOnly
+            Pure
+            StandaloneCF
+            (Standalone ByteString ByteString Hash)
+            StandaloneOp
+            ByteString
+            ByteString
+            Hash
+         -> ( forall b
+               . Transaction
+                    Pure
+                    StandaloneCF
+                    (Standalone ByteString ByteString Hash)
+                    StandaloneOp
+                    b
+              -> IO b
+            )
+         -> IO a
+       )
+    -> IO a
+withKVOnly ops action = do
+    ref <- newIORef emptyInMemoryDB
+    let run :: forall b. Pure b -> IO b
+        run act = do
+            db <- readIORef ref
+            let (a, db') = runPure db act
+            writeIORef ref db'
+            pure a
+        rtx = run . runTransactionUnguarded (pureDatabase csmtCodecs)
+        kvOps =
+            mkKVOnlyOps
+                []
+                2
+                100
+                StandaloneKVCol
+                StandaloneCSMTCol
+                StandaloneJournalCol
+                StandaloneMetricsCol
+                (iso id id)
+                prefixedFromKV
+                hashHashing
+                rtx
+                rtx
+                (const $ pure ())
+    mapM_ (applyKVOnly (kvCommon kvOps) rtx) ops
+    action kvOps rtx
+
+runKVOnlyToFull :: [KVOp] -> IO KVOnlyResult
+runKVOnlyToFull ops =
+    withKVOnly ops $ \kvOps rtx -> do
+        Just fullOps <- toFull kvOps
+        KVOnlyResult
+            <$> rtx (opsRootHash fullOps)
+            <*> rtx leafSetT
+            <*> rtx kvMapT
+
+runRecoveredKVOnlyToFull :: [KVOp] -> IO KVOnlyResult
+runRecoveredKVOnlyToFull ops =
+    withKVOnly ops $ \_ rtx -> do
+        state <-
+            openOps
+                []
+                2
+                100
+                StandaloneKVCol
+                StandaloneCSMTCol
+                StandaloneJournalCol
+                StandaloneMetricsCol
+                (iso id id)
+                prefixedFromKV
+                hashHashing
+                rtx
+                rtx
+                (const $ pure ())
+        recovered <- case state of
+            Ready (ChooseKVOnly kvOps) -> pure kvOps
+            Ready (ChooseFull _) ->
+                fail "expected ChooseKVOnly"
+            NeedsRecovery _ ->
+                fail "unexpected sentinel recovery"
+        Just fullOps <- toFull recovered
+        KVOnlyResult
+            <$> rtx (opsRootHash fullOps)
+            <*> rtx leafSetT
+            <*> rtx kvMapT
+
+applyKVOnly
+    :: CommonOps
+        Pure
+        StandaloneCF
+        (Standalone ByteString ByteString Hash)
+        StandaloneOp
+        ByteString
+        ByteString
+    -> ( forall b
+          . Transaction
+                Pure
+                StandaloneCF
+                (Standalone ByteString ByteString Hash)
+                StandaloneOp
+                b
+         -> IO b
+       )
+    -> KVOp
+    -> IO ()
+applyKVOnly common rtx = \case
+    Put k v -> rtx $ opsInsert common k v
+    Del k -> rtx $ opsDelete common k
+
+fullRoot :: InMemoryDB -> Maybe Hash
+fullRoot db =
+    fst $ runPure db $ runPureTransaction csmtCodecs rootT
+
+fullLeaves :: InMemoryDB -> LeafSet
+fullLeaves db =
+    fst $ runPure db $ runPureTransaction csmtCodecs leafSetT
+
+opsForModel :: EquivalentModel -> ([KVOp], [KVOp])
+opsForModel (EquivalentModel pairs) =
+    ( map (uncurry Put) pairs
+    , concatMap path pairs
+    )
+  where
+    path (k, final) =
+        [ Put k (oppositePrefix final)
+        , Put k final
+        ]
+
+    oppositePrefix v =
+        let marker =
+                case treePrefix prefixedFromKV v of
+                    [L] -> 255
+                    _ -> 0
+        in  B.cons marker (B.drop 1 v)
+
+spec :: Spec
+spec =
+    describe "CSMT prefix reconciliation properties" $ do
+        it
+            "P1 model conformance: KVOnly toFull observable state equals Map model"
+            $ property
+            $ forAllShrink genOps shrinkOps
+            $ \ops -> do
+                let model = modelOps ops
+                KVOnlyResult{kvOnlyLeaves, kvOnlyKV} <-
+                    runKVOnlyToFull ops
+                kvOnlyKV `shouldBe` model
+                kvOnlyLeaves `shouldBe` expectedLeaves model
+
+        it
+            "P2 mode equivalence: Full and KVOnly toFull roots and leaves match"
+            $ property
+            $ forAllShrink genOps shrinkOps
+            $ \ops -> do
+                let fullDb = runFull ops
+                KVOnlyResult{kvOnlyRoot, kvOnlyLeaves} <-
+                    runKVOnlyToFull ops
+                kvOnlyRoot `shouldBe` fullRoot fullDb
+                kvOnlyLeaves `shouldBe` fullLeaves fullDb
+
+        it "P3 no-orphans: leaves and KV values form a bijection"
+            $ property
+            $ forAllShrink genOps shrinkOps
+            $ \ops -> do
+                let model = modelOps ops
+                KVOnlyResult{kvOnlyLeaves, kvOnlyKV} <-
+                    runKVOnlyToFull ops
+                kvOnlyKV `shouldBe` model
+                Set.size kvOnlyLeaves `shouldBe` Map.size model
+                kvOnlyLeaves `shouldBe` expectedLeaves model
+
+        it
+            "P4 targeted relocation: 103d753d-style update leaves no old-prefix leaf"
+            $ property
+            $ forAllShrink genRelocation shrinkRelocation
+            $ \(Relocation _ old new) -> do
+                let key =
+                        "103d753d77c8c541bb912bae22bbaf655ed3bfb177b6598ee0c57720f368cf61#0"
+                    ops =
+                        [ Put key old
+                        , Put key new
+                        ]
+                    model = modelOps ops
+                KVOnlyResult{kvOnlyRoot, kvOnlyLeaves} <-
+                    runKVOnlyToFull ops
+                oldPrefixLeaves <-
+                    withKVOnly ops $ \kvOps rtx -> do
+                        Just _ <- toFull kvOps
+                        rtx
+                            $ collectValues
+                                StandaloneCSMTCol
+                                []
+                                (treePrefix prefixedFromKV old)
+                length oldPrefixLeaves `shouldBe` 0
+                kvOnlyLeaves `shouldBe` expectedLeaves model
+                kvOnlyRoot `shouldBe` fullRoot (runFull ops)
+
+        it
+            "P5 crash-recovery determinism: reopened KVOnly journal replays to Full root"
+            $ property
+            $ forAllShrink genOps shrinkOps
+            $ \ops -> do
+                let fullDb = runFull ops
+                KVOnlyResult{kvOnlyRoot, kvOnlyLeaves} <-
+                    runRecoveredKVOnlyToFull ops
+                kvOnlyRoot `shouldBe` fullRoot fullDb
+                kvOnlyLeaves `shouldBe` fullLeaves fullDb
+
+        it "P6 path independence: equal models yield equal roots"
+            $ property
+            $ forAllShrink genEquivalentModel shrinkEquivalentModel
+            $ \equivalent -> do
+                let (ops1, ops2) = opsForModel equivalent
+                    model1 = modelOps ops1
+                    model2 = modelOps ops2
+                model1 `shouldBe` model2
+                fullRoot (runFull ops1)
+                    `shouldBe` fullRoot (runFull ops2)

--- a/test/CSMT/TreePrefixSpec.hs
+++ b/test/CSMT/TreePrefixSpec.hs
@@ -77,14 +77,25 @@ spec = do
             -- Single leaf: tree key [L,R] stored at path [] with jump [L,R]
             length csmt `shouldBe` 1
 
-        it "different values produce different tree keys for same key" $ do
+        it "prefix-changing update relocates the same key" $ do
             -- key [R], even value 2 → tree key [L, R]
             -- key [R], odd value 3  → tree key [R, R]
-            -- These are different tree entries despite the same user key
-            let db = insertP [R] 2 $ insertP [R] 3 emptyInMemoryDB
-                csmt = inMemoryCSMTParsed word64Codecs db
-            -- Should have 3 nodes: root + 2 leaves
-            length csmt `shouldBe` 3
+            -- The update must remove the old [L, R] leaf.
+            let db = insertP [R] 3 $ insertP [R] 2 emptyInMemoryDB
+                fresh = insertP [R] 3 emptyInMemoryDB
+                collectedL =
+                    fst
+                        $ runPure db
+                        $ runPureTransaction word64Codecs
+                        $ collectValues StandaloneCSMTCol [] [L]
+                collectedR =
+                    fst
+                        $ runPure db
+                        $ runPureTransaction word64Codecs
+                        $ collectValues StandaloneCSMTCol [] [R]
+            db `shouldBe` fresh
+            collectedL `shouldBe` []
+            map value collectedR `shouldBe` [3]
 
         it "deletion removes the prefixed tree key" $ do
             let db = deleteP [R] $ insertP [R] 2 emptyInMemoryDB
@@ -112,11 +123,11 @@ spec = do
             -- the tree splits at the prefix level [L] vs [R]:
             --   key [L], value 2 (even) → tree key [L, L]
             --   key [R], value 4 (even) → tree key [L, R]
-            --   key [L], value 3 (odd)  → tree key [R, L]
+            --   key [L,L], value 3 (odd)  → tree key [R, L, L]
             let db =
                     insertP [L] 2
                         $ insertP [R] 4
-                        $ insertP [L] 3 emptyInMemoryDB
+                        $ insertP [L, L] 3 emptyInMemoryDB
                 collectedL =
                     fst
                         $ runPure db

--- a/test/CSMT/Verify/CompletenessSpec.hs
+++ b/test/CSMT/Verify/CompletenessSpec.hs
@@ -22,10 +22,11 @@ import CSMT.Backend.Pure
     )
 import CSMT.Core.CBOR (renderCompletenessProof)
 import CSMT.Hashes (Hash, hashHashing, mkHash, renderHash)
-import CSMT.Interface (Hashing (..), Indirect (..))
+import CSMT.Interface (Hashing (..), Indirect (..), Key)
 import CSMT.Proof.Completeness
-    ( CompletenessProof
+    ( CompletenessProof (..)
     , collectValues
+    , foldCompletenessProof
     , generateProof
     )
 import CSMT.Test.Lib
@@ -40,15 +41,23 @@ import CSMT.Verify qualified as Verify
 import Data.Bits (xor)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
-import Data.List (sort)
+import Data.List (isPrefixOf, nub, sort)
 import Data.Word (Word8)
 import Database.KV.Transaction (query)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck
     ( Gen
+    , Property
     , arbitrary
+    , checkCoverage
+    , chooseInt
+    , conjoin
+    , counterexample
+    , cover
+    , elements
     , forAll
+    , frequency
     , listOf
     , vectorOf
     , (===)
@@ -89,8 +98,135 @@ genTreeProof = do
             -- the values to the proof.
             pure (B.replicate 32 0, [], B.empty)
 
+genDeepPrefixTree :: Gen (Key, [Indirect Hash])
+genDeepPrefixTree = do
+    depth <- chooseInt (2, 6)
+    prefixKey <- vectorOf depth (elements [L, R])
+    let targetLeaves =
+            [ prefixKey ++ [L, L]
+            , prefixKey ++ [L, R]
+            , prefixKey ++ [R, L]
+            ]
+        siblingLeaves =
+            [ take i prefixKey
+                ++ [opposite (prefixKey !! i)]
+                ++ [L, R]
+            | i <- [0 .. depth - 1]
+            ]
+        keys = targetLeaves <> siblingLeaves
+    pure (prefixKey, zipWith indirect keys (intHash <$> [1 ..]))
+  where
+    opposite L = R
+    opposite R = L
+
+genRandomTreeAndPrefix :: Gen (Key, [Indirect Hash])
+genRandomTreeAndPrefix = do
+    keyCount <- chooseInt (16, 64)
+    keys0 <- prefixFree . nub <$> vectorOf (keyCount * 4) genRandomKey
+    let keys = take keyCount keys0
+    if length keys < 8
+        then genRandomTreeAndPrefix
+        else do
+            targetKey <- elements keys
+            prefixLen <-
+                frequency
+                    [ (1, pure 0)
+                    , (3, chooseInt (0, length targetKey))
+                    , (6, chooseInt (min 2 (length targetKey), length targetKey))
+                    ]
+            let prefixKey = take prefixLen targetKey
+            pure (prefixKey, zipWith indirect keys (intHash <$> [1 ..]))
+  where
+    genRandomKey :: Gen Key
+    genRandomKey = do
+        keyLen <- chooseInt (6, 16)
+        vectorOf keyLen (elements [L, R])
+
+    prefixFree :: [Key] -> [Key]
+    prefixFree = foldr insertIfCompatible []
+      where
+        insertIfCompatible key keys
+            | all (compatible key) keys = key : keys
+            | otherwise = keys
+
+        compatible a b =
+            not (a `isPrefixOf` b || b `isPrefixOf` a)
+
 genBS :: Gen ByteString
 genBS = B.pack <$> listOf (arbitrary :: Gen Word8)
+
+verifiesCompletenessRoundTrip
+    :: Key -> [Indirect Hash] -> Property
+verifiesCompletenessRoundTrip prefixKey values =
+    let expectedLeaves =
+            sort
+                [ leaf
+                | leaf@Indirect{jump} <- values
+                , prefixKey `isPrefixOf` jump
+                ]
+        (mp, mr, collected) = evalPureFromEmptyDB $ do
+            insertHashes values
+            proof <-
+                runPureTransaction hashCodecs
+                    $ generateProof
+                        StandaloneCSMTCol
+                        []
+                        prefixKey
+            rootI <-
+                runPureTransaction hashCodecs
+                    $ query StandaloneCSMTCol []
+            collectedLeaves <-
+                runPureTransaction hashCodecs
+                    $ collectValues
+                        StandaloneCSMTCol
+                        []
+                        prefixKey
+            pure
+                ( proof :: Maybe (CompletenessProof Hash)
+                , rootI
+                , collectedLeaves
+                )
+    in  case (mp, mr) of
+            (Just proof@CompletenessWitness{cpInclusionSteps}, Just rootIndirect) ->
+                let trustedRoot = rootHash hashHashing rootIndirect
+                    rootBs = renderHash trustedRoot
+                    proofBs = renderCompletenessProof proof
+                    sortedCollected = sort collected
+                    stepCount = length cpInclusionSteps
+                in  cover
+                        30
+                        (stepCount >= 2)
+                        "deep (>=2 inclusion steps)"
+                        $ counterexample
+                            ( "prefix="
+                                <> show prefixKey
+                                <> ", inclusion steps="
+                                <> show stepCount
+                            )
+                        $ conjoin
+                            [ sortedCollected === expectedLeaves
+                            , foldCompletenessProof
+                                hashHashing
+                                trustedRoot
+                                prefixKey
+                                sortedCollected
+                                proof
+                                === Just trustedRoot
+                            , Verify.verifyCompletenessProof
+                                rootBs
+                                prefixKey
+                                sortedCollected
+                                proofBs
+                                === True
+                            ]
+            (Just CompletenessEmpty{}, _) ->
+                counterexample
+                    "existing prefix unexpectedly produced an empty proof"
+                    False
+            _ ->
+                counterexample
+                    "expected populated proof + root for existing prefix"
+                    False
 
 spec :: Spec
 spec = describe "csmt-verify completeness" $ do
@@ -128,6 +264,68 @@ spec = describe "csmt-verify completeness" $ do
                 []
                 garbage
                 === False
+
+    prop "round-trips populated deep-prefix proofs"
+        $ forAll genDeepPrefixTree
+        $ \(prefixKey, values) -> do
+            let expectedLeaves =
+                    sort
+                        [ leaf
+                        | leaf@Indirect{jump} <- values
+                        , prefixKey `isPrefixOf` jump
+                        ]
+                (mp, mr, collected) = evalPureFromEmptyDB $ do
+                    insertHashes values
+                    proof <-
+                        runPureTransaction hashCodecs
+                            $ generateProof
+                                StandaloneCSMTCol
+                                []
+                                prefixKey
+                    rootI <-
+                        runPureTransaction hashCodecs
+                            $ query StandaloneCSMTCol []
+                    collectedLeaves <-
+                        runPureTransaction hashCodecs
+                            $ collectValues
+                                StandaloneCSMTCol
+                                []
+                                prefixKey
+                    pure
+                        ( proof :: Maybe (CompletenessProof Hash)
+                        , rootI
+                        , collectedLeaves
+                        )
+            sort collected `shouldBe` expectedLeaves
+            case (mp, mr) of
+                ( Just proof@CompletenessWitness{cpInclusionSteps}
+                    , Just rootIndirect
+                    ) -> do
+                        cpInclusionSteps `shouldSatisfy` \steps ->
+                            length steps >= 2
+                        let trustedRoot =
+                                rootHash hashHashing rootIndirect
+                            rootBs = renderHash trustedRoot
+                            proofBs = renderCompletenessProof proof
+                        foldCompletenessProof
+                            hashHashing
+                            trustedRoot
+                            prefixKey
+                            (sort collected)
+                            proof
+                            `shouldBe` Just trustedRoot
+                        Verify.verifyCompletenessProof
+                            rootBs
+                            prefixKey
+                            (sort collected)
+                            proofBs
+                            `shouldBe` True
+                _ -> error "expected populated proof + root"
+
+    prop "round-trips arbitrary tree + arbitrary existing prefix"
+        $ checkCoverage
+        $ forAll genRandomTreeAndPrefix
+        $ uncurry verifiesCompletenessRoundTrip
 
     it "the wire format round-trips a hand-built proof" $ do
         -- Decoder/encoder symmetry on an already-known proof so we

--- a/test/MTS/PropertySpec.hs
+++ b/test/MTS/PropertySpec.hs
@@ -19,7 +19,7 @@ import CSMT.Insertion
     ( expandToBucketDepth
     , mergeSubtreeRoots
     )
-import CSMT.Interface (FromKV (..), Indirect, Key)
+import CSMT.Interface (Direction (L, R), FromKV (..), Indirect, Key)
 import CSMT.MTS
     ( CommonOps (..)
     , CsmtImpl
@@ -39,6 +39,7 @@ import CSMT.MTS
     , readJournalChunkT
     )
 import CSMT.Populate (patchParallel)
+import CSMT.Proof.Completeness (collectValues)
 import Control.Exception (SomeException, try)
 import Control.Lens (Iso', iso)
 import Control.Monad (foldM, foldM_, forM_)
@@ -61,8 +62,7 @@ import Database.KV.Cursor
     )
 import Database.KV.Database (KeyOf, ValueOf)
 import Database.KV.Transaction
-    ( delete
-    , insert
+    ( insert
     , iterating
     , runTransactionUnguarded
     )
@@ -132,6 +132,15 @@ csmtCodecs =
         , nodeCodec = isoHash
         }
 
+prefixedFromKVHashes :: FromKV ByteString ByteString Hash
+prefixedFromKVHashes =
+    fromKVHashes
+        { treePrefix = \v ->
+            case B.uncons v of
+                Just (w, _) | w < 128 -> [L]
+                _ -> [R]
+        }
+
 -- ------------------------------------------------------------------
 -- CSMT store factory
 -- ------------------------------------------------------------------
@@ -150,6 +159,22 @@ mkCsmtStore = do
         run
         (pureDatabase csmtCodecs)
         fromKVHashes
+        hashHashing
+
+mkPrefixedCsmtStore :: IO (MerkleTreeStore 'Full CsmtImpl IO)
+mkPrefixedCsmtStore = do
+    ref <- newIORef emptyInMemoryDB
+    let run :: forall b. Pure b -> IO b
+        run action = do
+            db <- readIORef ref
+            let (a, db') = runPure db action
+            writeIORef ref db'
+            pure a
+    csmtMerkleTreeStore
+        []
+        run
+        (pureDatabase csmtCodecs)
+        prefixedFromKVHashes
         hashHashing
 
 -- ------------------------------------------------------------------
@@ -475,6 +500,47 @@ mkCsmtKVOnlyOps = do
         , RunTxPure runTx
         )
 
+mkPrefixedCsmtKVOnlyOps
+    :: IO
+        ( Ops
+            'KVOnly
+            Pure
+            StandaloneCF
+            (Standalone ByteString ByteString Hash)
+            StandaloneOp
+            ByteString
+            ByteString
+            Hash
+        , RunTxPure
+        )
+mkPrefixedCsmtKVOnlyOps = do
+    ref <- newIORef emptyInMemoryDB
+    let run :: forall b. Pure b -> IO b
+        run action = do
+            s <- readIORef ref
+            let (a, s') = runPure s action
+            writeIORef ref s'
+            pure a
+        db = pureDatabase csmtCodecs
+        runTx = run . runTransactionUnguarded db
+    pure
+        ( mkKVOnlyOps
+            []
+            2
+            100
+            StandaloneKVCol
+            StandaloneCSMTCol
+            StandaloneJournalCol
+            StandaloneMetricsCol
+            (iso id id)
+            prefixedFromKVHashes
+            hashHashing
+            runTx
+            runTx
+            (const $ pure ())
+        , RunTxPure runTx
+        )
+
 -- ------------------------------------------------------------------
 -- Helpers
 -- ------------------------------------------------------------------
@@ -509,7 +575,7 @@ collectAll = do
             Just e -> go ((entryKey e, entryValue e) : acc)
 
 -- | Parse journal entry tag byte.
--- 0x01 = JInsert, 0x02 = JUpdate, 0x00 = JDelete
+-- 0x01 = JInsert, 0x02/0x03 = JUpdate, 0x00 = JDelete.
 data JTag = JIns | JUpd | JDel
     deriving stock (Eq, Show)
 
@@ -517,6 +583,15 @@ parseTag :: ByteString -> (JTag, ByteString)
 parseTag bs = case B.uncons bs of
     Just (0x01, rest) -> (JIns, rest)
     Just (0x02, rest) -> (JUpd, rest)
+    Just (0x03, rest) ->
+        let (lenBytes, payload) = B.splitAt 4 rest
+            oldLen =
+                B.foldl'
+                    (\acc w -> acc * 256 + fromIntegral w)
+                    0
+                    lenBytes
+            (_, new) = B.splitAt oldLen payload
+        in  (JUpd, new)
     Just (0x00, rest) -> (JDel, rest)
     _ -> error "invalid journal tag"
 
@@ -794,6 +869,80 @@ spec = do
                         actual <-
                             rtx (opsRootHash fullOps)
                         actual `shouldBe` expected
+        it "KVOnly toFull relocates prefix-changing updates" $ do
+            (ops0, RunTxPure rtx) <- mkPrefixedCsmtKVOnlyOps
+            let key = "103d753d77c8c541"
+                oldValue = B.cons 0 "old-wallet-input"
+                newValue = B.cons 255 "new-wallet-input"
+            rtx $ opsInsert (kvCommon ops0) key oldValue
+            Just full1 <- toFull ops0
+            Just kv2 <- toKVOnly full1
+            rtx $ opsInsert (kvCommon kv2) key newValue
+            Just full2 <- toFull kv2
+            refStore <- mkPrefixedCsmtStore
+            mtsInsert (mtsKV refStore) key newValue
+            expected <- mtsRootHash (mtsTree refStore)
+            actual <- rtx $ opsRootHash full2
+            actual `shouldBe` expected
+            oldPrefixValues <-
+                rtx
+                    $ collectValues
+                        StandaloneCSMTCol
+                        []
+                        [L]
+            newPrefixValues <-
+                rtx
+                    $ collectValues
+                        StandaloneCSMTCol
+                        []
+                        [R]
+            length oldPrefixValues `shouldBe` 0
+            length newPrefixValues `shouldBe` 1
+        it "prefixed Full root equals KVOnly toFull root"
+            $ property
+            $ forAll genOps
+            $ \ops -> do
+                (kvOps, RunTxPure rtx) <- mkPrefixedCsmtKVOnlyOps
+                expectedStore <- mkPrefixedCsmtStore
+                expectedKV <-
+                    foldM
+                        (applyOp (kvCommon kvOps) rtx)
+                        Map.empty
+                        ops
+                mapM_
+                    (uncurry $ mtsInsert $ mtsKV expectedStore)
+                    $ Map.toList expectedKV
+                Just fullOps <- toFull kvOps
+                expected <- mtsRootHash (mtsTree expectedStore)
+                actual <- rtx $ opsRootHash fullOps
+                actual `shouldBe` expected
+        it "prefixed KVOnly toFull leaves no orphan tree leaves"
+            $ property
+            $ forAll genOps
+            $ \ops -> do
+                (kvOps, RunTxPure rtx) <- mkPrefixedCsmtKVOnlyOps
+                expectedKV <-
+                    foldM
+                        (applyOp (kvCommon kvOps) rtx)
+                        Map.empty
+                        ops
+                Just _fullOps <- toFull kvOps
+                oldPrefixValues <-
+                    rtx
+                        $ collectValues
+                            StandaloneCSMTCol
+                            []
+                            [L]
+                newPrefixValues <-
+                    rtx
+                        $ collectValues
+                            StandaloneCSMTCol
+                            []
+                            [R]
+                let treeLeafCount =
+                        length oldPrefixValues
+                            + length newPrefixValues
+                treeLeafCount `shouldBe` Map.size expectedKV
         it "journal is empty after toFull" $ do
             (ops, RunTxPure rtx) <- mkCsmtKVOnlyOps
             rtx (opsInsert (kvCommon ops) "k" "v")
@@ -1331,6 +1480,66 @@ spec = do
                 assertAfterReplay full5 kv3
 
     describe "CSMT crash recovery" $ do
+        it "recovered prefixed journal update matches deterministic root" $ do
+            ref <- newIORef emptyInMemoryDB
+            let run :: forall b. Pure b -> IO b
+                run action = do
+                    s <- readIORef ref
+                    let (a, s') = runPure s action
+                    writeIORef ref s'
+                    pure a
+                db = pureDatabase csmtCodecs
+                rtx = run . runTransactionUnguarded db
+                key = "103d753d77c8c541"
+                oldValue = B.cons 0 "old-wallet-input"
+                newValue = B.cons 255 "new-wallet-input"
+                mkOps =
+                    mkKVOnlyOps
+                        []
+                        2
+                        100
+                        StandaloneKVCol
+                        StandaloneCSMTCol
+                        StandaloneJournalCol
+                        StandaloneMetricsCol
+                        (iso id id)
+                        prefixedFromKVHashes
+                        hashHashing
+                        rtx
+                        rtx
+                        (const $ pure ())
+            rtx $ opsInsert (kvCommon mkOps) key oldValue
+            Just full1 <- toFull mkOps
+            Just kv2 <- toKVOnly full1
+            rtx $ opsInsert (kvCommon kv2) key newValue
+            state <-
+                openOps
+                    []
+                    2
+                    100
+                    StandaloneKVCol
+                    StandaloneCSMTCol
+                    StandaloneJournalCol
+                    StandaloneMetricsCol
+                    (iso id id)
+                    prefixedFromKVHashes
+                    hashHashing
+                    rtx
+                    rtx
+                    (const $ pure ())
+            recoveredKV <- case state of
+                Ready (ChooseKVOnly kvOps) ->
+                    pure kvOps
+                Ready (ChooseFull _) ->
+                    fail "expected ChooseKVOnly"
+                NeedsRecovery _ ->
+                    fail "unexpected sentinel recovery"
+            Just recoveredFull <- toFull recoveredKV
+            refStore <- mkPrefixedCsmtStore
+            mtsInsert (mtsKV refStore) key newValue
+            expected <- mtsRootHash $ mtsTree refStore
+            actual <- rtx $ opsRootHash recoveredFull
+            actual `shouldBe` expected
         it "recovery after simulated crash matches clean replay"
             $ property
             $ forAll genBSPairs


### PR DESCRIPTION
## Problem

`generateProof` (csmt-write) emitted `cpInclusionSteps = reverse inclusionSteps`. But `navigate` already accumulates those steps **subtree→root** (it prepends while descending), and `foldInclusionSteps` (csmt-core) consumes them **subtree→root**. The `reverse` flips them to root→subtree.

It's a no-op for 0 or 1 inclusion steps, so empty-prefix and single-subtree completeness proofs verified fine — which is why it stayed hidden. With **≥2 inclusion steps** (a tree with two or more address subtrees) the proof folds to the wrong root, so `verifyCompletenessProof` / `foldCompletenessProof` reject a valid set (`CompletenessProofInvalid`).

Surfaced downstream as `GET /tokens/:id/requests` completeness failing once a token and a request coexist (cardano-foundation/moog #152 canary; lambdasistemi/cardano-mpfs-offchain #319).

## Fix

`cpInclusionSteps = inclusionSteps` — keep the subtree→root order `foldInclusionSteps` expects (matches inclusion proofs).

## Test (the coverage gap)

The only round-trip property for the client `verifyCompletenessProof` ran at the **empty prefix** (0 steps); the one non-empty-prefix test used 1-bit prefixes (1 step) via the write-side verifier. Neither reached ≥2 steps.

Added `round-trips populated deep-prefix proofs`: a `forAll` generator plants a sibling at every level of a depth∈[2,6] prefix (guaranteeing ≥2 inclusion steps), asserts `length cpInclusionSteps >= 2` so it can't silently degrade, and cross-checks **both** `foldCompletenessProof` (write) and `verifyCompletenessProof` (verify) at the deep prefix. RED before the fix, green after; full CSMT suite 241/0.