### PR TITLE
fix(release): close cabal version block with x-release-please-end

### DIFF
--- a/mts.cabal
+++ b/mts.cabal
@@ -4,7 +4,7 @@ name:            mts
 -- x-release-please-start-version
 version:         1.0.0
 
--- x-release-please-end-version
+-- x-release-please-end
 synopsis:        Merkle Tree Store with pluggable trie implementations
 description:
   MTS is a Haskell library providing a shared Merkle tree store


### PR DESCRIPTION
The generic-updater block end marker must be `x-release-please-end` (not `x-release-please-end-version`). With the wrong marker, release-please never closed the block and skipped bumping `mts.cabal` — so the v1.0.1 release PR (#164) left the cabal version at 1.0.0, which the new drift guard correctly failed on.

Verified locally: `cabal check` rc=0, `just format-check` rc=0, drift guard passes (cabal 1.0.0 == manifest 1.0.0 on this branch).

After merge, release-please regenerates #164 with the `mts.cabal` bump to 1.0.1 and its drift guard goes green.