### PR TITLE
fix(release): run release-please in manifest mode so extra-files apply

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,12 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
+          # No release-type input on purpose: passing it makes the action
+          # ignore release-please-config.json (and its extra-files generic
+          # updater for mts.cabal), bumping only the manifest. Manifest mode
+          # reads release-type "simple" from the config file instead.
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           # Non-GITHUB_TOKEN identity so the release PR's branch push emits
           # pull_request/push events — otherwise GitHub suppresses them for
           # GITHUB_TOKEN-authored commits and the required checks never run.


### PR DESCRIPTION
Passing `release-type: simple` as an action **input** makes release-please-action ignore `release-please-config.json` (and its `extra-files` generic updater for `mts.cabal`), bumping only the manifest. That's why v1.0.1's PR #164 left the cabal version at 1.0.0 — the drift guard correctly blocked it.

Fix: drop the input and point at the config/manifest files so the action runs **manifest mode**, which reads `release-type: "simple"` from the config AND applies `extra-files`.

**Verified locally** (not via CI): `release-please manifest-pr --dry-run --debug` shows `mts.cabal: [class Generic extends DefaultUpdater]` in the plan — manifest mode assigns the updater and bumps it.

After merge, release-please regenerates #164 with the `mts.cabal` 1.0.1 bump and its drift guard goes green.