### PR TITLE
docs: align README, docs site, and agent layer with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Repository Agent Guide
+
+## What this repo is
+
+`haskell-mts` is a Haskell library (package name `mts`) providing a
+shared Merkle tree store interface with two pluggable trie backends:
+**CSMT** (a compact sparse binary trie) and **MPF** (a 16-ary Merkle
+Patricia Forest with Aiken-compatible hashing). Both expose the same
+mode-indexed `MerkleTreeStore` GADT and pass a shared QuickCheck suite.
+The repo also ships a generic swap-partition rollback library
+(`mts:rollbacks`) with Lean 4 correctness proofs, WASM builds of the
+pure write/verify paths with in-browser demos, an interactive `mts`
+CLI for CSMT, and a TypeScript CSMT proof verifier.
+
+It is split into Cabal sublibraries (see `mts.cabal`): `mts` (interface
++ properties), `csmt-core`, `csmt-write`, `csmt`, `csmt-verify`,
+`mpf-write`, `mpf`, `rollbacks`, plus test-lib helpers.
+
+## How to work here
+
+The nix dev shell provides GHC, cabal, just, fourmolu, mkdocs, and
+asciinema tooling. Prefer `just` recipes over raw cabal.
+
+```bash
+nix develop                 # enter the dev shell
+just build                  # cabal build all --enable-tests --enable-benchmarks
+just test                   # cabal test unit-tests (add "pattern" to filter)
+just test "MPF"             # run only matching specs
+just format                 # fourmolu + cabal-fmt + nixfmt
+just format-check           # CI formatting gate
+just lean                   # build the Lean 4 proofs (cd lean && lake build)
+just bench                  # run benchmarks
+just serve-docs             # mkdocs live preview
+just build-docs             # mkdocs build
+```
+
+There is a single test-suite, `unit-tests` (`cabal test unit-tests`),
+covering CSMT, MPF, the shared properties, and rollbacks. (The
+`just test-mpf` / `just integration` recipes reference test-suites that
+do not exist in `mts.cabal` — use `just test` instead.)
+
+Build the CLI and run it:
+
+```bash
+nix build .#mts
+export CSMT_DB_PATH=./mydb
+./result/bin/mts <<< 'i k v'
+```
+
+WASM artifacts and demos are exported by the flake on x86_64-linux
+(`nix build .#csmt-verify-wasm`, `nix run .#docs`, etc.).
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose
+description matches your task:
+
+- `skills/haskell-mts-guide/` — how the repo is laid out, how to build
+  and test it, where the CSMT/MPF/rollbacks logic lives, how to use the
+  `mts` CLI and the library API, and where answers to common questions
+  live.
+
+## Conventions
+
+- Apache-2.0 licensed; keep every component Hackage-shaped where
+  possible (`cabal check`), though `rocksdb-kv-transactions` is not yet
+  on Hackage.
+- Fourmolu formatting with a 70-character line limit, leading commas.
+- Releases are cut by release-please (manifest mode); `mts.cabal`'s
+  version block is kept in sync and CI fails on drift.

--- a/README.md
+++ b/README.md
@@ -3,101 +3,87 @@
 [![CI](https://github.com/lambdasistemi/haskell-mts/actions/workflows/CI.yaml/badge.svg)](https://github.com/lambdasistemi/haskell-mts/actions/workflows/CI.yaml)
 [![Documentation](https://github.com/lambdasistemi/haskell-mts/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/lambdasistemi/haskell-mts/actions/workflows/deploy-docs.yaml)
 
-A Haskell library providing a shared Merkle tree store interface with two
-implementations:
+Merkle Trees implementation in Haskell with persistent storage and Merkle proofs.
 
-- **CSMT** - Compact Sparse Merkle Tree (binary trie, path compression, CBOR
-  inclusion proofs)
-- **MPF** - Merkle Patricia Forest (16-ary trie, hex nibble keys, Aiken
-  compatible)
+## What is this
 
-Both implementations share a common `MerkleTreeStore` record. The shared
-QuickCheck property suite currently contains 13 properties: CSMT passes all
-13, while MPF passes the first 10 and still leaves completeness proofs
-pending.
+MTS is a Haskell library providing a shared interface for authenticated
+key-value stores backed by Merkle tries. It ships two implementations:
+
+- **CSMT** - Compact Sparse Merkle Tree: a binary trie with path
+  compression, CBOR-encoded inclusion and exclusion proofs, and
+  completeness proofs over prefix-grouped subtrees.
+- **MPF** - Merkle Patricia Forest: a 16-ary trie over hex nibble keys,
+  with root hashes and proof-step encodings compatible with the Aiken
+  reference implementation.
+
+Both implementations expose the same mode-indexed `MerkleTreeStore`
+GADT. In `Full` mode every mutation updates the trie, and root hash,
+inclusion, exclusion, and completeness proofs are available. In
+`KVOnly` mode mutations only append to a journal for fast ingest; the
+trie is rebuilt later by a parallel journal replay. Feature parity is
+enforced by a shared QuickCheck suite: 13 parity properties plus 6
+journal/replay properties, each run against both backends.
+
+The repository also contains a generic swap-partition rollback library
+(`mts:rollbacks`) whose core algorithms are proved correct in Lean 4
+(`lean/`), WASM builds of the pure write/verify paths powering
+in-browser demos, and a TypeScript verifier for CSMT proofs.
 
 > **Warning**: This project is in early development and is not production-ready.
 
-## Features
+## Architecture
 
-- **Shared interface**: `MerkleTreeStore` record parameterised by
-  implementation tag and monad, with type families for key/value/hash/proof
-  types
-- **Two trie backends**: Binary (CSMT) and 16-ary (MPF), swappable via the
-  shared interface
-- **Merkle proofs**: Inclusion and exclusion proofs for both implementations;
-  CSMT also supports completeness proofs
-- **Persistent storage**: RocksDB backend for both implementations
-- **Batch and streaming inserts**: MPF supports batch, chunked, and streaming
-  insertion modes
-- **Aiken compatibility**: MPF produces root hashes and proof-step encodings
-  matching the Aiken reference implementation
-- **Browser demos**: three static demos shipped through the docs site
-  (`csmt-verify.wasm`, `csmt-write.wasm`, `mpf-write.wasm` +
-  `mpf-verify.wasm`)
-- **CLI tool**: Interactive command-line interface for CSMT operations
-- **TypeScript verifier**: Client-side CSMT proof verification in
-  browser/Node.js
-- **Pure MPF verifier**: exact Aiken inclusion/exclusion verification in
-  Haskell via `MPF.Verify`
-
-## What Landed For MPF
-
-- explicit exclusion proofs with the same Aiken proof-step transport used for
-  inclusion proofs
-- a pure `MPF.Verify` module for exact Aiken proof-step verification
-- `mpf-write.wasm` and `mpf-verify.wasm`, wired into a browser demo that can
-  build, prove, and verify entirely in the browser
-- docs-site packaging for all three demos: CSMT verify, CSMT write, and MPF
-  write
-
-## Quick Start
-
-### Using the MTS Interface (recommended)
-
-```haskell
-import MTS.Interface (MerkleTreeStore(..))
-
--- Works with any implementation
-example :: MerkleTreeStore imp IO -> IO ()
-example store = do
-    mtsInsert store "key" "value"
-    proof <- mtsMkProof store "key"
-    root  <- mtsRootHash store
-    print (proof, root)
+```mermaid
+graph TD
+    CLI["mts executable<br/>interactive CSMT CLI"] --> CSMT
+    subgraph SUBLIBS["Cabal sublibraries"]
+        MTSI["mts<br/>MTS.Interface + shared properties"]
+        CSMTCORE["mts:csmt-core<br/>types, proof algebra, CBOR"]
+        CSMTW["mts:csmt-write<br/>pure backend, insert/delete, proofs"]
+        CSMT["mts:csmt<br/>RocksDB backend + CLI frontend"]
+        CSMTV["mts:csmt-verify<br/>pure Blake2b verification, WASM-safe"]
+        MPFW["mts:mpf-write<br/>pure backend, Aiken hashing, proofs"]
+        MPF["mts:mpf<br/>RocksDB backend"]
+        ROLL["mts:rollbacks<br/>swap-partition rollback log"]
+    end
+    CSMT --> CSMTW
+    CSMTW --> CSMTCORE
+    CSMTW --> MTSI
+    CSMTW --> CSMTV
+    CSMTV --> CSMTCORE
+    MPF --> MPFW
+    MPFW --> MTSI
+    MPFW --> CSMTV
+    WASM["WASM executables<br/>csmt/mpf write + verify demos"] --> CSMTW
+    WASM --> MPFW
+    WASM --> CSMTV
+    TS["TypeScript verifier<br/>verifiers/typescript"] -. "verifies CSMT proofs" .-> CSMTCORE
+    LEAN["Lean 4 proofs<br/>lean/"] -. "models" .-> ROLL
+    CSMT --> RDB[("RocksDB")]
+    MPF --> RDB
 ```
 
-### Constructing a CSMT Store
+## Install
 
-```haskell
-import CSMT.MTS (csmtMerkleTreeStore)
-import CSMT.Hashes (fromKVHashes, hashHashing)
-import CSMT.Backend.RocksDB (withStandaloneRocksDB)
+### Release artifacts
 
-main :: IO ()
-main = withStandaloneRocksDB "mydb" codecs $ \run db ->
-    let store = csmtMerkleTreeStore run db fromKVHashes hashHashing
-    in mtsInsert store "key" "value"
+Each [GitHub release](https://github.com/lambdasistemi/haskell-mts/releases)
+ships Linux x86_64 artifacts for the `mts` CLI: an AppImage, a `.deb`,
+an `.rpm`, and a docker image tarball.
+
+```bash
+gh release download --repo lambdasistemi/haskell-mts --pattern '*.AppImage'
+chmod +x mts-v*.AppImage
+./mts-v*.AppImage --version
 ```
 
-### Constructing an MPF Store
+The docker tarball loads as `ghcr.io/paolino/mts/mts`:
 
-```haskell
-import MPF.MTS (mpfMerkleTreeStore)
-import MPF.Hashes (fromHexKVAikenHashes, mpfHashing)
-import MPF.Backend.RocksDB (withMPFStandaloneRocksDB)
-
-main :: IO ()
-main = withMPFStandaloneRocksDB "mydb" codecs $ \run db ->
-    let store = mpfMerkleTreeStore run db fromHexKVAikenHashes mpfHashing
-    in mtsInsert store "key" "value"
+```bash
+gh release download --repo lambdasistemi/haskell-mts --pattern '*docker*'
+docker load < mts-v*-docker.tar.gz
 ```
-
-Use `fromHexKVAikenHashes` when you want the same hashed key path that the
-Aiken-compatible proofs and browser demo use. `fromHexKVHashes` still exists
-for direct raw-byte-to-nibble routing.
-
-## Installation
 
 ### Using Nix
 
@@ -114,9 +100,78 @@ Requires a working Haskell environment and RocksDB development files:
 cabal install
 ```
 
-## WASM Outputs With Nix
+## Quickstart
 
-The flake exports both the combined WASM bundle and the individual modules:
+Point the CLI at a database directory and pipe commands in:
+
+```bash
+export CSMT_DB_PATH=./mydb
+mts <<'EOF'
+i key1 value1
+q key1
+r
+EOF
+```
+
+```text
+AddedKey
+hJggAAEBAAEAAQEAAQEAAAEAAQABAQEBAAABAAABAQAAAAFYIBCf1UdGHyJjFT9Ie9m6K1UWWQ67U3o15jkbh4ifOE8RgJggAAEBAAEAAQEAAQEAAAEAAQABAQEBAAABAAABAQAAAAE=
+HZ9W8HqKzlkg3M7y1ivUYtAGm1qJ48zRCU8O3+CCf/A=
+```
+
+Run `mts` without piping for an interactive session with the same
+commands. See the [CLI manual](https://lambdasistemi.github.io/haskell-mts/manual/)
+for the full command set.
+
+## Usage
+
+### Library
+
+`MerkleTreeStore` is indexed by mode: KV operations live in the
+`MtsKV` record (always available), tree operations in `MtsTree`
+(only in `Full` mode). Construct a CSMT-backed store with
+`csmtMerkleTreeStore`, here over the in-memory backend:
+
+```haskell
+import CSMT.Backend.Pure (emptyInMemoryDB, pureDatabase, runPure)
+import CSMT.Hashes (fromKVHashes, hashHashing)
+import CSMT.Interface (csmtCodecs)
+import CSMT.MTS (csmtMerkleTreeStore)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import MTS.Interface (MtsKV (..), MtsTree (..), mtsKV, mtsTree)
+
+main :: IO ()
+main = do
+    ref <- newIORef emptyInMemoryDB
+    let run action = do
+            db <- readIORef ref
+            let (a, db') = runPure db action
+            writeIORef ref db'
+            pure a
+    store <-
+        csmtMerkleTreeStore [] run (pureDatabase csmtCodecs)
+            fromKVHashes hashHashing
+    mtsInsert (mtsKV store) "key" "value"
+    mproof <- mtsMkProof (mtsTree store) "key"
+    mroot <- mtsRootHash (mtsTree store)
+    print (() <$ mproof, () <$ mroot)
+```
+
+The first argument is the namespace prefix (`[]` for the root). The
+MPF equivalent is `mpfMerkleTreeStore` from `MPF.MTS` with
+`fromHexKVAikenHashes`/`mpfHashing` from `MPF.Hashes`. For persistent
+storage use `withRocksDB` from `CSMT.Backend.RocksDB` (or
+`withMPFRocksDB` from `MPF.Backend.RocksDB`) to obtain the database
+handle, as done by the CLI frontend in `CSMT.Frontend.CLI.App`.
+
+Use `fromHexKVAikenHashes` when you want the same hashed key path that
+the Aiken-compatible proofs and browser demo use. `fromHexKVHashes`
+routes raw key bytes directly to nibbles.
+
+### WASM outputs
+
+The flake exports the combined WASM bundle and the individual modules
+(x86_64-linux only):
 
 ```bash
 nix build .#wasm-artifacts
@@ -135,20 +190,6 @@ PORT=8002 nix run .#mpf-wasm-write-demo
 PORT=8003 nix run .#docs
 ```
 
-## CLI Tool
-
-The `mts` executable provides an interactive CLI for CSMT operations:
-
-```bash
-export CSMT_DB_PATH=./mydb
-mts
-> i key1 value1
-> q key1
-AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
-> r
-NrJMih3czFriydMUwvFKFK6VYKZYVjKpKGe1WC4e+VU=
-```
-
 ## Documentation
 
 Full documentation at [lambdasistemi.github.io/haskell-mts](https://lambdasistemi.github.io/haskell-mts/)
@@ -160,6 +201,25 @@ Useful entry points:
 - [CSMT WASM verifier demo](https://lambdasistemi.github.io/haskell-mts/wasm-demo/)
 - [CSMT WASM write demo](https://lambdasistemi.github.io/haskell-mts/wasm-write-demo/)
 - [MPF WASM write demo](https://lambdasistemi.github.io/haskell-mts/wasm-mpf-demo/)
+
+For AI agents, start at [AGENTS.md](AGENTS.md).
+
+## Development
+
+The nix dev shell carries GHC, cabal, just, fourmolu, mkdocs, and the
+asciinema tooling:
+
+```bash
+nix develop
+just build         # cabal build all (tests + benchmarks)
+just test          # unit tests; just test "pattern" to filter
+just format        # fourmolu + cabal-fmt + nixfmt
+just lean          # build the Lean 4 proofs
+just serve-docs    # mkdocs live preview
+```
+
+`just` lists all recipes. CI runs the build, unit tests, benchmarks,
+TypeScript verifier tests, and formatting checks via the flake.
 
 ## License
 

--- a/docs/architecture/inclusion-proof.cddl
+++ b/docs/architecture/inclusion-proof.cddl
@@ -1,5 +1,6 @@
 ; CDDL specification for CSMT Inclusion Proof
-; CBOR encoding used by CSMT.Hashes.CBOR module
+; CBOR encoding defined in the CSMT.Core.CBOR module
+; (re-exported by CSMT.Hashes.CBOR)
 
 ; Direction in the merkle tree path (L=0, R=1)
 direction = 0 / 1
@@ -22,11 +23,12 @@ proof_step = [
     step_sibling: indirect
 ]
 
-; Complete inclusion proof
+; Complete inclusion proof (4-element array).
+; The root hash is NOT carried in the proof; the verifier supplies a
+; trusted root hash separately and compares it to the recomputed root.
 inclusion_proof = [
     proof_key: key,         ; The key being proven
     proof_value: hash,      ; Hash of the value at the key
-    proof_root_hash: hash,  ; Root hash this proves against
     proof_steps: [* proof_step],
     proof_root_jump: key    ; Jump path at the root
 ]

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,22 +1,24 @@
 # Storage Layer
 
-Both MTS implementations use a three-column storage model with RocksDB as
+Both MTS implementations use a four-column storage model with RocksDB as
 the persistent backend and in-memory backends for testing.
 
 ## Shared Model
 
-Both CSMT and MPF store data in three columns:
+Both CSMT and MPF store data in four columns:
 
 | Column | Key | Value | Purpose |
 |--------|-----|-------|---------|
 | KV | User key (`k`) | User value (`v`) | Original key-value pairs |
 | Trie | Derived tree key | Node reference | Merkle tree structure |
 | Journal | User key (`k`) | Tagged value | KVOnly mode replay log |
+| Metrics | Counter name | Int | Persistent KV count / journal size |
 
 The KV column stores original key-value pairs, enabling value retrieval
 and proof generation. The trie column stores the Merkle tree structure
 with implementation-specific node types. The journal column records
-mutations made in KVOnly mode.
+mutations made in KVOnly mode, and the metrics column holds
+transactional counters (KV count, journal size) for O(1) metrics queries.
 
 ### Journal Entry Format
 
@@ -163,6 +165,7 @@ data Standalone k v a x where
     StandaloneKVCol      :: Standalone k v a (KV k v)
     StandaloneCSMTCol    :: Standalone k v a (KV Key (Indirect a))
     StandaloneJournalCol :: Standalone k v a (KV ByteString ByteString)
+    StandaloneMetricsCol :: Standalone k v a (KV ByteString Int)
 ```
 
 ---
@@ -253,8 +256,10 @@ putHexIndirect HexIndirect{hexJump, hexValue, hexIsLeaf} = do
 
 ```haskell
 data MPFStandalone k v a x where
-    MPFStandaloneKVCol  :: MPFStandalone k v a (KV k v)
-    MPFStandaloneMPFCol :: MPFStandalone k v a (KV HexKey (HexIndirect a))
+    MPFStandaloneKVCol      :: MPFStandalone k v a (KV k v)
+    MPFStandaloneMPFCol     :: MPFStandalone k v a (KV HexKey (HexIndirect a))
+    MPFStandaloneJournalCol :: MPFStandalone k v a (KV ByteString ByteString)
+    MPFStandaloneMetricsCol :: MPFStandalone k v a (KV ByteString Int)
 ```
 
 ---

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -21,11 +21,11 @@ graph TD
 
 | Layer | Description |
 |-------|-------------|
-| **MTS Interface** | Shared `MerkleTreeStore` record with type families. Mode-indexed by `KVOnly` / `Full`. |
+| **MTS Interface** | Shared `MerkleTreeStore` GADT with type families. Mode-indexed by `KVOnly` / `Full`. |
 | **Ops GADT** | `CommonOps` + `Ops` GADT with bidirectional transitions (`toFull` / `toKVOnly`). |
 | **CSMT Implementation** | Binary trie with path compression, CBOR proofs, completeness proofs, CLI, crash recovery. |
-| **MPF Implementation** | 16-ary trie with hex nibble keys, batch/streaming inserts, Aiken-compatible hashes and proof-step verification. |
-| **Storage Backends** | RocksDB (persistent) and in-memory (testing) for both implementations. Three columns: KV, Trie, Journal. |
+| **MPF Implementation** | 16-ary trie with hex nibble keys, batch/streaming inserts, Aiken-compatible hashes, proof-step verification, completeness proofs. |
+| **Storage Backends** | RocksDB (persistent) and in-memory (testing) for both implementations. Four columns: KV, Trie, Journal, Metrics. |
 
 ### Components
 
@@ -41,8 +41,10 @@ graph TD
   verification for browser/Node.js.
 - **Browser WASM demos**: static demos for CSMT read-only verification, CSMT
   write/prove/verify, and MPF write/prove/verify.
+- **Rollbacks** (`mts:rollbacks`): a standalone swap-partition rollback log,
+  independent of the trie stores, with Lean 4 correctness proofs under
+  `lean/`.
 
 ## Planned
 
 - HTTP service exposing MTS operations via a RESTful API
-- MPF completeness proofs

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -29,7 +29,7 @@ With these three hashes, anyone can recompute the root and verify the proof.
 
 ## MTS: The Shared Interface
 
-MTS defines a common `MerkleTreeStore` record that abstracts over the trie
+MTS defines a common `MerkleTreeStore` GADT that abstracts over the trie
 implementation. Type families determine the concrete key, value, hash, proof,
 leaf, and completeness proof types for each backend:
 
@@ -38,11 +38,13 @@ leaf, and completeness proof types for each backend:
 | `mtsInsert` | `MtsKey imp -> MtsValue imp -> m ()` |
 | `mtsDelete` | `MtsKey imp -> m ()` |
 | `mtsRootHash` | `m (Maybe (MtsHash imp))` |
-| `mtsMkProof` | `MtsKey imp -> m (Maybe (MtsProof imp))` |
+| `mtsMkProof` | `MtsKey imp -> m (Maybe (MtsHash imp, MtsProof imp))` |
 | `mtsVerifyProof` | `MtsValue imp -> MtsProof imp -> m Bool` |
 | `mtsBatchInsert` | `[(MtsKey imp, MtsValue imp)] -> m ()` |
 
-Application code written against `MerkleTreeStore imp m` works with either
+`mtsInsert`/`mtsDelete` live in the `MtsKV` record (both modes); the
+remaining operations live in `MtsTree` (`Full` mode only). Application
+code written against `MerkleTreeStore mode imp m` works with either
 CSMT or MPF. See [MTS Interface](interface.md) for the full API.
 
 ## Sparse Merkle Trees
@@ -166,23 +168,25 @@ a given set of entries is **all** entries under that prefix. It consists of:
 2. A sequence of merge operations to reconstruct the subtree
 3. Sibling hashes at the boundary to connect back to the root
 
-Completeness proofs are currently implemented for CSMT only. MPF
-completeness proofs are planned.
+Both CSMT and MPF implement completeness proofs (CSMT in
+`CSMT.Proof.Completeness`, MPF in `MPF.Proof.Completeness`).
 
 ## Storage Model
 
-Both implementations use a three-column storage model:
+Both implementations use a four-column storage model:
 
 | Column | Key | Value | Purpose |
 |--------|-----|-------|---------|
 | KV | User key | User value | Original key-value pairs |
 | Trie | Derived tree key | Node (jump + hash) | Merkle tree structure |
 | Journal | User key | Tagged value | KVOnly replay log |
+| Metrics | Counter name | Int | Persistent KV count / journal size |
 
 The tree key is derived from the user key (and optionally a prefix from
 the value) using the `FromKV`/`FromHexKV` conversion records. The Journal
 column records mutations made in KVOnly mode for later replay against the
-tree.
+tree, and the Metrics column maintains transactional counters for O(1)
+metrics queries.
 
 See [Storage Layer](architecture/storage.md) for implementation-specific
 details.
@@ -224,18 +228,23 @@ the journal column brackets the non-atomic `toFull` sequence:
 2. Replay loop (parallel bucket transactions)
 3. `mergeSubtreeRoots` + delete sentinel (atomic)
 
-If the process crashes between steps 1–4, the next `toFull` detects the
+If the process crashes between steps 1 and 3, the next `toFull` detects the
 sentinel, runs `mergeSubtreeRoots` to fix the tree top, then continues
 with the normal replay of remaining journal entries.
 
-The `DbState` type exposes this as a three-state open result:
+The `DbState` type exposes this as a two-state open result:
 
 - `NeedsRecovery` — sentinel found, must run recovery first
 - `Ready` — clean state, choose KVOnly or Full
 
 ## Rollbacks
 
-The `rollbacks` library implements a swap-partition model where two
-database partitions alternate between "live" and "staging" roles.
-Rollbacks discard the staging partition and swap back. Formal
-correctness is proved in Lean 4 (see `lean/` directory).
+The `rollbacks` library (`mts:rollbacks`) implements a swap-partition
+model: every mutation is a *swap*. Inserting, updating, or deleting a
+key puts a new binding into the state and yields the displaced
+binding, which is the inverse operation. The store records each
+rollback point's inverse log; `rollbackTo` replays those inverses in
+reverse order to restore an earlier state. The model and its
+correctness are formalized in Lean 4 — see `lean/Rollbacks/`
+(`SwapPartition.lean` for the model, `Rollback.lean` for the proofs).
+This library is independent of the CSMT/MPF trees.

--- a/docs/csmt.md
+++ b/docs/csmt.md
@@ -27,14 +27,16 @@ CSMT is the original implementation in this package. It provides:
 
 ```haskell
 data FromKV k v a = FromKV
-    { fromK      :: k -> Key        -- User key to binary path
+    { isoK       :: Iso' k Key      -- User key <-> binary path (bidirectional)
     , fromV      :: v -> a           -- User value to hash
     , treePrefix :: v -> Key         -- Optional prefix for secondary indexing
     }
 ```
 
-The default `fromKVHashes` hashes both key and value with Blake2b-256 and
-uses no prefix (`treePrefix = const []`).
+`isoK` is an isomorphism (not a one-way function) so that proofs can
+recover the original key. The default `fromKVHashes` maps keys to/from
+their byte paths, hashes values with Blake2b-256, and uses no prefix
+(`treePrefix = const []`).
 
 ### `Indirect` - Tree Nodes
 
@@ -56,14 +58,16 @@ data Hashing a = Hashing
 
 ## Storage
 
-CSMT uses two columns:
+CSMT uses four RocksDB columns (KV, CSMT tree, journal, and metrics);
+the two that hold the data and tree are:
 
 | Column | Key | Value |
 |--------|-----|-------|
 | KV | User key (`k`) | User value (`v`) |
-| CSMT | `treePrefix(v) <> fromK(k)` | `Indirect a` (jump + hash) |
+| CSMT | `treePrefix(v) <> view isoK k` | `Indirect a` (jump + hash) |
 
-See [Storage Layer](architecture/storage.md) for serialization details.
+See [Storage Layer](architecture/storage.md) for the journal/metrics
+columns and serialization details.
 
 ## Inclusion Proofs
 
@@ -118,13 +122,13 @@ via the `PatchOp` type.
 ```haskell
 patchParallel
     :: (GCompare d, Ord jk, Monad m)
-    => Int                         -- bucket bits (e.g. 4 → 16 buckets)
-    -> Key                         -- global prefix
+    => Int                              -- bucket bits (e.g. 4 → 16 buckets)
+    -> Key                              -- global prefix (usually [])
     -> Hashing a
-    -> Selector d Key (Indirect a) -- CSMT column
-    -> Selector d jk v             -- journal column
-    -> [(jk, PatchOp Key a)]       -- (journal key, tree op) pairs
-    -> [Transaction m cf d ops ()] -- independent bucket transactions
+    -> Selector d Key (Indirect a)      -- CSMT column
+    -> Selector d jk v                  -- journal column
+    -> [(jk, PatchOp Key a)]            -- (journal key, tree op) pairs
+    -> [(Int, Transaction m cf d ops ())] -- (op count, txn) per active bucket
 ```
 
 Benchmarks on a development machine (RocksDB, `-O2 -threaded -N`):
@@ -171,7 +175,7 @@ A **sentinel flag** in the journal column brackets this sequence:
 3. mergeSubtreeRoots + delete sentinel (one transaction)
 ```
 
-If the process crashes between steps 1–4, the next `toFull` call
+If the process crashes between steps 1 and 3, the next `toFull` call
 detects the sentinel, runs `mergeSubtreeRoots` to fix the tree
 top, deletes the sentinel, then replays remaining journal entries
 normally.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,34 +10,37 @@ authenticated key-value stores backed by Merkle tries. It ships with two
 implementations:
 
 - **CSMT** - Compact Sparse Merkle Tree: a binary trie with path compression,
-  CBOR-encoded inclusion proofs, and completeness proofs via secondary
-  indexing.
+  CBOR-encoded inclusion and exclusion proofs, and completeness proofs via
+  secondary indexing.
 - **MPF** - Merkle Patricia Forest: a 16-ary trie using hex nibble keys,
   with batch/streaming inserts and root hashes compatible with the Aiken
   reference implementation.
 
-Both implementations conform to a single `MerkleTreeStore` record type
-parameterised by an implementation tag and a monad, so application code
-can be written once and run against either backend.
+Both implementations conform to a single `MerkleTreeStore` GADT indexed by
+a `Mode` (`KVOnly` or `Full`), an implementation tag, and a monad, so
+application code can be written once and run against either backend.
 
 ## Features
 
-- **Shared interface**: `MerkleTreeStore` record with type families for key,
-  value, hash, proof, leaf, and completeness proof types
+- **Shared interface**: mode-indexed `MerkleTreeStore` GADT with type
+  families for key, value, hash, proof, leaf, and completeness proof types
   ([MTS Interface](interface.md))
-- **13 QuickCheck properties**: Verify feature parity across implementations
-  (insert-verify, order independence, batch equivalence, completeness
-  round-trip, etc.)
+- **Shared QuickCheck suite**: 13 parity properties plus 6 journal/replay
+  properties (insert-verify, order independence, completeness round-trip,
+  replay idempotence, etc.), each run against both implementations
 - **Two trie backends**: Binary (CSMT) and 16-ary (MPF), each with RocksDB
   and in-memory storage
-- **Merkle proofs**: Inclusion and exclusion proofs for both
-  implementations; CSMT also supports completeness proofs over
-  prefix-grouped subtrees
+- **Merkle proofs**: Inclusion, exclusion, and completeness proofs for
+  both implementations
+- **KVOnly fast ingest**: journal-backed mutations with parallel replay
+  (`patchParallel`) and crash recovery
 - **Batch and streaming inserts**: MPF supports `insertingBatch`,
   `insertingChunked`, and `insertingStream` for large datasets
 - **Aiken compatibility**: MPF produces root hashes and proof-step
   encodings matching the Aiken `MerkleTree` implementation (verified
   against the 30-fruit test vector)
+- **Rollbacks**: generic swap-partition rollback library
+  (`mts:rollbacks`) with Lean 4 correctness proofs under `lean/`
 - **Browser demos**: published static demos for read-only CSMT verify,
   CSMT write/prove/verify, and MPF write/prove/verify
 - **CLI tool**: Interactive command-line interface for CSMT tree operations
@@ -50,14 +53,16 @@ can be written once and run against either backend.
 
 === "MTS Interface"
     ```haskell
-    import MTS.Interface (MerkleTreeStore(..))
+    import MTS.Interface
+        ( MtsKV (..), MtsTree (..), mtsKV, mtsTree )
 
-    example :: MerkleTreeStore imp IO -> IO ()
+    -- KV ops live in MtsKV, tree ops in MtsTree ('Full mode only)
+    example :: MerkleTreeStore 'Full imp IO -> IO ()
     example store = do
-        mtsInsert store "key" "value"
-        proof <- mtsMkProof store "key"
-        root  <- mtsRootHash store
-        print (proof, root)
+        mtsInsert (mtsKV store) "key" "value"
+        proof <- mtsMkProof (mtsTree store) "key"
+        root  <- mtsRootHash (mtsTree store)
+        print (() <$ proof, () <$ root)
     ```
 
 === "CLI"
@@ -65,24 +70,26 @@ can be written once and run against either backend.
     export CSMT_DB_PATH=./mydb
     mts
     > i key1 value1
-    > q key1
-    AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
+    Added key, inclusion proof generated
+    > r
+    root: HZ9W8HqKzlkg3M7y1ivUYtAGm1qJ48zRCU8O3+CCf/A=
     ```
 
 ## Status
 
 ### Shared Interface (`mts`)
-- [x] `MerkleTreeStore` record with type families
-- [x] 13 shared QuickCheck properties
-- [x] CSMT passes all 13 properties
-- [x] MPF passes 10 of 13 (completeness proofs pending)
+- [x] Mode-indexed `MerkleTreeStore` GADT with type families
+- [x] 13 shared parity properties + 6 replay properties
+- [x] CSMT passes the full suite
+- [x] MPF passes the full suite
 
 ### CSMT Implementation (`mts:csmt`)
 - [x] Insertion and deletion
-- [x] Inclusion proof generation and verification (CBOR)
+- [x] Inclusion and exclusion proof generation and verification (CBOR)
 - [x] Completeness proofs (prefix-based subtrees)
 - [x] Persistent storage (RocksDB)
 - [x] Secondary indexing via `treePrefix`
+- [x] KVOnly journal mode with parallel replay and crash recovery
 - [x] CLI tool
 - [x] TypeScript proof verifier
 - [x] Insertion benchmarks
@@ -90,13 +97,14 @@ can be written once and run against either backend.
 ### MPF Implementation (`mts:mpf`)
 - [x] Insertion and deletion
 - [x] Inclusion and exclusion proof generation
+- [x] Completeness proofs (`MPF.Proof.Completeness`)
 - [x] Pure Aiken inclusion/exclusion verification (`MPF.Verify`)
 - [x] Batch, chunked, and streaming inserts
 - [x] Aiken-compatible root hashes and proof-step encoding
 - [x] Browser write/prove/verify demo (`mpf-write.wasm` + `mpf-verify.wasm`)
 - [x] Persistent storage (RocksDB)
-- [ ] Completeness proofs
-- [ ] Benchmarks
+- [x] KVOnly journal mode with replay
+- [x] Benchmarks (`mpf-bench`, `mpf-bench-rocksdb`, `unified`)
 
 ## Tutorials And Demos
 
@@ -112,5 +120,4 @@ Start here if you want a guided path through the repository:
 
 ### Planned
 - [ ] HTTP service with RESTful API
-- [ ] MPF completeness proofs
 - [ ] Production-grade testing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,34 +1,39 @@
 # Installation
 
-There is currently no releasing in place, but you can install via the provided artifacts from the CI.
-
-## Docker images
-
-```bash
-gh run download -n mts-image
-i=$(docker load < mts-image | sed -e 's/Loaded image: //')
-docker run $i
-```
+Releases are cut by release-please; each
+[GitHub release](https://github.com/lambdasistemi/haskell-mts/releases)
+ships Linux x86_64 artifacts for the `mts` CLI built from the nix flake.
 
 ## AppImage bundles
 
 ```bash
-gh run download -n mts.AppImage
-./mts.AppImage
+gh release download --repo lambdasistemi/haskell-mts --pattern '*.AppImage'
+chmod +x mts-v*.AppImage
+./mts-v*.AppImage --version
 ```
 
-## RPM packages
+## Docker images
+
+The tarball loads as `ghcr.io/paolino/mts/mts` with `mts` as entrypoint:
 
 ```bash
-gh run download -n mts-rpm
-sudo rpm -i mts.rpm
+gh release download --repo lambdasistemi/haskell-mts --pattern '*docker*'
+i=$(docker load < mts-v*-docker.tar.gz | sed -e 's/Loaded image: //')
+docker run $i --version
 ```
 
 ## DEB packages
 
 ```bash
-gh run download -n mts-deb
-sudo dpkg -i mts.deb
+gh release download --repo lambdasistemi/haskell-mts --pattern '*.deb'
+sudo dpkg -i mts-v*.deb
+```
+
+## RPM packages
+
+```bash
+gh release download --repo lambdasistemi/haskell-mts --pattern '*.rpm'
+sudo rpm -i mts-v*.rpm
 ```
 
 ## Building from source
@@ -58,7 +63,7 @@ cabal install
 ## WASM Outputs And Preview Commands
 
 The flake exports the combined browser-WASM bundle plus one package per
-module:
+module (x86_64-linux only, where the GHC WASM toolchain is available):
 
 ```bash
 nix build .#wasm-artifacts

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -15,6 +15,7 @@ type family MtsHash imp              -- Hash type
 type family MtsProof imp             -- Inclusion proof type
 type family MtsLeaf imp              -- Leaf type (for completeness proofs)
 type family MtsCompletenessProof imp -- Completeness proof type
+type family MtsPrefix imp            -- Namespace prefix type
 ```
 
 ### CSMT Type Instances
@@ -26,7 +27,8 @@ type family MtsCompletenessProof imp -- Completeness proof type
 | `MtsHash CsmtImpl` | `Hash` (Blake2b-256) |
 | `MtsProof CsmtImpl` | `InclusionProof Hash` |
 | `MtsLeaf CsmtImpl` | `Indirect Hash` |
-| `MtsCompletenessProof CsmtImpl` | `CompletenessProof` |
+| `MtsCompletenessProof CsmtImpl` | `CompletenessProof Hash` |
+| `MtsPrefix CsmtImpl` | `Key` |
 
 ### MPF Type Instances
 
@@ -37,7 +39,8 @@ type family MtsCompletenessProof imp -- Completeness proof type
 | `MtsHash MpfImpl` | `MPFHash` (Blake2b-256) |
 | `MtsProof MpfImpl` | `MPFProof MPFHash` |
 | `MtsLeaf MpfImpl` | `HexIndirect MPFHash` |
-| `MtsCompletenessProof MpfImpl` | `()` (not yet implemented) |
+| `MtsCompletenessProof MpfImpl` | `MPFCompose MPFHash` |
+| `MtsPrefix MpfImpl` | `HexKey` |
 
 ## MerkleTreeStore Record
 
@@ -49,9 +52,15 @@ data MerkleTreeStore (mode :: Mode) imp m where
     MkFull   :: MtsKV imp m -> MtsTree imp m -> MerkleTreeStore 'Full imp m
 ```
 
-`MtsKV` provides insert/delete/query. `MtsTree` provides root hash,
-proofs, batch insert, and completeness operations. In KVOnly mode,
-only KV operations are available.
+`MtsKV` provides `mtsInsert`, `mtsDelete`, and `mtsMetrics` (persistent
+KV/journal counters). `MtsTree` provides root hash, proofs, batch
+insert, leaf collection, and completeness operations. Use the `mtsKV`
+and `mtsTree` accessors to reach them; in `KVOnly` mode only KV
+operations are available.
+
+The `MtsTransition` record bundles a `KVOnly` store with a one-shot
+`transitionToFull` action that replays the journal and returns the
+`Full` store, disabling the `KVOnly` handle.
 
 ## Split-Mode Ops GADT
 
@@ -91,69 +100,82 @@ data Ops (mode :: Mode) m cf d ops k v a where
 
 ### `csmtMerkleTreeStore`
 
-Build a CSMT-backed store. Requires a natural transformation from the
-database monad to `IO`, a `Database` handle, a `FromKV` record, and a
-`Hashing` record:
+Build a CSMT-backed `Full` store. Takes the namespace prefix (`[]` for
+the root), a natural transformation from the database monad to `IO`, a
+`Database` handle, a `FromKV` record, and a `Hashing` record. Fails if
+the journal contains unplayed entries:
 
 ```haskell
 csmtMerkleTreeStore
     :: (MonadFail m)
-    => (forall b. m b -> IO b)
+    => Key                       -- prefix, [] for root
+    -> (forall b. m b -> IO b)
     -> Database m StandaloneCF (Standalone ByteString ByteString Hash) StandaloneOp
     -> FromKV ByteString ByteString Hash
     -> Hashing Hash
-    -> MerkleTreeStore CsmtImpl IO
+    -> IO (MerkleTreeStore 'Full CsmtImpl IO)
 ```
 
 ### `mpfMerkleTreeStore`
 
-Build an MPF-backed store. Same pattern, with MPF-specific types:
+Build an MPF-backed `Full` store. Same pattern, with MPF-specific types:
 
 ```haskell
 mpfMerkleTreeStore
     :: (MonadFail m)
-    => (forall b. m b -> IO b)
+    => HexKey                    -- prefix, [] for root
+    -> (forall b. m b -> IO b)
     -> Database m MPFStandaloneCF (MPFStandalone ByteString ByteString MPFHash) MPFStandaloneOp
     -> FromHexKV ByteString ByteString MPFHash
     -> MPFHashing MPFHash
-    -> MerkleTreeStore MpfImpl IO
+    -> IO (MerkleTreeStore 'Full MpfImpl IO)
 ```
+
+Both implementations also provide `KVOnly` constructors
+(`csmtKVOnlyStore`, `mpfKVOnlyStore`), managed transitions
+(`csmtManagedTransition`, `mpfManagedTransition`), and namespaced
+variants (`csmtNamespacedMTS`, `mpfNamespacedMTS`) that scope multiple
+independent trees inside one database via the `MtsPrefix` type.
 
 ## Usage Example
 
 From the test suite (`MTS.PropertySpec`), showing how to construct both
-stores:
+stores over the in-memory backends:
 
 ```haskell
 -- CSMT store using in-memory backend
-mkCsmtStore :: IO (MerkleTreeStore CsmtImpl IO)
+mkCsmtStore :: IO (MerkleTreeStore 'Full CsmtImpl IO)
 mkCsmtStore = do
     ref <- newIORef emptyInMemoryDB
-    let run action = do
+    let run :: forall b. Pure b -> IO b
+        run action = do
             db <- readIORef ref
             let (a, db') = runPure db action
             writeIORef ref db'
             pure a
-    pure $ csmtMerkleTreeStore run (pureDatabase csmtCodecs)
-                               fromKVHashes hashHashing
+    csmtMerkleTreeStore [] run (pureDatabase csmtCodecs)
+        fromKVHashes hashHashing
 
 -- MPF store using in-memory backend
-mkMpfStore :: IO (MerkleTreeStore MpfImpl IO)
+mkMpfStore :: IO (MerkleTreeStore 'Full MpfImpl IO)
 mkMpfStore = do
     ref <- newIORef emptyMPFInMemoryDB
-    let run action = do
+    let run :: forall b. MPFPure b -> IO b
+        run action = do
             db <- readIORef ref
             let (a, db') = runMPFPure db action
             writeIORef ref db'
             pure a
-    pure $ mpfMerkleTreeStore run (mpfPureDatabase mpfCodecs)
-                              fromHexKVBS mpfHashing
+    mpfMerkleTreeStore [] run (mpfPureDatabase mpfCodecs)
+        fromHexKVHashes mpfHashing
 ```
 
 ## Shared QuickCheck Properties
 
-The `MTS.Properties` module provides 12 properties that any
-`MerkleTreeStore` implementation should satisfy:
+The `MTS.Properties` module provides the shared property suite run by
+`MTS.PropertySpec` against both implementations: 13 parity properties
+over `Full` stores plus 6 journal/replay properties over the
+KVOnly-then-replay lifecycle.
 
 | # | Property | Description |
 |---|----------|-------------|
@@ -162,14 +184,24 @@ The `MTS.Properties` module provides 12 properties that any
 | 3 | `propInsertionOrderIndependence` | Same keys in any order produce the same root hash |
 | 4 | `propDeleteRemovesKey` | Insert k v, delete k, verify fails |
 | 5 | `propDeletePreservesSiblings` | Delete one key, other keys still verify |
-| 6 | `propBatchEqualsSequential` | Batch insert produces same root as sequential |
-| 7 | `propInsertDeleteAllEmpty` | Insert N, delete all N, root is Nothing |
-| 8 | `propEmptyTreeNoRoot` | Empty tree has no root hash |
-| 9 | `propSingleInsertHasRoot` | Single insert produces a root hash |
-| 10 | `propWrongValueRejects` | Verify with wrong value returns False |
+| 6 | `propInsertDeleteAllEmpty` | Insert N, delete all N, root is Nothing |
+| 7 | `propEmptyTreeNoRoot` | Empty tree has no root hash |
+| 8 | `propSingleInsertHasRoot` | Single insert produces a root hash |
+| 9 | `propWrongValueRejects` | Verify with wrong value returns False |
+| 10 | `propProofAnchoredToRoot` | Root returned by `mtsMkProof` matches `mtsFoldProof` |
 | 11 | `propCompletenessRoundTrip` | Insert N, completeness proof verifies |
 | 12 | `propCompletenessEmpty` | Empty tree has no completeness proof |
 | 13 | `propCompletenessAfterDelete` | Completeness proof verifies after partial deletion |
 
-CSMT passes all 13 properties. MPF passes properties 1-10; completeness
-properties (11-13) are pending implementation.
+Replay properties (per implementation):
+
+| # | Property | Description |
+|---|----------|-------------|
+| 14 | `propKVOnlyThenReplayMatchesFull` | KVOnly inserts + replay produce the same root as a Full store |
+| 15 | `propKVOnlyThenReplayProofsWork` | All keys have valid proofs after replay |
+| 16 | `propKVOnlyDeleteThenReplay` | Surviving keys verify after KVOnly deletes + replay |
+| 17 | `propReplayIdempotent` | Replaying an empty journal is a no-op |
+| 18 | `propJournalCompression` | Insert-then-delete in KVOnly leaves no trace after replay |
+| 19 | `propReplayTraceMonotonic` | Replay trace entries-remaining decreases monotonically |
+
+Both CSMT and MPF pass the full suite.

--- a/docs/library.md
+++ b/docs/library.md
@@ -15,32 +15,40 @@ definition.
 
 ### Basic Usage
 
-```haskell
-import MTS.Interface (MerkleTreeStore(..))
+KV operations come from `mtsKV`; tree operations (root hash, proofs,
+batch insert) come from `mtsTree` and require a `'Full`-mode store:
 
-example :: MerkleTreeStore imp IO -> IO ()
+```haskell
+import MTS.Interface
+    ( MerkleTreeStore, Mode (Full)
+    , MtsKV (..), MtsTree (..), mtsKV, mtsTree )
+
+example :: MerkleTreeStore 'Full imp IO -> IO ()
 example store = do
+    let kv   = mtsKV store
+        tree = mtsTree store
+
     -- Insert
-    mtsInsert store "key1" "value1"
-    mtsInsert store "key2" "value2"
+    mtsInsert kv "key1" "value1"
+    mtsInsert kv "key2" "value2"
 
     -- Root hash
-    mroot <- mtsRootHash store
+    mroot <- mtsRootHash tree
     print mroot
 
-    -- Inclusion proof
-    mp <- mtsMkProof store "key1"
+    -- Inclusion proof (returns the root hash alongside the proof)
+    mp <- mtsMkProof tree "key1"
     case mp of
         Nothing -> putStrLn "Key not found"
-        Just proof -> do
-            ok <- mtsVerifyProof store "value1" proof
+        Just (_root, proof) -> do
+            ok <- mtsVerifyProof tree "value1" proof
             print ok  -- True
 
     -- Batch insert
-    mtsBatchInsert store [("key3", "value3"), ("key4", "value4")]
+    mtsBatchInsert tree [("key3", "value3"), ("key4", "value4")]
 
     -- Delete
-    mtsDelete store "key1"
+    mtsDelete kv "key1"
 ```
 
 ### Constructing Stores
@@ -63,8 +71,8 @@ integration), use the `mts:csmt` sub-library directly.
 | `CSMT.Insertion` | `inserting`, `expandToBucketDepth`, `mergeSubtreeRoots` |
 | `CSMT.Deletion` | `deleting` |
 | `CSMT.Populate` | `patchParallel`, `PatchOp` — bucketed parallel replay |
-| `CSMT.Proof.Insertion` | `buildInclusionProof`, `verifyInclusionProof`, `computeRootHash` |
-| `CSMT.Proof.Completeness` | `generateProof`, `collectValues`, `foldProof` |
+| `CSMT.Proof.Insertion` | `buildInclusionProof`, `verifyInclusionProof`, `computeRootHash`, `foldProof` |
+| `CSMT.Proof.Completeness` | `generateProof`, `collectValues`, `foldCompletenessProof` |
 | `CSMT.Backend.RocksDB` | RocksDB persistent backend |
 | `CSMT.Backend.Pure` | In-memory backend for testing |
 | `CSMT.Backend.Standalone` | Column selectors and codecs |
@@ -72,57 +80,73 @@ integration), use the `mts:csmt` sub-library directly.
 
 ### Insert and Delete
 
+Every low-level tree operation takes a namespace prefix as its first
+argument (use `[]` for the root). `inserting`/`deleting` also take an
+explicit `Hashing` record:
+
 ```haskell
-import CSMT.Hashes (fromKVHashes)
+import CSMT.Hashes (fromKVHashes, hashHashing)
 import CSMT.Insertion (inserting)
 import CSMT.Deletion (deleting)
 
--- In a transaction context:
-inserting fromKVHashes hashing StandaloneKVCol StandaloneCSMTCol "key" "value"
-deleting  fromKVHashes hashing StandaloneKVCol StandaloneCSMTCol "key"
+-- In a transaction context (prefix [] = root):
+inserting [] fromKVHashes hashHashing StandaloneKVCol StandaloneCSMTCol "key" "value"
+deleting  [] fromKVHashes hashHashing StandaloneKVCol StandaloneCSMTCol "key"
 ```
+
+`CSMT.Hashes` also re-exports prefix-free convenience wrappers
+`insert`/`delete` (used by the CLI) that bake in `[]` and `hashHashing`.
 
 ### Inclusion Proofs
 
 ```haskell
 import CSMT.Proof.Insertion (buildInclusionProof, verifyInclusionProof)
 
--- Generate (in transaction)
-result <- buildInclusionProof fromKVHashes StandaloneKVCol StandaloneCSMTCol "key"
+-- Generate (in transaction); first arg is the namespace prefix
+result <- buildInclusionProof [] fromKVHashes StandaloneKVCol StandaloneCSMTCol "key"
 -- result :: Maybe (ByteString, InclusionProof Hash)
 
 -- Verify (pure, requires trusted root hash)
-verifyInclusionProof hashing trustedRootHash proof  -- :: Bool
+verifyInclusionProof hashHashing trustedRootHash proof  -- :: Bool
 ```
 
 ### Completeness Proofs
 
-```haskell
-import CSMT.Proof.Completeness (generateProof, collectValues, foldProof)
+`collectValues` and `generateProof` take the store's namespace prefix
+and the target prefix the proof should cover (both `[]` for a whole
+unnamespaced tree):
 
--- Collect leaves under a prefix
-leaves <- collectValues StandaloneCSMTCol prefix
+```haskell
+import CSMT.Proof.Completeness
+    (generateProof, collectValues, foldCompletenessProof)
+
+-- Collect leaves under the target prefix
+leaves <- collectValues StandaloneCSMTCol [] targetPrefix
 
 -- Generate proof
-mproof <- generateProof StandaloneCSMTCol prefix
+Just proof <- generateProof StandaloneCSMTCol [] targetPrefix
 
--- Verify
-let computed = foldProof (combineHash hashing) leaves proof
+-- Verify against a trusted root (pure); recomputes the root
+let computed = foldCompletenessProof hashHashing trustedRoot targetPrefix leaves proof
+-- computed :: Maybe Hash -- Just root on success
 ```
 
 ### Custom Key/Value Types
 
 ```haskell
+import Control.Lens (iso)
 import CSMT.Interface (FromKV(..))
 
 myFromKV :: FromKV MyKey MyValue Hash
 myFromKV = FromKV
-    { fromK      = myKeyToPath
+    { isoK       = iso myKeyToPath myPathToKey  -- Iso' MyKey Key
     , fromV      = myValueToHash
     , treePrefix = const []
     }
 ```
 
+`isoK` is an isomorphism between the external key type and the tree
+`Key` (a list of directions), so keys round-trip back out of proofs.
 The `treePrefix` field enables secondary indexing by prepending a prefix
 derived from the value to the tree key.
 
@@ -133,6 +157,7 @@ CSMT uses type-safe GADT column selectors:
 - `StandaloneKVCol` - Key-value column
 - `StandaloneCSMTCol` - CSMT tree column
 - `StandaloneJournalCol` - Journal column (KVOnly replay)
+- `StandaloneMetricsCol` - Persistent metrics counters (KV count, journal size)
 
 ### KVOnly Mode
 
@@ -247,28 +272,32 @@ use the `mts:mpf` sub-library directly.
 | `MPF.Deletion` | `deleting` |
 | `MPF.Proof.Insertion` | `mkMPFInclusionProof`, `verifyMPFInclusionProof`, `foldMPFProof` |
 | `MPF.Proof.Exclusion` | `mkMPFExclusionProof`, `verifyMPFExclusionProof`, `foldMPFExclusionProof` |
+| `MPF.Proof.Completeness` | `collectMPFLeaves`, `generateMPFCompletenessProof`, `foldMPFCompletenessProof` |
 | `MPF.Verify` | `verifyAikenInclusionProof`, `verifyAikenExclusionProof` |
 | `MPF.Backend.RocksDB` | RocksDB persistent backend |
 | `MPF.Backend.Pure` | In-memory backend for testing |
 | `MPF.Backend.Standalone` | Column selectors and codecs |
-| `MPF.MTS` | `MpfImpl`, `mpfMerkleTreeStore` |
+| `MPF.MTS` | `MpfImpl`, `mpfMerkleTreeStore`, `mpfKVOnlyStore`, `mpfReplayJournal` |
 
 ### Insert Modes
+
+Like CSMT, every MPF tree op takes a namespace prefix first (`[]` for
+the root):
 
 ```haskell
 import MPF.Insertion (inserting, insertingBatch, insertingChunked, insertingStream)
 
 -- Sequential (small datasets)
-inserting fromKV hashing kvCol mpfCol key value
+inserting [] fromKV hashing kvCol mpfCol key value
 
 -- Batch (medium datasets, O(n log n))
-insertingBatch fromKV hashing kvCol mpfCol [(k1, v1), (k2, v2)]
+insertingBatch [] fromKV hashing kvCol mpfCol [(k1, v1), (k2, v2)]
 
 -- Chunked (large datasets, bounded memory)
-insertingChunked fromKV hashing kvCol mpfCol chunkSize pairs
+insertingChunked [] fromKV hashing kvCol mpfCol chunkSize pairs
 
 -- Streaming (very large datasets, ~16x lower peak memory)
-insertingStream fromKV hashing kvCol mpfCol pairs
+insertingStream [] fromKV hashing kvCol mpfCol pairs
 ```
 
 ### Hex Key Operations
@@ -292,6 +321,8 @@ MPF uses its own GADT column selectors:
 
 - `MPFStandaloneKVCol` - Key-value column
 - `MPFStandaloneMPFCol` - MPF tree column
+- `MPFStandaloneJournalCol` - Journal column (KVOnly replay)
+- `MPFStandaloneMetricsCol` - Persistent metrics counters
 
 ### Aiken Proof Verification
 
@@ -312,7 +343,8 @@ These functions verify the exact proof-step bytes emitted by
 - `Nothing` from proof/root operations means "key not found" or "tree empty"
 - Invalid proofs return `False` from verification
 - Database errors surface as exceptions
-- MPF completeness proof operations currently `fail`
+- Constructing a `Full` store while the journal is non-empty `fail`s
+  (replay the journal first)
 
 ## Performance Tips
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -43,19 +43,32 @@ Generate and verify self-contained inclusion proofs:
 
 The MTS package includes a command-line interface (CLI) tool for interacting with the CSMT tree. The CLI provides commands for adding/removing elements, generating proofs, and verifying membership.
 
-CLI works in interactive mode by default. You can also pass commands directly as stdin as we are doing in this manual.
+CLI works in interactive mode by default. You can also pass commands directly as stdin as we are doing in this manual. In piped mode, status messages are printed in their short form (e.g. `AddedKey` instead of `Added key, inclusion proof generated`).
 
+### Invocation
+
+```text
+mts DIR [--csmt-max-files INT] [--kv-max-files INT]
+```
+
+| Setting | Env var | Default | Meaning |
+| ------- | ------- | ------- | ------- |
+| `DIR` (argument) | `CSMT_DB_PATH` | required | Path to the RocksDB database |
+| `--csmt-max-files` | `CSMT_MAX_FILES` | 1 | Maximum number of CSMT column files |
+| `--kv-max-files` | `KV_MAX_FILES` | 1 | Maximum number of KV column files |
 
 ### List of commands
 | Command | Description                        | Arguments        | Return value                 |
 | ------- | ---------------------------------- | ---------------- | ---------------------------- |
-| `i`     | Insert a key-value pair            | key,  value      |                              |
+| `i`     | Insert a key-value pair            | key, value       |                              |
 | `d`     | Delete a key                       | key              |                              |
 | `q`     | Query inclusion proof for a key    | key              | base64 encoding of the proof |
 | `r`     | Get the current root of the CSMT   |                  | base64 encoding of the root  |
 | `v`     | Verify inclusion proof             | proof            | Valid or Invalid             |
 | `w`     | Query value for a key              | key              | value                        |
-| `c`     | Comment (no operation)             |                  |                              |
+| `p`     | Query node at partial key          | path (`LRLL...`), optional | node jump path + value hash |
+| `k`     | Show a key as tree directions      | key              | `LR...` direction string     |
+| `#`     | Comment (no operation)             | free text        |                              |
 
 ## Basic operations
 
@@ -79,10 +92,13 @@ Setup the environment variable `CSMT_DB_PATH` to point to a directory where the 
     ```
 === "Output"
     ```text
-    AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
+    AddedKey
+    hJggAAEBAAEAAQEAAQEAAAEAAQABAQEBAAABAAABAQAAAAFYIBCf1UdGHyJjFT9Ie9m6K1UWWQ67U3o15jkbh4ifOE8RgJggAAEBAAEAAQEAAQEAAAEAAQABAQEBAAABAAABAQAAAAE=
     ```
 
-The `output` is the inclusion proof for `key1`. It will not change depending on the value associated with the key.
+The first line acknowledges the insert; the second is the
+base64-encoded CBOR inclusion proof for `key1`. The proof embeds the
+hash of the stored value, so it changes when the value changes.
 
 Now the database contains the value for `key1`, and you can query its inclusion proof at any time.
 
@@ -91,7 +107,7 @@ Now the database contains the value for `key1`, and you can query its inclusion 
 === "Input"
     ```bash
     mts <<$
-    v AQDjun1C8tTl1kdY1oon8sAQWL86/UMiJyZFswQ9Sf49XQAA
+    v hJggAAEBAAEAAQEAAQEAAAEAAQABAQEBAAABAAABAQAAAAFYIBCf1UdGHyJjFT9Ie9m6K1UWWQ67U3o15jkbh4ifOE8RgJggAAEBAAEAAQEAAQEAAAEAAQABAQEBAAABAAABAQAAAAE=
     $
     ```
 === "Output"
@@ -133,7 +149,7 @@ Now if you try to query for the inclusion proof of `key1` again:
     ```
 === "Output"
     ```text
-    NoProofFound
+    KeyNotFound
     ```
 
 
@@ -180,10 +196,10 @@ If you insert some keys first:
 === "Output"
     ```text
     AddedKey
-    NrJMih3czFriydMUwvFKFK6VYKZYVjKpKGe1WC4e+VU=
+    HZ9W8HqKzlkg3M7y1ivUYtAGm1qJ48zRCU8O3+CCf/A=
     AddedKey
-    jyW/0W96OAsUNpbd+SgA0B/ZjM8zGBOd3xR5Y1iOJOs=
+    yZANE8s5l49/d0foRE87Ict/9WZT4zaQjyDyccPmzXE=
     DeletedKey
-    NrJMih3czFriydMUwvFKFK6VYKZYVjKpKGe1WC4e+VU=
+    HZ9W8HqKzlkg3M7y1ivUYtAGm1qJ48zRCU8O3+CCf/A=
     TreeEmpty
     ```

--- a/docs/mpf.md
+++ b/docs/mpf.md
@@ -182,9 +182,13 @@ The same Aiken-parity work also backs the browser demo:
 
 ## Completeness Proofs
 
-MPF completeness proofs are not yet implemented. The `mtsCollectLeaves`,
-`mtsMkCompletenessProof`, and `mtsVerifyCompletenessProof` fields
-currently raise an error.
+MPF supports completeness proofs via the `MPF.Proof.Completeness`
+module (`collectMPFLeaves`, `generateMPFCompletenessProof`,
+`foldMPFCompletenessProof`). The proof is an `MPFCompose` tree
+structure that recomputes the root hash; the verifier checks that the
+supplied leaves match the proof and that the recomputed root matches
+the trusted root. The `mtsCollectLeaves`, `mtsMkCompletenessProof`, and
+`mtsVerifyCompletenessProof` fields are wired to these functions.
 
 ## Browser Demo
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -12,15 +12,22 @@ a Haskell runtime.
 
 ## Installation
 
+!!! note
+    `@paolino/csmt-verify` is not published to the public npm registry
+    yet. Use it from source until a release is published.
+
+Build it from the repository:
+
 ```bash
-npm install @paolino/csmt-verify
+cd verifiers/typescript
+npm install
+npm run build      # emits dist/, the package main
 ```
 
-Or with yarn:
-
-```bash
-yarn add @paolino/csmt-verify
-```
+Then consume it from another project by path, e.g. with
+`npm install /path/to/haskell-mts/verifiers/typescript`, or vendor the
+built `dist/` output. The import examples below assume the package is
+resolvable as `@paolino/csmt-verify`.
 
 ## Quick Start
 

--- a/skills/haskell-mts-guide/SKILL.md
+++ b/skills/haskell-mts-guide/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: haskell-mts-guide
+description: >-
+  Guide for working in the haskell-mts repository (Haskell package
+  `mts`): a Merkle tree store with two pluggable trie backends, CSMT
+  (compact sparse binary trie) and MPF (16-ary Merkle Patricia Forest,
+  Aiken-compatible). Load this when a task mentions haskell-mts, the
+  `mts` CLI, MerkleTreeStore, CsmtImpl / MpfImpl, inclusion / exclusion
+  / completeness proofs, KVOnly vs Full mode, the journal/replay
+  (patchParallel, toFull, toKVOnly, DbState, mergeSubtreeRoots),
+  csmtMerkleTreeStore / mpfMerkleTreeStore, fromKVHashes /
+  fromHexKVAikenHashes, CSMT_DB_PATH, the RocksDB backend, the WASM
+  demos (csmt-verify.wasm, csmt-write.wasm, mpf-write.wasm,
+  mpf-verify.wasm), the TypeScript verifier @paolino/csmt-verify, the
+  swap-partition rollbacks library, the Lean 4 proofs under lean/, or
+  the cabal sublibraries (mts:csmt, mts:mpf, mts:csmt-core,
+  mts:csmt-write, mts:csmt-verify, mts:mpf-write, mts:rollbacks).
+  Use it to build, test (cabal test unit-tests), format (fourmolu), run
+  the CLI, or locate where CSMT/MPF/proof logic lives.
+---
+
+# haskell-mts guide
+
+`mts` is a Haskell Merkle tree store with one shared interface and two
+trie implementations (CSMT, MPF), plus a rollback library, WASM demos,
+and a TypeScript verifier. Everything is one Cabal package split into
+sublibraries.
+
+## Repository map
+
+| Path | Sublibrary / role | Purpose |
+|------|-------------------|---------|
+| `lib/mts/` | `mts` | `MTS.Interface` (the `MerkleTreeStore` GADT, type families, `Mode`), `MTS.Properties` (shared QuickCheck suite), `Data.Serialize.Extra` |
+| `lib/csmt-core/` | `mts:csmt-core` | Backend-agnostic CSMT: `CSMT.Core.{Types,Proof,Completeness,Exclusion,Hash,CBOR}`. Pure, WASM-safe. The CBOR wire format lives in `CSMT.Core.CBOR` |
+| `lib/csmt-write/` | `mts:csmt-write` | Pure CSMT write path: `CSMT`, `CSMT.Insertion`, `CSMT.Deletion`, `CSMT.Hashes`, `CSMT.MTS` (`csmtMerkleTreeStore`, `Ops` GADT, `DbState`), `CSMT.Populate` (`patchParallel`), `CSMT.Proof.*`, pure/standalone backends |
+| `lib/csmt/` | `mts:csmt` | Native add-ons: `CSMT.Backend.RocksDB`, `CSMT.Frontend.CLI.App` (the `mts` CLI). Re-exports all of `csmt-write` |
+| `lib/csmt-verify/` | `mts:csmt-verify` | Pure DB-free verification (`CSMT.Verify`, `CSMT.Verify.Blake2b`). Cross-compiles to WASM |
+| `lib/mpf-write/` | `mts:mpf-write` | Pure MPF write path: `MPF`, `MPF.Insertion.*`, `MPF.Hashes(.Aiken)`, `MPF.MTS` (`mpfMerkleTreeStore`), `MPF.Proof.*`, `MPF.Verify` (Aiken proof verification) |
+| `lib/mpf/` | `mts:mpf` | Native add-on: `MPF.Backend.RocksDB`. Re-exports `mpf-write` |
+| `lib/rollbacks/` | `mts:rollbacks` | Swap-partition rollback log (`MTS.Rollbacks.*`). Independent of the tries |
+| `app/cli/main.hs` | exe `mts` | CLI entry point (delegates to `CSMT.Frontend.CLI.App`) |
+| `app/{csmt,mpf}-{verify,write}-wasm/` | WASM exes | stdio WASM entry points (built only with the `wasm` cabal flag) |
+| `app/{test-vectors,fixtures}/` | exes | `csmt-test-vectors`, `csmt-fixtures` generators |
+| `test/` | `unit-tests` | hspec-discover suite for CSMT, MPF, shared props, rollbacks |
+| `bench/` | benchmarks | `bench`, `populate-bench`, `unified`, `mpf-bench`, `mpf-bench-rocksdb` |
+| `lean/` | Lean 4 | Rollback correctness proofs (`Rollbacks/SwapPartition.lean`, `Rollbacks/Rollback.lean`, …) |
+| `verifiers/typescript/` | TS | `@paolino/csmt-verify` (CSMT proof verification; not yet on npm) |
+| `verifiers/browser*/` | static | HTML/JS for the WASM demos |
+| `docs/` | mkdocs | Documentation site source |
+| `nix/`, `CI/`, `CD/` | infra | Flake modules, release script, docker compose |
+
+## Build, test, run
+
+Use the nix dev shell and `just`:
+
+```bash
+nix develop
+just build                 # cabal build all --enable-tests --enable-benchmarks
+just test                  # cabal test unit-tests --test-show-details=direct
+just test "Exclusion"      # filter specs by pattern
+just format / format-check # fourmolu (70-col, leading commas) + cabal-fmt + nixfmt
+just lean                  # build Lean proofs
+just bench                 # benchmarks
+just build-docs            # mkdocs build
+```
+
+There is one test-suite, `unit-tests`. Ignore `just test-mpf` and
+`just integration` — they name suites that are not declared in
+`mts.cabal`.
+
+Build and run the CLI:
+
+```bash
+nix build .#mts
+export CSMT_DB_PATH=./mydb
+./result/bin/mts            # interactive; or pipe commands on stdin
+```
+
+WASM modules and demos (x86_64-linux): `nix build .#csmt-verify-wasm`,
+`.#csmt-write-wasm`, `.#mpf-verify-wasm`, `.#mpf-write-wasm`,
+`.#wasm-artifacts`; preview servers `nix run .#csmt-verify-wasm-demo`,
+`.#csmt-wasm-write-demo`, `.#mpf-wasm-write-demo`, `.#docs`.
+
+## Navigating the code
+
+- **Shared interface / where parity is defined**: `MTS.Interface`
+  (the `MerkleTreeStore mode imp m` GADT, `MtsKV`/`MtsTree` records,
+  `MtsKey`/`MtsValue`/`MtsHash`/`MtsProof`/`MtsLeaf`/`MtsPrefix` type
+  families). The parity + replay properties run in
+  `test/MTS/PropertySpec.hs` against both backends.
+- **CSMT store construction**: `CSMT.MTS.csmtMerkleTreeStore`
+  (prefix → runner → `Database` → `FromKV` → `Hashing` → `Full`
+  store). KVOnly/lifecycle: `csmtKVOnlyStore`, `csmtManagedTransition`,
+  and the `Ops` GADT (`mkKVOnlyOps`, `mkFullOps`, `openOps`,
+  `DbState`).
+- **MPF store construction**: `MPF.MTS.mpfMerkleTreeStore` (same
+  shape, `FromHexKV` + `MPFHashing`). Aiken parity hinges on
+  `fromHexKVAikenHashes` / `aikenKeyPath` in `MPF.Hashes`.
+- **Proofs**: CSMT inclusion in `CSMT.Proof.Insertion`
+  (`buildInclusionProof`, `verifyInclusionProof`, `computeRootHash`),
+  exclusion in `CSMT.Core.Exclusion`, completeness in
+  `CSMT.Proof.Completeness`. MPF in `MPF.Proof.{Insertion,Exclusion,
+  Completeness}` and `MPF.Verify`. CBOR wire format: `CSMT.Core.CBOR`
+  (4-element inclusion array; root hash is NOT in the proof).
+- **Persistence**: `CSMT.Backend.RocksDB.withRocksDB` and
+  `MPF.Backend.RocksDB.withMPFRocksDB`. Four column families: KV, tree,
+  journal, metrics (see `*.Backend.Standalone`).
+- **Parallel replay / crash recovery**: `CSMT.Populate.patchParallel`,
+  `expandToBucketDepth`, `mergeSubtreeRoots`; the journal sentinel and
+  `DbState` (`NeedsRecovery` / `Ready`) in `CSMT.MTS`.
+- **CLI**: `CSMT.Frontend.CLI.App` — command parser (`i d q v w r p k
+  #`), option/env parsing (`CSMT_DB_PATH`, `--csmt-max-files`,
+  `--kv-max-files`).
+
+## Using the artifact
+
+The `mts` CLI operates on a CSMT database at `CSMT_DB_PATH`. It runs
+interactively or reads commands from stdin (piped mode prints short
+status tokens like `AddedKey`). Commands: `i <k> <v>` insert,
+`d <k>` delete, `q <k>` inclusion proof (base64 CBOR), `v <proof>`
+verify against current root, `w <k>` value lookup, `r` root hash,
+`p [path]` node at partial key, `k <k>` key as `L`/`R` directions,
+`# …` comment.
+
+```bash
+export CSMT_DB_PATH=./mydb
+mts <<'EOF'
+i key1 value1
+q key1
+r
+EOF
+```
+
+Library usage (CSMT, in-memory backend): build a store with
+`csmtMerkleTreeStore [] run (pureDatabase csmtCodecs) fromKVHashes
+hashHashing`, then `mtsInsert (mtsKV store) k v`,
+`mtsMkProof (mtsTree store) k`, `mtsRootHash (mtsTree store)`. The
+first argument is the namespace prefix (`[]` = root); every low-level
+tree op (`inserting`, `deleting`, `buildInclusionProof`,
+`collectValues`, `generateProof`) also takes that prefix first. The
+MPF equivalent is `mpfMerkleTreeStore` with `fromHexKVAikenHashes` /
+`mpfHashing`. Persistent stores wrap these with `withRocksDB` /
+`withMPFRocksDB`. See `docs/library.md` and `docs/interface.md`.
+
+## Answering questions
+
+- **"What is this / how does it work?"** → `README.md` (overview +
+  architecture diagram), `docs/index.md`, `docs/concepts.md`.
+- **"How do I install / run the CLI?"** → `README.md` Install/Quickstart,
+  `docs/installation.md`, `docs/manual.md` (verified CLI transcripts).
+- **"How do I use the library / which constructor?"** →
+  `docs/interface.md`, `docs/library.md`, and `MTS.Interface` /
+  `CSMT.MTS` / `MPF.MTS` source.
+- **"CSMT vs MPF differences, proof formats, hashing?"** →
+  `docs/csmt.md`, `docs/mpf.md`, `docs/architecture/{inclusion-proof,
+  exclusion-proof,storage,example}.md` (CDDL in
+  `docs/architecture/*.cddl`).
+- **"How are the two backends kept in parity?"** →
+  `lib/mts/MTS/Properties.hs` + `test/MTS/PropertySpec.hs`.
+- **"Browser / WASM / TypeScript verification?"** →
+  `docs/wasm-demo.md`, `docs/wasm-write-demo.md`,
+  `docs/wasm-mpf-demo.md`, `docs/typescript.md`,
+  `verifiers/typescript/`.
+- **"Rollbacks / Lean proofs?"** → `lib/rollbacks/`, `lean/`, and the
+  Rollbacks section of `docs/concepts.md`.
+- **Release/CI questions** → `.github/workflows/`,
+  `release-please-config.json`, `justfile`.
+
+Always verify a claimed command, flag, or module path against the
+source before relying on it — the CLI's authoritative command list is
+`helpInteractive` in `CSMT.Frontend.CLI.App`.

--- a/verifiers/typescript/README.md
+++ b/verifiers/typescript/README.md
@@ -4,8 +4,13 @@ TypeScript library for verifying CSMT (Compact Sparse Merkle Tree) inclusion pro
 
 ## Installation
 
+This package is not published to the public npm registry yet. Build it
+from the repository and consume it by path:
+
 ```bash
-npm install @paolino/csmt-verify
+cd verifiers/typescript
+npm install
+npm run build      # emits dist/, the package main
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Documentation review of the repository against the current state of the
code. The docs had drifted from the implementation in several places;
this brings README, the docs/ site, and the agent layer back in line
with what the code actually does. Docs-only diff — no code, flake,
workflow, justfile, or test changes.

## What was inaccurate

- **MPF completeness proofs documented as "not implemented".** The code
  ships `MPF.Proof.Completeness` (`collectMPFLeaves`,
  `generateMPFCompletenessProof`, `foldMPFCompletenessProof`) and wires
  it into `mtsCollectLeaves`/`mtsMkCompletenessProof`/
  `mtsVerifyCompletenessProof`. Index status, concepts, mpf, system, and
  library pages all claimed it was pending or raised an error.
- **Stale `MerkleTreeStore` shape.** Docs used `MerkleTreeStore imp m`
  with operations called directly on the store. The real type is a
  mode-indexed GADT `MerkleTreeStore (mode :: Mode) imp m` with KV ops in
  `MtsKV` and tree ops in `MtsTree`, reached via `mtsKV`/`mtsTree`.
- **Store constructors missing the namespace-prefix argument.**
  `csmtMerkleTreeStore`/`mpfMerkleTreeStore` and every low-level tree op
  (`inserting`, `deleting`, `buildInclusionProof`, `collectValues`,
  `generateProof`, MPF insert modes) take a prefix (`[]` for root) as
  their first argument; examples omitted it. The constructors also return
  `IO (MerkleTreeStore 'Full …)` and `fail` on a non-empty journal.
- **`FromKV` field wrong.** Docs showed `fromK :: k -> Key`; the record
  field is `isoK :: Iso' k Key` (so keys round-trip out of proofs).
- **CDDL bug:** `inclusion-proof.cddl` declared a `proof_root_hash`
  field. The encoder (`CSMT.Core.CBOR.encodeProof`) emits a 4-element
  array with no root hash — confirmed by the CLI proof starting with
  `0x84` and the TypeScript `InclusionProof` interface. Removed the field.
- **Storage model undercounted.** Both backends use four RocksDB columns
  (KV, tree, journal, **metrics**); docs said three and the
  `Standalone`/`MPFStandalone` GADT blocks omitted the journal/metrics
  selectors.
- **`patchParallel` signature** returned `[Transaction …]`; it actually
  returns `[(Int, Transaction …)]` (op-count per bucket).
- **Install/release drift.** Installation referenced "no releasing in
  place" and CI-artifact downloads; the project now releases via
  release-please with per-release AppImage/deb/rpm/docker artifacts
  (docker loads as `ghcr.io/paolino/mts/mts`).
- **CLI manual drift.** Command table missing `p`/`k`, listed a
  non-existent `c` comment command (it is `#`), and showed outdated proof
  and root-hash transcripts. Refreshed against the built binary, added
  the invocation/flags table.
- **TypeScript verifier** documented as `npm install @paolino/csmt-verify`
  — the package is not on the public npm registry (404) and there is no
  publish workflow. Changed to build-from-source instructions.
- Various smaller fixes: `mtsMkProof` returns `(hash, proof)`; property
  table re-derived from the suite (13 parity + 6 replay properties, each
  run against both backends); rollbacks library described to match the
  swap-partition model in the code (was an invented "two-partition
  live/staging" description).

## What changed

- **README** rewritten into the standard section order (What is this /
  Architecture / Install / Quickstart / Usage / Documentation /
  Development / License) with a new mermaid architecture diagram of the
  Cabal sublibraries, a verified quickstart, and a working library
  example.
- **docs/** pages corrected for the items above across index, concepts,
  interface, csmt, mpf, library, manual, installation, system, storage,
  typescript, and the inclusion-proof CDDL.
- **Agent layer added** (mandatory per the docs standard): root
  `AGENTS.md` and `skills/haskell-mts-guide/SKILL.md` (repository map,
  build/test/run, code navigation, CLI/library usage, and where answers
  live). README's Documentation section now points agents at AGENTS.md.

## How claims were verified

- Read every public module surface against `mts.cabal`: the
  `MerkleTreeStore` GADT and type-family instances, `csmt`/`mpf` store
  constructors, proof modules, `Standalone`/`MPFStandalone` column
  GADTs, the CBOR encoders, and `MTS.Properties` / `MTS.PropertySpec`
  (property counts and ordering).
- Built the CLI with `nix build .#mts` and ran every transcript in
  `manual.md` (and the README quickstart) through the binary; the proof,
  root-hash, and status outputs in the docs are copied from those runs.
  Verified `mts --help`/`--version` for the invocation table.
- Confirmed the architecture-diagram edges match the cabal
  `build-depends` graph; the `rollbacks` library is standalone (no MTS
  dep) and the Lean proofs live under `lean/`.
- Confirmed `@paolino/csmt-verify` is absent from the npm registry and
  has no publish workflow.
- Mermaid diagrams checked for valid arrows/labels and balanced
  brackets; all docs fences balanced, all mkdocs `nav` targets and
  `--8<--` snippet includes resolve.

The full `mkdocs build --strict` could not complete inside the
~14-minute attempt window on this runner (the nix dev-shell build did
not finish), so the docs site was validated manually as above rather
than by a strict build.
