### PR TITLE
ci(release): mint release-please token from the org App

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,12 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Mint a release token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         id: release
         with:
@@ -32,7 +38,7 @@ jobs:
           # Non-GITHUB_TOKEN identity so the release PR's branch push emits
           # pull_request/push events — otherwise GitHub suppresses them for
           # GITHUB_TOKEN-authored commits and the required checks never run.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
   publish:
     needs: release-please


### PR DESCRIPTION
Replaces `RELEASE_PLEASE_TOKEN` with a per-run token from the org `lambdasistemi-ci` App (`vars.CI_APP_ID` + org `secrets.CI_APP_PRIVATE_KEY`). App-token commits emit push/PR events so the release PR's checks run — exactly why the PAT identity was needed. Removes a manually-rotated PAT.